### PR TITLE
Feature/pro 53

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -949,7 +949,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/programUserResponse'
-              example:
+              examples:
                 programUserExample2:
                   $ref: '#/components/examples/singleProgramUser'
         "400":
@@ -2486,6 +2486,18 @@ components:
           description: Array of roles
           items:
             $ref: '#/components/schemas/role'
+        program:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            name:
+              type: string
+            abbreviation:
+              type: string
+            objective:
+              type: string
     program:
       type: object
       properties:
@@ -3532,6 +3544,11 @@ components:
               roles:
                 - id: e2d6c5c3-4064-4afe-abd6-0af90fbf2245
                   domain: Breeder
+              program:
+                id: 37935efa-4c0f-4269-8669-f78d21b26f04
+                name: Test Program
+                abbreviation: test,
+                objective: To test things
             - createdAt: "2020-02-09T09:57:35-04:00"
               updatedAt: "2020-02-09T09:57:35-04:00"
               createdByUser:
@@ -3548,7 +3565,12 @@ components:
                 email: tim.smith@mail.com
               roles:
                 - id: e2d6c5c3-4064-4afe-abd6-0af90fbf2245
-                  domain: Breeder
+                  domain: Breeder'
+              program:
+                id: 37935efa-4c0f-4269-8669-f78d21b26f04
+                name: Test Program
+                abbreviation: test,
+                objective: To test things
     singleProgramUser:
       value:
         metadata:
@@ -3577,6 +3599,11 @@ components:
           roles:
             - id: e2d6c5c3-4064-4afe-abd6-0af90fbf2245
               domain: Field Manager
+          program:
+            id: 37935efa-4c0f-4269-8669-f78d21b26f04
+            name: Test Program
+            abbreviation: test,
+            objective: To test things
     arrayOfCountries:
       value:
         metadata:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -74,10 +74,36 @@ paths:
                         domain: "admin"
                       }
                       ]
-                      activePrograms: [
+                      programRoles: [
                       {
-                        id: eac1f9ba-c0da-48aa-bac6-16e178dbbbcc,
-                        name: My Program
+                        active: false,
+                        roles: [
+                        {
+                          id: 20be0724-9451-46d5-a628-10fcb4a380e7,
+                          domain: member
+                        }
+                        ],
+                        program: {
+                          id: c57225a8-6649-44e3-b2ec-7c0f84a31a11,
+                          name: Test Program1,
+                          abbreviation: test1,
+                          objective: To test all the things
+                        }
+                      },
+                      {
+                        active: true,
+                        roles: [
+                        {
+                          id: 20be0724-9451-46d5-a628-10fcb4a380e7,
+                          domain: member
+                        }
+                        ],
+                        program: {
+                          id: 37935efa-4c0f-4269-8669-f78d21b26f04,
+                          name: Test Program,
+                          abbreviation: test,
+                          objective: To test things
+                        }
                       }
                       ]
                     - id: a2263532-1fa3-29a6-3a66-557f313c8ed6
@@ -85,7 +111,7 @@ paths:
                       name: Fred Brown
                       email: null
                       systemRoles: []
-                      activePrograms: []
+                      programRoles: []
         "400":
           description: Bad Request
           content:
@@ -152,7 +178,7 @@ paths:
                     domain: "admin"
                   }
                   ]
-                  activePrograms: []
+                  programRoles: []
         "400":
           description: Bad Request
           content:
@@ -229,10 +255,21 @@ paths:
                     domain: "admin"
                   }
                   ]
-                  activePrograms: [
+                  programRoles: [
                   {
-                    id: eac1f9ba-c0da-48aa-bac6-16e178dbbbcc,
-                    name: My Program
+                    active: false,
+                    roles: [
+                    {
+                      id: 20be0724-9451-46d5-a628-10fcb4a380e7,
+                      domain: member
+                    }
+                    ],
+                    program: {
+                      id: c57225a8-6649-44e3-b2ec-7c0f84a31a11,
+                      name: Test Program1,
+                      abbreviation: test1,
+                      objective: To test all the things
+                    }
                   }
                   ]
         "400":
@@ -319,10 +356,21 @@ paths:
                     domain: "admin"
                   }
                   ]
-                  activePrograms: [
+                  programRoles: [
                   {
-                    id: eac1f9ba-c0da-48aa-bac6-16e178dbbbcc,
-                    name: My Program
+                    active: true,
+                    roles: [
+                    {
+                      id: 20be0724-9451-46d5-a628-10fcb4a380e7,
+                      domain: member
+                    }
+                    ],
+                    program: {
+                      id: 37935efa-4c0f-4269-8669-f78d21b26f04,
+                      name: Test Program,
+                      abbreviation: test,
+                      objective: To test things
+                    }
                   }
                   ]
         "400":
@@ -480,6 +528,7 @@ paths:
                     domain: "admin"
                   }
                   ]
+                  programRoles: []
         "400":
           description: Bad Request
           content:
@@ -2341,14 +2390,33 @@ components:
               format: uuid
             domain:
               type: string
-        activePrograms:
+        programRoles:
           type: object
           properties:
-            id:
-              type: string
-              format: uuid
-            name:
-              type: string
+            active:
+              type: boolean
+            roles:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  domain:
+                    type: string
+            program:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                name:
+                  type: string
+                abbreviation:
+                  type: string
+                objective:
+                  type: string
     country:
       type: object
       properties:
@@ -2858,7 +2926,7 @@ components:
           type: array
           description: Array of topographies
           items:
-            $ref: '#/components/schemas/topography'
+            $ref: '#/components/schemas/topographyOption'
     topographiesResponseSingle:
       title: topographiesResponse
       required:
@@ -2869,7 +2937,7 @@ components:
         metadata:
           $ref: '#/components/schemas/metadata'
         result:
-          $ref: '#/components/schemas/topography'
+          $ref: '#/components/schemas/topographyOption'
     accessibilitiesResponse:
       title: accessibilitiesResponse
       required:
@@ -2890,7 +2958,7 @@ components:
           type: array
           description: Array of accessibilities
           items:
-            $ref: '#/components/schemas/accessibility'
+            $ref: '#/components/schemas/accessibilityOption'
     accessibilitiesResponseSingle:
       title: accessibilitiesResponse
       required:
@@ -2901,7 +2969,7 @@ components:
         metadata:
           $ref: '#/components/schemas/metadata'
         result:
-          $ref: '#/components/schemas/accessibility'
+          $ref: '#/components/schemas/accessibilityOption'
     environmentTypesResponse:
       title: environmentTypesResponse
       required:
@@ -2922,7 +2990,7 @@ components:
           type: array
           description: Array of environemnt types
           items:
-            $ref: '#/components/schemas/environmentType'
+            $ref: '#/components/schemas/environmentDataType'
     environmentTypesResponseSingle:
       title: environmentTypesResponse
       required:
@@ -2934,78 +3002,6 @@ components:
           $ref: '#/components/schemas/metadata'
         result:
           $ref: '#/components/schemas/location'
-    updateProgramRequest:
-      type: object
-      properties:
-        species:
-          type: object
-          properties:
-            id:
-              type: string
-              description: Id of species to assign to program
-            commonName:
-              type: string
-              description: Name of species
-          required:
-            - id
-        name:
-          type: string
-          description: name of program
-        abbreviation:
-          type: string
-          description: abbreviation for program name
-        objective:
-          type: string
-          description: program objective
-        documetation_url:
-          type: string
-          description: program documentation url
-      required:
-        - species
-        - name
-    countriesResponse:
-      title: countriesResponse
-      required:
-        - metadata
-        - result
-      type: object
-      properties:
-        metadata:
-          $ref: '#/components/schemas/metadata'
-        result:
-          $ref: '#/components/schemas/countriesResponseResult'
-    countriesResponseResult:
-      required:
-        - data
-      type: object
-      properties:
-        data:
-          type: array
-          description: Array of countries
-          items:
-            $ref: '#/components/schemas/country'
-    countriesResponseSingle:
-      title: countriesResponse
-      required:
-        - metadata
-        - result
-      type: object
-      properties:
-        metadata:
-          $ref: '#/components/schemas/metadata'
-        result:
-          $ref: '#/components/schemas/country'
-    topographiesResponse:
-      title: topographyOptionsResponse
-      required:
-        - metadata
-        - result
-      type: object
-      properties:
-        metadata:
-          $ref: '#/components/schemas/metadata'
-        result:
-          $ref: '#/components/schemas/topographyOptionsResponseResult'
     topographyOptionsResponseResult:
       required:
         - data

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -174,6 +174,7 @@ paths:
                   orcid: null
                   name: Bob Smith
                   email: bob@bob.com
+                  active: true
                   systemRoles: [
                   {
                     id: "d4f23375-0033-4d16-a62f-072e3a9198fa",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -68,6 +68,7 @@ paths:
                       orcid: 1234-4312-4352-6314
                       name: Bob Smith
                       email: bob.smith@mail.com
+                      active: true
                       systemRoles: [
                       {
                         id: "d4f23375-0033-4d16-a62f-072e3a9198fa",
@@ -110,6 +111,7 @@ paths:
                       orcid: 1234-4312-4352-6314
                       name: Fred Brown
                       email: null
+                      active: true
                       systemRoles: []
                       programRoles: []
         "400":
@@ -249,6 +251,7 @@ paths:
                   orcid: 1111-2222-3333-4444
                   name: Bob Smith
                   email: bob@bob.com
+                  active: true
                   systemRoles: [
                   {
                     id: "d4f23375-0033-4d16-a62f-072e3a9198fa",
@@ -350,6 +353,7 @@ paths:
                   orcid: 1111-2222-3333-4444
                   name: Bob Smith
                   email: bob@bob.com
+                  active: true
                   systemRoles: [
                   {
                     id: "d4f23375-0033-4d16-a62f-072e3a9198fa",
@@ -522,6 +526,7 @@ paths:
                   orcid: 1111-2222-3333-4444
                   name: Bob Smith
                   email: bob@bob.com
+                  active: true
                   systemRoles: [
                   {
                     id: "d4f23375-0033-4d16-a62f-072e3a9198fa",
@@ -2382,6 +2387,8 @@ components:
           type: string
         email:
           type: string
+        active:
+          type: boolean
         systemRoles:
           type: object
           properties:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -74,11 +74,18 @@ paths:
                         domain: "admin"
                       }
                       ]
+                      activePrograms: [
+                      {
+                        id: eac1f9ba-c0da-48aa-bac6-16e178dbbbcc,
+                        name: My Program
+                      }
+                      ]
                     - id: a2263532-1fa3-29a6-3a66-557f313c8ed6
                       orcid: 1234-4312-4352-6314
                       name: Fred Brown
                       email: null
                       systemRoles: []
+                      activePrograms: []
         "400":
           description: Bad Request
           content:
@@ -145,6 +152,7 @@ paths:
                     domain: "admin"
                   }
                   ]
+                  activePrograms: []
         "400":
           description: Bad Request
           content:
@@ -219,6 +227,12 @@ paths:
                   {
                     id: "d4f23375-0033-4d16-a62f-072e3a9198fa",
                     domain: "admin"
+                  }
+                  ]
+                  activePrograms: [
+                  {
+                    id: eac1f9ba-c0da-48aa-bac6-16e178dbbbcc,
+                    name: My Program
                   }
                   ]
         "400":
@@ -303,6 +317,12 @@ paths:
                   {
                     id: "d4f23375-0033-4d16-a62f-072e3a9198fa",
                     domain: "admin"
+                  }
+                  ]
+                  activePrograms: [
+                  {
+                    id: eac1f9ba-c0da-48aa-bac6-16e178dbbbcc,
+                    name: My Program
                   }
                   ]
         "400":
@@ -2307,10 +2327,28 @@ components:
         id:
           type: string
           format: uuid
+        orcid:
+          type: string
         name:
           type: string
         email:
           type: string
+        systemRoles:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            domain:
+              type: string
+        activePrograms:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            name:
+              type: string
     country:
       type: object
       properties:

--- a/src/main/java/org/breedinginsight/api/v1/controller/TopographyController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/TopographyController.java
@@ -35,7 +35,6 @@ import org.breedinginsight.api.model.v1.response.metadata.StatusCode;
 import org.breedinginsight.api.v1.controller.metadata.AddMetadata;
 import org.breedinginsight.model.Topography;
 import org.breedinginsight.services.TopographyService;
-import org.jooq.exception.DataAccessException;
 
 import javax.inject.Inject;
 import java.util.ArrayList;

--- a/src/main/java/org/breedinginsight/daos/UserDAO.java
+++ b/src/main/java/org/breedinginsight/daos/UserDAO.java
@@ -123,9 +123,9 @@ public class UserDAO extends BiUserDao {
             }
 
             // Add our program
-            if (programUser.getId() != null){
+            if (programUser.getProgramId() != null){
                 Optional<ProgramUser> programUserExists = Utilities.findInList(existingUser.getProgramRoles(),
-                        programUser, ProgramUser::getId);
+                        programUser, ProgramUser::getProgramId);
                 if (programUserExists.isPresent()) {
 
                     ProgramUser existingProgramUser = programUserExists.get();
@@ -134,7 +134,7 @@ public class UserDAO extends BiUserDao {
                     Optional<Role> roleExists = Utilities.findInList(existingProgramUser.getRoles(),
                             programRole, Role::getId);
                     if (!roleExists.isPresent()){
-                        programUser.addRole(programRole);
+                        existingProgramUser.addRole(programRole);
                     }
                 } else {
 

--- a/src/main/java/org/breedinginsight/daos/UserDAO.java
+++ b/src/main/java/org/breedinginsight/daos/UserDAO.java
@@ -85,8 +85,7 @@ public class UserDAO extends BiUserDao {
                 .leftJoin(SYSTEM_ROLE).on(SYSTEM_USER_ROLE.SYSTEM_ROLE_ID.eq(SYSTEM_ROLE.ID))
                 .leftJoin(PROGRAM_USER_ROLE).on(PROGRAM_USER_ROLE.USER_ID.eq(BI_USER.ID))
                 .leftJoin(PROGRAM).on(PROGRAM_USER_ROLE.PROGRAM_ID.eq(PROGRAM.ID))
-                    .and(PROGRAM.ACTIVE.eq(true))
-                    .and(PROGRAM_USER_ROLE.ACTIVE.eq(true));
+                    .and(PROGRAM.ACTIVE.eq(true));
     }
 
     private List<User> parseRecords(List<Record> records) {

--- a/src/main/java/org/breedinginsight/model/Program.java
+++ b/src/main/java/org/breedinginsight/model/Program.java
@@ -26,6 +26,9 @@ import org.breedinginsight.dao.db.tables.pojos.SpeciesEntity;
 import org.jooq.Record;
 
 
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
 import static org.breedinginsight.dao.db.Tables.*;
 
 @Getter
@@ -69,6 +72,25 @@ public class Program extends ProgramEntity {
                 .createdBy(record.getValue(PROGRAM.CREATED_BY))
                 .updatedBy(record.getValue(PROGRAM.UPDATED_BY))
                 .active(record.getValue(PROGRAM.ACTIVE))
+                .build();
+
+        return program;
+    }
+
+    public static Program parseSQLRecord(Record record, String alias){
+
+        // Generate our program record
+        Program program = Program.builder()
+                .id(record.getValue(alias + PROGRAM.ID.getName(), UUID.class))
+                .name(record.getValue(alias + PROGRAM.NAME.getName(), String.class))
+                .abbreviation(record.getValue(alias + PROGRAM.ABBREVIATION.getName(), String.class))
+                .objective(record.getValue(alias + PROGRAM.OBJECTIVE.getName(), String.class))
+                .documentationUrl(record.getValue(alias + PROGRAM.DOCUMENTATION_URL.getName(), String.class))
+                .createdAt(record.getValue(alias + PROGRAM.CREATED_AT.getName(), OffsetDateTime.class))
+                .updatedAt(record.getValue(alias + PROGRAM.UPDATED_AT.getName(), OffsetDateTime.class))
+                .createdBy(record.getValue(alias + PROGRAM.CREATED_BY.getName(), UUID.class))
+                .updatedBy(record.getValue(alias + PROGRAM.UPDATED_BY.getName(), UUID.class))
+                .active(record.getValue(alias + PROGRAM.ACTIVE.getName(), Boolean.class))
                 .build();
 
         return program;

--- a/src/main/java/org/breedinginsight/model/Program.java
+++ b/src/main/java/org/breedinginsight/model/Program.java
@@ -77,23 +77,4 @@ public class Program extends ProgramEntity {
         return program;
     }
 
-    public static Program parseSQLRecord(Record record, String alias){
-
-        // Generate our program record
-        Program program = Program.builder()
-                .id(record.getValue(alias + PROGRAM.ID.getName(), UUID.class))
-                .name(record.getValue(alias + PROGRAM.NAME.getName(), String.class))
-                .abbreviation(record.getValue(alias + PROGRAM.ABBREVIATION.getName(), String.class))
-                .objective(record.getValue(alias + PROGRAM.OBJECTIVE.getName(), String.class))
-                .documentationUrl(record.getValue(alias + PROGRAM.DOCUMENTATION_URL.getName(), String.class))
-                .createdAt(record.getValue(alias + PROGRAM.CREATED_AT.getName(), OffsetDateTime.class))
-                .updatedAt(record.getValue(alias + PROGRAM.UPDATED_AT.getName(), OffsetDateTime.class))
-                .createdBy(record.getValue(alias + PROGRAM.CREATED_BY.getName(), UUID.class))
-                .updatedBy(record.getValue(alias + PROGRAM.UPDATED_BY.getName(), UUID.class))
-                .active(record.getValue(alias + PROGRAM.ACTIVE.getName(), Boolean.class))
-                .build();
-
-        return program;
-    }
-
 }

--- a/src/main/java/org/breedinginsight/model/Program.java
+++ b/src/main/java/org/breedinginsight/model/Program.java
@@ -25,10 +25,6 @@ import org.breedinginsight.dao.db.tables.pojos.ProgramEntity;
 import org.breedinginsight.dao.db.tables.pojos.SpeciesEntity;
 import org.jooq.Record;
 
-
-import java.time.OffsetDateTime;
-import java.util.UUID;
-
 import static org.breedinginsight.dao.db.Tables.*;
 
 @Getter

--- a/src/main/java/org/breedinginsight/model/ProgramUser.java
+++ b/src/main/java/org/breedinginsight/model/ProgramUser.java
@@ -18,7 +18,6 @@
 package org.breedinginsight.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/src/main/java/org/breedinginsight/model/ProgramUser.java
+++ b/src/main/java/org/breedinginsight/model/ProgramUser.java
@@ -27,8 +27,10 @@ import lombok.experimental.SuperBuilder;
 import org.breedinginsight.dao.db.tables.pojos.ProgramUserRoleEntity;
 import org.jooq.Record;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.breedinginsight.dao.db.Tables.PROGRAM_USER_ROLE;
 
@@ -61,6 +63,23 @@ public class ProgramUser extends ProgramUserRoleEntity {
                 .createdBy(record.getValue(PROGRAM_USER_ROLE.CREATED_BY))
                 .updatedBy(record.getValue(PROGRAM_USER_ROLE.UPDATED_BY))
                 .active(record.getValue(PROGRAM_USER_ROLE.ACTIVE))
+                .build();
+
+        return programUser;
+    }
+
+    public static ProgramUser parseSQLRecord(Record record, String alias){
+        // Generate our program record
+        ProgramUser programUser = ProgramUser.builder()
+                .id(record.getValue(alias + PROGRAM_USER_ROLE.ID.getName(), UUID.class))
+                .roles(new ArrayList<>())
+                .programId(record.getValue(alias + PROGRAM_USER_ROLE.PROGRAM_ID.getName(), UUID.class))
+                .userId(record.getValue(alias + PROGRAM_USER_ROLE.USER_ID.getName(), UUID.class))
+                .createdAt(record.getValue(alias + PROGRAM_USER_ROLE.CREATED_AT.getName(), OffsetDateTime.class))
+                .updatedAt(record.getValue(alias + PROGRAM_USER_ROLE.UPDATED_AT.getName(), OffsetDateTime.class))
+                .createdBy(record.getValue(alias + PROGRAM_USER_ROLE.CREATED_BY.getName(), UUID.class))
+                .updatedBy(record.getValue(alias + PROGRAM_USER_ROLE.UPDATED_BY.getName(), UUID.class))
+                .active(record.getValue(alias + PROGRAM_USER_ROLE.ACTIVE.getName(), Boolean.class))
                 .build();
 
         return programUser;

--- a/src/main/java/org/breedinginsight/model/ProgramUser.java
+++ b/src/main/java/org/breedinginsight/model/ProgramUser.java
@@ -17,7 +17,7 @@
 
 package org.breedinginsight.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -27,10 +27,8 @@ import lombok.experimental.SuperBuilder;
 import org.breedinginsight.dao.db.tables.pojos.ProgramUserRoleEntity;
 import org.jooq.Record;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import static org.breedinginsight.dao.db.Tables.PROGRAM_USER_ROLE;
 
@@ -46,10 +44,12 @@ public class ProgramUser extends ProgramUserRoleEntity {
     private User createdByUser;
     private User updatedByUser;
 
+    @JsonIgnoreProperties(value={"createdAt", "createdByUser", "updatedAt", "updatedByUser", "active", "species"})
+    private Program program;
+
+    @JsonIgnoreProperties(value={"programRoles", "systemRoles"})
     private User user;
     private List<Role> roles;
-    @JsonIgnoreProperties(value={"createdAt", "createdBy", "updatedAt", "updatedBy", "active"})
-    private Program program;
 
     public static ProgramUser parseSQLRecord(Record record){
         // Generate our program record
@@ -68,25 +68,7 @@ public class ProgramUser extends ProgramUserRoleEntity {
         return programUser;
     }
 
-    public static ProgramUser parseSQLRecord(Record record, String alias){
-        // Generate our program record
-        ProgramUser programUser = ProgramUser.builder()
-                .id(record.getValue(alias + PROGRAM_USER_ROLE.ID.getName(), UUID.class))
-                .roles(new ArrayList<>())
-                .programId(record.getValue(alias + PROGRAM_USER_ROLE.PROGRAM_ID.getName(), UUID.class))
-                .userId(record.getValue(alias + PROGRAM_USER_ROLE.USER_ID.getName(), UUID.class))
-                .createdAt(record.getValue(alias + PROGRAM_USER_ROLE.CREATED_AT.getName(), OffsetDateTime.class))
-                .updatedAt(record.getValue(alias + PROGRAM_USER_ROLE.UPDATED_AT.getName(), OffsetDateTime.class))
-                .createdBy(record.getValue(alias + PROGRAM_USER_ROLE.CREATED_BY.getName(), UUID.class))
-                .updatedBy(record.getValue(alias + PROGRAM_USER_ROLE.UPDATED_BY.getName(), UUID.class))
-                .active(record.getValue(alias + PROGRAM_USER_ROLE.ACTIVE.getName(), Boolean.class))
-                .build();
-
-        return programUser;
-    }
-
     public void addRole(Role role) {
         roles.add(role);
     }
-
 }

--- a/src/main/java/org/breedinginsight/model/ProgramUser.java
+++ b/src/main/java/org/breedinginsight/model/ProgramUser.java
@@ -18,6 +18,7 @@
 package org.breedinginsight.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -46,6 +47,8 @@ public class ProgramUser extends ProgramUserRoleEntity {
 
     private User user;
     private List<Role> roles;
+    @JsonIgnoreProperties(value={"createdAt", "createdBy", "updatedAt", "updatedBy", "active"})
+    private Program program;
 
     public static ProgramUser parseSQLRecord(Record record){
         // Generate our program record

--- a/src/main/java/org/breedinginsight/model/Role.java
+++ b/src/main/java/org/breedinginsight/model/Role.java
@@ -26,8 +26,6 @@ import lombok.experimental.SuperBuilder;
 import org.breedinginsight.dao.db.tables.pojos.RoleEntity;
 import org.jooq.Record;
 
-import java.util.UUID;
-
 import static org.breedinginsight.dao.db.Tables.ROLE;
 
 @Getter

--- a/src/main/java/org/breedinginsight/model/Role.java
+++ b/src/main/java/org/breedinginsight/model/Role.java
@@ -50,11 +50,4 @@ public class Role extends RoleEntity {
                 .build();
     }
 
-    public static Role parseSQLRecord(Record record, String alias){
-        return Role.builder()
-                .id(record.getValue(alias + ROLE.ID.getName(), UUID.class))
-                .domain(record.getValue(alias + ROLE.DOMAIN.getName(), String.class))
-                .build();
-    }
-
 }

--- a/src/main/java/org/breedinginsight/model/Role.java
+++ b/src/main/java/org/breedinginsight/model/Role.java
@@ -26,6 +26,8 @@ import lombok.experimental.SuperBuilder;
 import org.breedinginsight.dao.db.tables.pojos.RoleEntity;
 import org.jooq.Record;
 
+import java.util.UUID;
+
 import static org.breedinginsight.dao.db.Tables.ROLE;
 
 @Getter
@@ -45,6 +47,13 @@ public class Role extends RoleEntity {
         return Role.builder()
                 .id(record.getValue(ROLE.ID))
                 .domain(record.getValue(ROLE.DOMAIN))
+                .build();
+    }
+
+    public static Role parseSQLRecord(Record record, String alias){
+        return Role.builder()
+                .id(record.getValue(alias + ROLE.ID.getName(), UUID.class))
+                .domain(record.getValue(alias + ROLE.DOMAIN.getName(), String.class))
                 .build();
     }
 

--- a/src/main/java/org/breedinginsight/model/User.java
+++ b/src/main/java/org/breedinginsight/model/User.java
@@ -44,7 +44,7 @@ public class User extends BiUserEntity{
     @NotNull
     private List<SystemRole> systemRoles;
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
-    @JsonIgnoreProperties(value = {"createdAt", "updatedAt", "active"})
+    @JsonIgnoreProperties(value = {"createdAt", "updatedAt"})
     @NotNull
     private List<Program> activePrograms;
 

--- a/src/main/java/org/breedinginsight/model/User.java
+++ b/src/main/java/org/breedinginsight/model/User.java
@@ -17,6 +17,7 @@
 
 package org.breedinginsight.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 import lombok.experimental.Accessors;
@@ -42,6 +43,10 @@ public class User extends BiUserEntity{
     @JsonInclude(value= JsonInclude.Include.ALWAYS)
     @NotNull
     private List<SystemRole> systemRoles;
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
+    @JsonIgnoreProperties(value = {"createdAt", "updatedAt", "active"})
+    @NotNull
+    private List<Program> activePrograms;
 
     public User(BiUserEntity biUser) {
         this.setId(biUser.getId());
@@ -49,6 +54,7 @@ public class User extends BiUserEntity{
         this.setName(biUser.getName());
         this.setEmail(biUser.getEmail());
         this.setSystemRoles(new ArrayList<>());
+        this.setActivePrograms(new ArrayList<>());
         this.setActive(biUser.getActive());
     }
 
@@ -63,6 +69,7 @@ public class User extends BiUserEntity{
                 .name(record.getValue(tableName.NAME))
                 .email(record.getValue(tableName.EMAIL))
                 .systemRoles(new ArrayList<>())
+                .activePrograms(new ArrayList<>())
                 .active(record.getValue(tableName.ACTIVE))
                 .build();
     }
@@ -74,4 +81,6 @@ public class User extends BiUserEntity{
     public void addRole(SystemRole role) {
         systemRoles.add(role);
     }
+
+    public void addActiveProgram(Program program) {activePrograms.add(program); }
 }

--- a/src/main/java/org/breedinginsight/model/User.java
+++ b/src/main/java/org/breedinginsight/model/User.java
@@ -40,12 +40,12 @@ import static org.breedinginsight.dao.db.Tables.BI_USER;
 @SuperBuilder
 public class User extends BiUserEntity{
 
-    @JsonInclude(value= JsonInclude.Include.ALWAYS)
+    @JsonInclude()
     @NotNull
     private List<SystemRole> systemRoles;
-    @JsonInclude(value = JsonInclude.Include.ALWAYS)
-    @JsonIgnoreProperties(value = {"createdAt", "updatedAt"})
+    @JsonInclude()
     @NotNull
+    @JsonIgnoreProperties(value = {"createdAt", "updatedAt", "createdByUser", "updatedByUser", "user"})
     private List<ProgramUser> programRoles;
 
     public User(BiUserEntity biUser) {

--- a/src/main/java/org/breedinginsight/model/User.java
+++ b/src/main/java/org/breedinginsight/model/User.java
@@ -46,7 +46,7 @@ public class User extends BiUserEntity{
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
     @JsonIgnoreProperties(value = {"createdAt", "updatedAt"})
     @NotNull
-    private List<Program> activePrograms;
+    private List<ProgramUser> programRoles;
 
     public User(BiUserEntity biUser) {
         this.setId(biUser.getId());
@@ -54,7 +54,7 @@ public class User extends BiUserEntity{
         this.setName(biUser.getName());
         this.setEmail(biUser.getEmail());
         this.setSystemRoles(new ArrayList<>());
-        this.setActivePrograms(new ArrayList<>());
+        this.setProgramRoles(new ArrayList<>());
         this.setActive(biUser.getActive());
     }
 
@@ -69,7 +69,7 @@ public class User extends BiUserEntity{
                 .name(record.getValue(tableName.NAME))
                 .email(record.getValue(tableName.EMAIL))
                 .systemRoles(new ArrayList<>())
-                .activePrograms(new ArrayList<>())
+                .programRoles(new ArrayList<>())
                 .active(record.getValue(tableName.ACTIVE))
                 .build();
     }
@@ -82,5 +82,5 @@ public class User extends BiUserEntity{
         systemRoles.add(role);
     }
 
-    public void addActiveProgram(Program program) {activePrograms.add(program); }
+    public void addProgramUser(ProgramUser programUser) {programRoles.add(programUser); }
 }

--- a/src/main/java/org/breedinginsight/utilities/Utilities.java
+++ b/src/main/java/org/breedinginsight/utilities/Utilities.java
@@ -17,9 +17,6 @@
 
 package org.breedinginsight.utilities;
 
-import org.breedinginsight.model.SystemRole;
-
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;

--- a/src/main/java/org/breedinginsight/utilities/Utilities.java
+++ b/src/main/java/org/breedinginsight/utilities/Utilities.java
@@ -1,0 +1,41 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.utilities;
+
+import org.breedinginsight.model.SystemRole;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+public class Utilities {
+
+    public static <T> Boolean existsInList(List<T> checkList, T objectToCheck, Function<T, UUID> getterMethod){
+
+        Optional<T> existingObject = checkList.stream()
+                .filter(p -> getterMethod.apply(p).equals(getterMethod.apply(objectToCheck)))
+                .findFirst();
+        if (existingObject.isPresent()){
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/breedinginsight/utilities/Utilities.java
+++ b/src/main/java/org/breedinginsight/utilities/Utilities.java
@@ -27,15 +27,11 @@ import java.util.function.Function;
 
 public class Utilities {
 
-    public static <T> Boolean existsInList(List<T> checkList, T objectToCheck, Function<T, UUID> getterMethod){
+    public static <T> Optional<T> findInList(List<T> checkList, T objectToCheck, Function<T, UUID> getterMethod){
 
         Optional<T> existingObject = checkList.stream()
                 .filter(p -> getterMethod.apply(p).equals(getterMethod.apply(objectToCheck)))
                 .findFirst();
-        if (existingObject.isPresent()){
-            return true;
-        } else {
-            return false;
-        }
+        return existingObject;
     }
 }

--- a/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
@@ -1364,6 +1364,11 @@ public class ProgramControllerIntegrationTest {
         JsonObject role = roles.get(0).getAsJsonObject();
         assertEquals(role.get("id").getAsString(),validRole.getId().toString(), "Wrong role id");
         assertEquals(role.get("domain").getAsString(),validRole.getDomain(), "Wrong domain");
+        JsonObject program = programUser.getAsJsonObject("program");
+        assertEquals(validProgram.getId().toString(), program.get("id").getAsString(), "Wrong program id");
+        assertEquals(validProgram.getName(), program.get("name").getAsString(), "Wrong program name");
+        assertEquals(validProgram.getAbbreviation(), program.get("abbreviation").getAsString(), "Wrong program abbreviation");
+        assertEquals(validProgram.getObjective(), program.get("objective").getAsString(), "Wrong program objective");
     }
 
     @Test
@@ -1393,6 +1398,11 @@ public class ProgramControllerIntegrationTest {
         JsonObject role = roles.get(0).getAsJsonObject();
         assertEquals(role.get("id").getAsString(),validRole.getId().toString(), "Wrong role id");
         assertEquals(role.get("domain").getAsString(),validRole.getDomain(), "Wrong domain");
+        JsonObject program = result.getAsJsonObject("program");
+        assertEquals(validProgram.getId().toString(), program.get("id").getAsString(), "Wrong program id");
+        assertEquals(validProgram.getName(), program.get("name").getAsString(), "Wrong program name");
+        assertEquals(validProgram.getAbbreviation(), program.get("abbreviation").getAsString(), "Wrong program abbreviation");
+        assertEquals(validProgram.getObjective(), program.get("objective").getAsString(), "Wrong program objective");
     }
 
     @Test

--- a/src/test/resources/sql/UserControllerIntegrationTest.sql
+++ b/src/test/resources/sql/UserControllerIntegrationTest.sql
@@ -41,3 +41,6 @@ join bi_user on bi_user.name = 'Test User' or bi_user.name = 'Other Test User'
 join role on role.domain = 'member'
 join bi_user as system_user on system_user.name = 'system'
 where program.name = 'Test Program1';
+
+-- name: DeactivateProgram
+update program set active = false where name = 'Test Program';

--- a/src/test/resources/sql/UserControllerIntegrationTest.sql
+++ b/src/test/resources/sql/UserControllerIntegrationTest.sql
@@ -1,0 +1,43 @@
+-- name: CopyrightNotice
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- name: InsertProgram
+insert into program (species_id, name, abbreviation, objective, created_by, updated_by)
+select species.id, 'Test Program', 'test', 'To test things', bi_user.id, bi_user.id from species
+join bi_user on bi_user.name = 'system' limit 1;
+
+insert into program (species_id, name, abbreviation, objective, created_by, updated_by)
+select species.id, 'Test Program1', 'test1', 'To test all the things', bi_user.id, bi_user.id from species
+join bi_user on bi_user.name = 'system' limit 1;
+
+-- name: InsertUserProgramAssociations
+insert into program_user_role (program_id, user_id, role_id, created_by, updated_by)
+select program.id, bi_user.id, role.id, system_user.id, system_user.id
+from program
+join bi_user on bi_user.name = 'Test User' or bi_user.name = 'Other Test User'
+join role on role.domain = 'member'
+join bi_user as system_user on system_user.name = 'system'
+where program.name = 'Test Program';
+
+insert into program_user_role (program_id, user_id, role_id, active, created_by, updated_by)
+select program.id, bi_user.id, role.id, false, system_user.id, system_user.id
+from program
+join bi_user on bi_user.name = 'Test User' or bi_user.name = 'Other Test User'
+join role on role.domain = 'member'
+join bi_user as system_user on system_user.name = 'system'
+where program.name = 'Test Program1';


### PR DESCRIPTION
Adds the program roles to the user controller return data. The program roles object that is returned now includes the program object that the role is referring to. Inactive program users will be returned for a user, program users that belong to an inactive program will not be returned. 

This will be useful in the future feature of permission checks in bi-api on the program level. 

Also includes updates to the UserControllerIntegrationTest to update the test data creation and pulling using fannypack. 

## Dependencies

This feature is paired with PRO-53 of bi-web. 

## Review

- Tests are adjusted properly for new user controller return objects. 
- Works with bi-web PRO-53. 
- Normal code review