### PR TITLE
Feature/pro 78

### DIFF
--- a/src/main/java/org/breedinginsight/api/model/v1/request/OrcidRequest.java
+++ b/src/main/java/org/breedinginsight/api/model/v1/request/OrcidRequest.java
@@ -1,0 +1,35 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.api.model.v1.request;
+
+import io.micronaut.core.annotation.Introspected;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Introspected
+public class OrcidRequest {
+    @NotBlank
+    String orcid;
+}

--- a/src/main/java/org/breedinginsight/api/model/v1/request/OrcidRequest.java
+++ b/src/main/java/org/breedinginsight/api/model/v1/request/OrcidRequest.java
@@ -22,6 +22,7 @@ import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 
+//TODO: Remove once registration flow is complete
 @Getter
 @Setter
 @Builder

--- a/src/main/java/org/breedinginsight/api/v1/controller/UserController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/UserController.java
@@ -204,6 +204,9 @@ public class UserController {
         } catch (DoesNotExistException e) {
             log.info(e.getMessage());
             return HttpResponse.notFound();
+        } catch (AlreadyExistsException e){
+            log.info(e.getMessage());
+            return HttpResponse.status(HttpStatus.CONFLICT, e.getMessage());
         }
     }
 

--- a/src/main/java/org/breedinginsight/api/v1/controller/UserController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/UserController.java
@@ -26,6 +26,7 @@ import io.micronaut.security.rules.SecurityRule;
 import lombok.extern.slf4j.Slf4j;
 import org.breedinginsight.api.auth.AuthenticatedUser;
 import org.breedinginsight.api.auth.SecurityService;
+import org.breedinginsight.api.model.v1.request.OrcidRequest;
 import org.breedinginsight.api.model.v1.request.SystemRolesRequest;
 import org.breedinginsight.api.model.v1.request.UserRequest;
 import org.breedinginsight.api.model.v1.response.DataResponse;
@@ -184,6 +185,25 @@ public class UserController {
         } catch (AuthorizationException e) {
             log.info(e.getMessage());
             return HttpResponse.status(HttpStatus.FORBIDDEN, e.getMessage());
+        }
+    }
+
+    //TODO: Remove once registration flow is implemented.
+    // Endpoint not in the api docs. This will be removed in v0.2
+    @Put("/users/{userId}/orcid")
+    @Produces(MediaType.APPLICATION_JSON)
+    @AddMetadata
+    @Secured(SecurityRule.IS_AUTHENTICATED)
+    public HttpResponse<Response<User>> updateUser(@PathVariable UUID userId, @Body @Valid OrcidRequest orcidRequest) {
+
+        try {
+            AuthenticatedUser actingUser = securityService.getUser();
+            User user = userService.updateOrcid(actingUser, userId, orcidRequest);
+            Response<User> response = new Response<>(user);
+            return HttpResponse.ok(response);
+        } catch (DoesNotExistException e) {
+            log.info(e.getMessage());
+            return HttpResponse.notFound();
         }
     }
 

--- a/src/main/java/org/breedinginsight/services/UserService.java
+++ b/src/main/java/org/breedinginsight/services/UserService.java
@@ -19,6 +19,7 @@ package org.breedinginsight.services;
 
 import lombok.extern.slf4j.Slf4j;
 import org.breedinginsight.api.auth.AuthenticatedUser;
+import org.breedinginsight.api.model.v1.request.OrcidRequest;
 import org.breedinginsight.api.model.v1.request.SystemRolesRequest;
 import org.breedinginsight.api.model.v1.request.UserRequest;
 import org.breedinginsight.dao.db.tables.daos.SystemRoleDao;
@@ -290,5 +291,20 @@ public class UserService {
 
     public boolean exists(UUID id){
         return dao.existsById(id);
+    }
+
+    public User updateOrcid(AuthenticatedUser activeUser, UUID userId, OrcidRequest orcidRequest) throws DoesNotExistException {
+
+        // This is a temporary fix so any authenticated user is able to update any users orcid.
+
+        BiUserEntity biUser = dao.fetchOneById(userId);
+
+        if (biUser == null) {
+            throw new DoesNotExistException("UUID for user does not exist");
+        }
+
+        biUser.setOrcid(orcidRequest.getOrcid());
+        dao.update(biUser);
+        return new User(dao.fetchOneById(userId));
     }
 }

--- a/src/main/java/org/breedinginsight/services/UserService.java
+++ b/src/main/java/org/breedinginsight/services/UserService.java
@@ -306,7 +306,7 @@ public class UserService {
 
         List<BiUserEntity> biUserWithOrcidList = dao.fetchByOrcid(orcidRequest.getOrcid());
         for (BiUserEntity biUserWithOrcid: biUserWithOrcidList){
-            if (!biUserWithOrcid.getId().toString().equals(userId.toString())){
+            if (!biUserWithOrcid.getId().equals(userId)){
                 throw new AlreadyExistsException("Orcid already in use");
             }
         }

--- a/src/main/java/org/breedinginsight/services/UserService.java
+++ b/src/main/java/org/breedinginsight/services/UserService.java
@@ -293,6 +293,7 @@ public class UserService {
         return dao.existsById(id);
     }
 
+    //TODO: Remove once registration flow is complete
     public User updateOrcid(AuthenticatedUser activeUser, UUID userId, OrcidRequest orcidRequest) throws DoesNotExistException, AlreadyExistsException {
 
         // This is a temporary fix so any authenticated user is able to update any users orcid.

--- a/src/main/java/org/breedinginsight/services/UserService.java
+++ b/src/main/java/org/breedinginsight/services/UserService.java
@@ -293,7 +293,7 @@ public class UserService {
         return dao.existsById(id);
     }
 
-    public User updateOrcid(AuthenticatedUser activeUser, UUID userId, OrcidRequest orcidRequest) throws DoesNotExistException {
+    public User updateOrcid(AuthenticatedUser activeUser, UUID userId, OrcidRequest orcidRequest) throws DoesNotExistException, AlreadyExistsException {
 
         // This is a temporary fix so any authenticated user is able to update any users orcid.
 
@@ -301,6 +301,13 @@ public class UserService {
 
         if (biUser == null) {
             throw new DoesNotExistException("UUID for user does not exist");
+        }
+
+        List<BiUserEntity> biUserWithOrcidList = dao.fetchByOrcid(orcidRequest.getOrcid());
+        for (BiUserEntity biUserWithOrcid: biUserWithOrcidList){
+            if (!biUserWithOrcid.getId().toString().equals(userId.toString())){
+                throw new AlreadyExistsException("Orcid already in use");
+            }
         }
 
         biUser.setOrcid(orcidRequest.getOrcid());

--- a/src/test/java/org/breedinginsight/api/v1/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/UserControllerIntegrationTest.java
@@ -839,6 +839,7 @@ public class UserControllerIntegrationTest extends DatabaseTest {
         assertEquals(1, resultProgramRoles.size(), "Deactivated program was returned in roles");
     }
 
+    //TODO: Remove once registration flow is complete
     @Test
     @Order(8)
     public void putUserOrcidUserNotFound() {
@@ -859,6 +860,7 @@ public class UserControllerIntegrationTest extends DatabaseTest {
         assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
     }
 
+    //TODO: Remove once registration flow is complete
     @Test
     @Order(8)
     public void putUserOrcidSuccess() {
@@ -884,6 +886,7 @@ public class UserControllerIntegrationTest extends DatabaseTest {
         assertEquals(otherTestUser.getEmail(), result.get("email").getAsString(), "Wrong email");
     }
 
+    //TODO: Remove once registration flow is complete
     @Test
     @Order(8)
     public void putUserOrcidInUseBySelf() {
@@ -903,6 +906,7 @@ public class UserControllerIntegrationTest extends DatabaseTest {
         assertEquals(HttpStatus.OK, response.getStatus());
     }
 
+    //TODO: Remove once registration flow is complete
     @Test
     @Order(8)
     public void putUserOrcidInUseByOther() {

--- a/src/test/java/org/breedinginsight/api/v1/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/UserControllerIntegrationTest.java
@@ -891,12 +891,11 @@ public class UserControllerIntegrationTest extends DatabaseTest {
     @Order(8)
     public void putUserOrcidInUseBySelf() {
 
-        String orcid = "0000-0000-0000-0000";
         JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("orcid", orcid);
+        requestBody.addProperty("orcid", testUser.getOrcid());
 
         Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/users/" + otherTestUser.getId().toString() + "/orcid", requestBody.toString())
+                PUT("/users/" + testUser.getId().toString() + "/orcid", requestBody.toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
         );

--- a/src/test/java/org/breedinginsight/api/v1/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/UserControllerIntegrationTest.java
@@ -883,4 +883,45 @@ public class UserControllerIntegrationTest extends DatabaseTest {
         assertEquals(orcid, result.get("orcid").getAsString(), "Wrong orcid");
         assertEquals(otherTestUser.getEmail(), result.get("email").getAsString(), "Wrong email");
     }
+
+    @Test
+    @Order(8)
+    public void putUserOrcidInUseBySelf() {
+
+        String orcid = "0000-0000-0000-0000";
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("orcid", orcid);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/users/" + otherTestUser.getId().toString() + "/orcid", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    @Order(8)
+    public void putUserOrcidInUseByOther() {
+
+        String orcid = TestTokenValidator.ANOTHER_TEST_USER_ORCID;
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("orcid", orcid);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/users/" + otherTestUser.getId().toString() + "/orcid", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.CONFLICT, e.getStatus());
+    }
 }
+


### PR DESCRIPTION
Adds an update orcid endpoint as a temporary fix for assigning an orcid to a user. 

## Dependencies
- Is paired on PRO-78 on bi-web

## Design 

- Added an additional endpoint instead of modifying the existing endpoints so that the feature is easily removed and is less likely to cause errors when we remove it later. 