### PR TITLE
insert [NULL] into db when coordinates not specified

### DIFF
--- a/src/main/java/org/breedinginsight/model/ProgramLocation.java
+++ b/src/main/java/org/breedinginsight/model/ProgramLocation.java
@@ -54,7 +54,7 @@ public class ProgramLocation extends PlaceEntity {
     @JsonInclude(JsonInclude.Include.ALWAYS)
     public Feature getCoordinatesJson() throws JsonProcessingException {
         ObjectMapper objMapper = new ObjectMapper();
-        return objMapper.readValue(super.getCoordinates().data(), Feature.class);
+        return super.getCoordinates() != null ? objMapper.readValue(super.getCoordinates().data(), Feature.class) : null;
     }
 
     public ProgramLocation(PlaceEntity placeEntity) {

--- a/src/main/java/org/breedinginsight/services/ProgramLocationService.java
+++ b/src/main/java/org/breedinginsight/services/ProgramLocationService.java
@@ -253,7 +253,7 @@ public class ProgramLocationService {
         placeEntity.setAccessibilityId(accessibilityId);
         placeEntity.setTopographyId(topographyId);
         placeEntity.setAbbreviation(programLocationRequest.getAbbreviation());
-        placeEntity.setCoordinates(JSONB.valueOf(coordinates));
+        placeEntity.setCoordinates(coordinates != null ? JSONB.valueOf(coordinates) : null);
         placeEntity.setCoordinateUncertainty(programLocationRequest.getCoordinateUncertainty());
         placeEntity.setCoordinateDescription(programLocationRequest.getCoordinateDescription());
         placeEntity.setSlope(programLocationRequest.getSlope());

--- a/src/main/java/org/breedinginsight/services/ProgramLocationService.java
+++ b/src/main/java/org/breedinginsight/services/ProgramLocationService.java
@@ -208,7 +208,7 @@ public class ProgramLocationService {
                 .accessibilityId(accessibilityId)
                 .topographyId(topographyId)
                 .abbreviation(programLocationRequest.getAbbreviation())
-                .coordinates(JSONB.valueOf(coordinates))
+                .coordinates(coordinates != null ? JSONB.valueOf(coordinates) : null)
                 .coordinateUncertainty(programLocationRequest.getCoordinateUncertainty())
                 .coordinateDescription(programLocationRequest.getCoordinateDescription())
                 .slope(programLocationRequest.getSlope())

--- a/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
@@ -436,6 +436,11 @@ public class ProgramControllerIntegrationTest {
         JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
         assertEquals(requestBody.get("name").getAsString(), result.get("name").getAsString(),"Wrong name");
         String locationId = result.get("id").getAsString();
+
+        // Check that the coordinates is [NULL] in DB
+        Optional<ProgramLocation> programLocation = programLocationService.getById(UUID.fromString(validProgramId), UUID.fromString(locationId));
+        assertNull(programLocation.get().getCoordinates());
+
         programLocationService.delete(UUID.fromString(locationId));
     }
 

--- a/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
@@ -850,6 +850,10 @@ public class ProgramControllerIntegrationTest {
         JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
         assertEquals("Field 1", result.get("name").getAsString(), "Wrong name");
 
+        // Check that the coordinates is [NULL] in DB
+        Optional<ProgramLocation> programLocation = programLocationService.getById(UUID.fromString(validProgramId), UUID.fromString(locationId));
+        assertNull(programLocation.get().getCoordinates());
+
         programLocationService.delete(UUID.fromString(locationId));
     }
 


### PR DESCRIPTION
The trello card explains it all, 

https://trello.com/c/03b8Z0jy/167-pro-77-bug-post-locations-controller-inserts-null-into-sql-column-when-there-is-no-data

- Made bi-api insert NULL into db when coordinates are not passed in. 
- Made bi-api not error out when reading NULL for coordinates from DB