### PR TITLE
Add internal server error handler and tests

### DIFF
--- a/src/main/java/org/breedinginsight/api/v1/controller/InternalServerErrorHandler.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/InternalServerErrorHandler.java
@@ -1,0 +1,26 @@
+package org.breedinginsight.api.v1.controller;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.server.exceptions.ExceptionHandler;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.inject.Singleton;
+import java.util.UUID;
+
+@Produces
+@Singleton
+@Slf4j
+@Requires(classes = {Exception.class, ExceptionHandler.class})
+public class InternalServerErrorHandler implements ExceptionHandler<Exception, HttpResponse> {
+
+    @Override
+    public HttpResponse handle(HttpRequest request, Exception e) {
+        UUID errorId = UUID.randomUUID();
+        String logErrorMsg = String.format("Error Id: %s", errorId);
+        log.error(logErrorMsg, e);
+        return HttpResponse.serverError(logErrorMsg);
+    }
+}

--- a/src/main/java/org/breedinginsight/api/v1/controller/ProgramController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ProgramController.java
@@ -51,22 +51,16 @@ public class ProgramController {
     @Secured(SecurityRule.IS_AUTHENTICATED)
     public HttpResponse<Response<DataResponse<Program>>> getPrograms() {
 
-        try {
-            List<Program> programs = programService.getAll();
+        List<Program> programs = programService.getAll();
 
-            List<Status> metadataStatus = new ArrayList<>();
-            metadataStatus.add(new Status(StatusCode.INFO, "Successful Query"));
-            //TODO: Put in the actual page size
-            Pagination pagination = new Pagination(programs.size(), 1, 1, 0);
-            Metadata metadata = new Metadata(pagination, metadataStatus);
+        List<Status> metadataStatus = new ArrayList<>();
+        metadataStatus.add(new Status(StatusCode.INFO, "Successful Query"));
+        //TODO: Put in the actual page size
+        Pagination pagination = new Pagination(programs.size(), 1, 1, 0);
+        Metadata metadata = new Metadata(pagination, metadataStatus);
 
-            Response<DataResponse<Program>> response = new Response(metadata, new DataResponse<>(programs));
-            return HttpResponse.ok(response);
-        } catch (DataAccessException e){
-            log.error("Error executing query: {}", e.getMessage());
-            return HttpResponse.serverError();
-        }
-
+        Response<DataResponse<Program>> response = new Response(metadata, new DataResponse<>(programs));
+        return HttpResponse.ok(response);
     }
 
     @Get("/programs/{programId}")
@@ -75,20 +69,13 @@ public class ProgramController {
     @Secured(SecurityRule.IS_AUTHENTICATED)
     public HttpResponse<Response<Program>> getProgram(@PathVariable UUID programId) {
 
-        try {
-            Optional<Program> program = programService.getById(programId);
-            if(program.isPresent()) {
-                Response<Program> response = new Response(program.get());
-                return HttpResponse.ok(response);
-            } else {
-                return HttpResponse.notFound();
-            }
-
-        } catch (DataAccessException e){
-            log.error("Error executing query: {}", e.getMessage());
-            return HttpResponse.serverError();
+        Optional<Program> program = programService.getById(programId);
+        if(program.isPresent()) {
+            Response<Program> response = new Response(program.get());
+            return HttpResponse.ok(response);
+        } else {
+            return HttpResponse.notFound();
         }
-
     }
 
     @Post("/programs")

--- a/src/test/java/org/breedinginsight/api/v1/controller/InternalServerErrorHandlerUnitTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/InternalServerErrorHandlerUnitTest.java
@@ -1,0 +1,111 @@
+package org.breedinginsight.api.v1.controller;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.RxHttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.netty.cookies.NettyCookie;
+import io.micronaut.test.annotation.MicronautTest;
+import io.micronaut.test.annotation.MockBean;
+import io.reactivex.Flowable;
+import org.breedinginsight.services.ProgramService;
+import org.jooq.exception.DataAccessException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static io.micronaut.http.HttpRequest.GET;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class InternalServerErrorHandlerUnitTest {
+
+    ListAppender<ILoggingEvent> loggingEventListAppender;
+
+    @Inject
+    ProgramService programService;
+    @Inject
+    ProgramController programController;
+
+    @Inject
+    @Client("/${micronaut.bi.api.version}")
+    RxHttpClient client;
+
+    @MockBean(ProgramController.class)
+    ProgramController programController() {
+        return mock(ProgramController.class);
+    }
+
+    @MockBean(ProgramService.class)
+    ProgramService programService() {
+        return mock(ProgramService.class);
+    }
+
+    @BeforeEach
+    void setupErrorLogger() {
+
+        Logger logger = (Logger) LoggerFactory.getLogger(InternalServerErrorHandler.class);
+        ListAppender<ILoggingEvent> loggingEventListAppender = new ListAppender<>();
+        loggingEventListAppender.start();
+        logger.addAppender(loggingEventListAppender);
+        this.loggingEventListAppender = loggingEventListAppender;
+    }
+
+    @Test
+    public void getProgramsInternalServerError() {
+
+        when(programController.getPrograms()).thenThrow(new DataAccessException("Query 123 failed"));
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs").cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, e.getStatus(), "Response status is incorrect");
+
+        // Check that we can find our error id in logs
+        String errorId = e.getResponse().body().toString();
+        ILoggingEvent loggingEvent = loggingEventListAppender.list.get(0);
+        assertEquals(Level.ERROR, loggingEvent.getLevel(), "Wrong logging level was used");
+        assertEquals(errorId, loggingEvent.getMessage(), "Id returned doesn't match logging id");
+
+    }
+
+    @Test
+    public void controllerHandledExceptionIgnored() {
+
+        when(programService.getById(any(UUID.class))).thenReturn(Optional.empty());
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/" + UUID.randomUUID()).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus(), "Response status is incorrect");
+
+        assertEquals(0, loggingEventListAppender.list.size(), "Logs were entered, but shouldn't have been.");
+    }
+}


### PR DESCRIPTION
This feature creates an ID for internal server errors and prints them to the logs so that we are able to debug the errors later. 

## Design Concepts

I used the micronaut custom error handling ability to catch all unhandled exceptions that are returned from the controllers. When we receive the unhandled exception, a UUID is created and logged with stack trace of the error. An internal server error response with the error UUID is then returned. 

https://guides.micronaut.io/micronaut-error-handling/guide/index.html

Exceptions that are thrown in the services and handled in the controllers are not affected. By handling all unhandled exceptions, we can remove the custom `DataAccessException` handling that we were doing on all controller code and also expand the types errors we are able to trace. 

Only getAll() and getById() in the ProgramController have been modified to account for the new error handling so far. There is another card to convert the existing controllers over to the new error handling method. 

https://trello.com/c/D5WB7q1J/183-inf-69-update-controllers-to-throw-custom-web-exception-to-ensure-logging-is-consistent

Once this pull request is merged, the other controller methods will be converted. 

## Review Considerations
- Is testing coverage complete? 
- Does the design make sense? 

Note: This feature breaks two DataAcessException unit tests `getProgramsAllDataAccessException` and `getProgramsSingleDataAccessException`. This is because the getById and getAll functions were converted to the new error handling code as an example. These tests will be removed in INF-69. 