### PR TITLE
Feature/inf 200

### DIFF
--- a/src/main/resources/db/migration/V0.5.14__set-orcid-unique.sql
+++ b/src/main/resources/db/migration/V0.5.14__set-orcid-unique.sql
@@ -1,0 +1,19 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE bi_user
+ADD CONSTRAINT orcid_unique UNIQUE (orcid);


### PR DESCRIPTION
Adds a unique constraint to the db for orcid. I did not need to add a unique check and tests to bi-api, because these were already implemented on PRO-78. This is based onto PRO-78, so that should be review and approved first. 

## Testing

Try out this query after applying your flyway migrations:

```
insert into bi_user (orcid, created_by, updated_by)
select '0000-0003-0437-8310', id, id from bi_user bu where name = 'system' 
```

That will give you a unique constraint error.