### PR TITLE
INF-138 - Include data in response even if not populated

### DIFF
--- a/src/main/java/org/breedinginsight/api/model/v1/response/DataResponse.java
+++ b/src/main/java/org/breedinginsight/api/model/v1/response/DataResponse.java
@@ -17,6 +17,7 @@
 
 package org.breedinginsight.api.model.v1.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 import lombok.experimental.Accessors;
 
@@ -29,5 +30,6 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DataResponse<T> {
+    @JsonInclude()
     private List<T> data;
 }

--- a/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
@@ -1603,7 +1603,7 @@ public class ProgramControllerIntegrationTest {
         JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
         assertEquals(meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), 0, "Wrong totalCount");
 
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        JsonArray result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").getAsJsonArray("data");
         assertEquals(result.size(),0, "Wrong size");
 
     }


### PR DESCRIPTION
One Line of code to fix it all, One line to find them,
One Line of code to bring them all and in the Jackson bind them

## Testing

- Tests run
- Data object is in the result of the response even if not results are returned. 