### PR TITLE
INF-59 - Set appropriate logging configuration

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
         </encoder>
     </appender>
 
-    <logger name="org.breedinginsight" level="INFO"/>
+    <logger name="org.breedinginsight" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
## Changes
- Added logger config for org.breedinginsight
  - Logging for our application code can now be controlled independently from framework logging

## Test Cases

### Disable all framework logging and only see breeding insight logging
- In `bi-api/src/main/resources/logback.xml`, set `root level="OFF"`
- Keep org.breedinginsight logger level as `INFO`
- Start bi-api 
- Cause an application logging event to be generated in org.breedinginsight
  - I sent a `GET http://localhost:8081/v1/users/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa`
    - This will attempt to get a user that doesn't exist and cause a logging event
- Verify that you see only the UserController log message and no framework log messages in stdout

### Disable breeding insight logging and see only framework logging
- In `bi-api/src/main/resources/logback.xml`, set `root level="INFO"`
- Set org.breedinginsight logger level as `OFF`
- Start bi-api 
- Cause an application logging event to be generated in org.breedinginsight
  - I sent a `GET http://localhost:8081/v1/users/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa`
    - This will attempt to get a user that doesn't exist
- Verify that you see only the framework log messages and no UserController log message in stdout

## Acceptance Criteria
- Verify test cases pass and functionality is as expected

