### PR TITLE
Feature/pro 33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,6 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/src/main/java/org/breedinginsight/api/auth/AuthServiceLoginHandler.java
+++ b/src/main/java/org/breedinginsight/api/auth/AuthServiceLoginHandler.java
@@ -37,9 +37,7 @@ import org.breedinginsight.services.UserService;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLDecoder;
+import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
@@ -96,15 +94,16 @@ public class AuthServiceLoginHandler extends JwtCookieLoginHandler {
                 if (request.getCookies().contains(loginSuccessUrlCookieName)){
                     Cookie loginSuccessCookie = request.getCookies().get(loginSuccessUrlCookieName);
                     String returnUrl = loginSuccessCookie.getValue();
-                    if (isValidURI(returnUrl)){
-                        try {
-                            locationUrl = URLDecoder.decode(returnUrl, StandardCharsets.UTF_8.name());
-                        } catch (UnsupportedEncodingException e){}
-                    }
+                    try {
+                        returnUrl = URLDecoder.decode(returnUrl, StandardCharsets.UTF_8.name());
+                        if (isValidURL(returnUrl)){
+                            locationUrl = returnUrl;
+                        }
+                    } catch (UnsupportedEncodingException e){}
                 }
             }
 
-            URI location = new URI(locationUrl).normalize();
+            URI location = new URI(locationUrl);
 
             MutableHttpResponse mutableHttpResponse = HttpResponse.seeOther(location);
 
@@ -126,11 +125,11 @@ public class AuthServiceLoginHandler extends JwtCookieLoginHandler {
         return super.loginFailed(authenticationFailed);
     }
 
-    private Boolean isValidURI(String url) {
+    private Boolean isValidURL(String urlString) {
         try {
-            new URI(url);
-            return true;
-        } catch (URISyntaxException e){
+            URL url = new URL(urlString);
+            return "https".equals(url.getProtocol()) || "http".equals(url.getProtocol());
+        } catch (MalformedURLException e){
             return false;
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -103,6 +103,8 @@ datasources:
 #        url: ${oauth.user-search-url:`https://pub.sandbox.orcid.org/v2.1/search`}
 #
 web:
+  cookies:
+    login-redirect: redirect-login
   login:
     success:
       url: ${web.loginSuccessUrl:`http://localhost:8080/program-selection`}

--- a/src/test/java/org/breedinginsight/api/auth/AuthServiceLoginHandlerUnitTest.java
+++ b/src/test/java/org/breedinginsight/api/auth/AuthServiceLoginHandlerUnitTest.java
@@ -66,7 +66,7 @@ public class AuthServiceLoginHandlerUnitTest {
     @Test
     public void returnsPassedUrlGoodHttpUrl() {
 
-        String expectedUrl = "http://localhost:8080/test";
+        String expectedUrl = "http://localhost:8080/test?testparam=true";
         HttpRequest request = mock(HttpRequest.class, CALLS_REAL_METHODS);
         Cookie returnUrlCookie = Cookie.of("redirect-login", expectedUrl);
         SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
@@ -85,7 +85,7 @@ public class AuthServiceLoginHandlerUnitTest {
     @Test
     public void returnsPassedUrlGoodHttpsUrl() {
 
-        String expectedUrl = "https://localhost:8080/test";
+        String expectedUrl = "https://localhost:8080/test?testparam=blueberry";
         HttpRequest request = mock(HttpRequest.class, CALLS_REAL_METHODS);
         Cookie returnUrlCookie = Cookie.of("redirect-login", expectedUrl);
         SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);

--- a/src/test/java/org/breedinginsight/api/auth/AuthServiceLoginHandlerUnitTest.java
+++ b/src/test/java/org/breedinginsight/api/auth/AuthServiceLoginHandlerUnitTest.java
@@ -1,0 +1,146 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.api.auth;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.context.ServerRequestContext;
+import io.micronaut.http.cookie.Cookie;
+import io.micronaut.http.simple.cookies.SimpleCookies;
+import io.micronaut.test.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@MicronautTest
+public class AuthServiceLoginHandlerUnitTest {
+
+    @Inject
+    AuthServiceLoginHandler authServiceLoginHandler;
+
+    @Property(name = "micronaut.security.token.jwt.cookie.login-success-target-url")
+    String defaultUrl;
+
+    @Test
+    public void returnsDefaultBadUrl() {
+
+        HttpRequest request = mock(HttpRequest.class, CALLS_REAL_METHODS);
+        Cookie returnUrlCookie = Cookie.of("redirect-login", "localhost:8080/test");
+        SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
+        cookies.put("redirect-login", returnUrlCookie);
+        doReturn(cookies).when(request).getCookies();
+        ServerRequestContext.set(request);
+
+        Cookie jwtToken = Cookie.of("phylo-token", "test");
+        List<Cookie> securityCookies = List.of(jwtToken);
+
+        HttpResponse response = authServiceLoginHandler.loginSuccessWithCookies(securityCookies);
+
+        checkAssertions(response, jwtToken, defaultUrl);
+    }
+
+    @Test
+    public void returnsPassedUrlGoodHttpUrl() {
+
+        String expectedUrl = "http://localhost:8080/test";
+        HttpRequest request = mock(HttpRequest.class, CALLS_REAL_METHODS);
+        Cookie returnUrlCookie = Cookie.of("redirect-login", expectedUrl);
+        SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
+        cookies.put("redirect-login", returnUrlCookie);
+        doReturn(cookies).when(request).getCookies();
+        ServerRequestContext.set(request);
+
+        Cookie jwtToken = Cookie.of("phylo-token", "test");
+        List<Cookie> securityCookies = List.of(jwtToken);
+
+        HttpResponse response = authServiceLoginHandler.loginSuccessWithCookies(securityCookies);
+
+        checkAssertions(response, jwtToken, expectedUrl);
+    }
+
+    @Test
+    public void returnsPassedUrlGoodHttpsUrl() {
+
+        String expectedUrl = "https://localhost:8080/test";
+        HttpRequest request = mock(HttpRequest.class, CALLS_REAL_METHODS);
+        Cookie returnUrlCookie = Cookie.of("redirect-login", expectedUrl);
+        SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
+        cookies.put("redirect-login", returnUrlCookie);
+        doReturn(cookies).when(request).getCookies();
+        ServerRequestContext.set(request);
+
+        Cookie jwtToken = Cookie.of("phylo-token", "test");
+        List<Cookie> securityCookies = List.of(jwtToken);
+
+        HttpResponse response = authServiceLoginHandler.loginSuccessWithCookies(securityCookies);
+
+        checkAssertions(response, jwtToken, expectedUrl);
+    }
+
+    @Test
+    public void returnsDefaultUrlCookieNotExist() {
+
+        HttpRequest request = mock(HttpRequest.class, CALLS_REAL_METHODS);
+        SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
+        doReturn(cookies).when(request).getCookies();
+        ServerRequestContext.set(request);
+
+        Cookie jwtToken = Cookie.of("phylo-token", "test");
+        List<Cookie> securityCookies = List.of(jwtToken);
+
+        HttpResponse response = authServiceLoginHandler.loginSuccessWithCookies(securityCookies);
+
+        checkAssertions(response, jwtToken, defaultUrl);
+    }
+
+    public void checkAssertions(HttpResponse response, Cookie jwtToken, String expectedLocation) {
+
+        // Check location is as expected
+        String redirectLocation = response.getHeaders().get("Location");
+        assertEquals(expectedLocation, redirectLocation);
+
+        // Check cookies were not altered
+        String cookieString = response.getHeaders().get("set-cookie");
+        String[] splitCookie = cookieString.split("=");
+        Map<String, String> responseCookies = new HashMap<>();
+        for (Integer i = 0; i < splitCookie.length - 1; i++){
+            if (i % 2 == 0){
+                responseCookies.put(splitCookie[i], splitCookie[i+1]);
+            }
+        }
+        Map<String, String> requestCookie = new HashMap<>();
+        requestCookie.put(jwtToken.getName(), jwtToken.getValue());
+
+        for (String key: responseCookies.keySet()){
+            assertTrue(requestCookie.containsKey(key));
+            if (requestCookie.containsKey(key)){
+                assertEquals(requestCookie.get(key), responseCookies.get(key),"Returned cookie does not equal passed cookie (cookie was modified)");
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/breedinginsight/api/auth/AuthServiceLoginHandlerUnitTest.java
+++ b/src/test/java/org/breedinginsight/api/auth/AuthServiceLoginHandlerUnitTest.java
@@ -26,6 +26,7 @@ import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.simple.cookies.SimpleCookies;
 import io.micronaut.test.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.annotation.JsonAppend;
 
 import javax.inject.Inject;
 import java.util.HashMap;
@@ -44,12 +45,14 @@ public class AuthServiceLoginHandlerUnitTest {
 
     @Property(name = "micronaut.security.token.jwt.cookie.login-success-target-url")
     String defaultUrl;
+    @Property(name = "web.cookies.login-redirect")
+    String loginRedirectCookieName;
 
     @Test
     public void returnsDefaultBadUrl() {
 
         HttpRequest request = mock(HttpRequest.class, CALLS_REAL_METHODS);
-        Cookie returnUrlCookie = Cookie.of("redirect-login", "localhost:8080/test");
+        Cookie returnUrlCookie = Cookie.of(loginRedirectCookieName, "localhost:8080/test");
         SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
         cookies.put("redirect-login", returnUrlCookie);
         doReturn(cookies).when(request).getCookies();
@@ -68,7 +71,7 @@ public class AuthServiceLoginHandlerUnitTest {
 
         String expectedUrl = "http://localhost:8080/test?testparam=true";
         HttpRequest request = mock(HttpRequest.class, CALLS_REAL_METHODS);
-        Cookie returnUrlCookie = Cookie.of("redirect-login", expectedUrl);
+        Cookie returnUrlCookie = Cookie.of(loginRedirectCookieName, expectedUrl);
         SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
         cookies.put("redirect-login", returnUrlCookie);
         doReturn(cookies).when(request).getCookies();
@@ -87,7 +90,7 @@ public class AuthServiceLoginHandlerUnitTest {
 
         String expectedUrl = "https://localhost:8080/test?testparam=blueberry";
         HttpRequest request = mock(HttpRequest.class, CALLS_REAL_METHODS);
-        Cookie returnUrlCookie = Cookie.of("redirect-login", expectedUrl);
+        Cookie returnUrlCookie = Cookie.of(loginRedirectCookieName, expectedUrl);
         SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
         cookies.put("redirect-login", returnUrlCookie);
         doReturn(cookies).when(request).getCookies();


### PR DESCRIPTION
Implements changes to check the cookies on successful login and looks for a cookie named `redirect-login`. If the cookie is present, and has a valid url as its value, the user is redirected to that url on successful login. If the cookie is not present or is not a valid url, the user is redirected to the default url set in the config. 

Should be reviewed with PRO-33 on bi-web. 