### PR TITLE
[ISSUE-9] Make traits duplicate check within the program

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           java-version: 13
 
       - name: Build with Maven
-        run: mvn -B flyway:migrate install --file pom.xml --settings settings.xml 
+        run: mvn validate -B flyway:migrate clean install --file pom.xml --settings settings.xml 
         env:
           DB_USER: postgres
           DB_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
         aliases:
           - dbserver
   brapi-server:
-    image: breedinginsight/brapi-java-server
+    image: breedinginsight/brapi-java-server:v2.0-1
     container_name: brapi-server
     depends_on:
       - bidb

--- a/src/main/java/org/breedinginsight/api/auth/AuthServiceLoginHandler.java
+++ b/src/main/java/org/breedinginsight/api/auth/AuthServiceLoginHandler.java
@@ -92,7 +92,7 @@ public class AuthServiceLoginHandler extends JwtCookieLoginHandler {
         try {
             String locationUrl = this.jwtCookieConfiguration.getLoginSuccessTargetUrl();
 
-            Optional<HttpRequest<Object>> requestOptional = ServerRequestContext.currentRequest();
+            Optional<HttpRequest<Object>> requestOptional = this.getCurrentRequest();
             if (requestOptional.isPresent()){
                 HttpRequest<Object> request = requestOptional.get();
                 if (request.getCookies().contains(loginSuccessUrlCookieName)){
@@ -142,4 +142,9 @@ public class AuthServiceLoginHandler extends JwtCookieLoginHandler {
             return false;
         }
     }
+
+    public Optional<HttpRequest<Object>> getCurrentRequest() {
+        return ServerRequestContext.currentRequest();
+    }
+
 }

--- a/src/main/java/org/breedinginsight/daos/TraitDAO.java
+++ b/src/main/java/org/breedinginsight/daos/TraitDAO.java
@@ -356,7 +356,7 @@ public class TraitDAO extends TraitDao {
                 .join(updatedByTableAlias).on(TRAIT.UPDATED_BY.eq(updatedByTableAlias.ID));
     }
 
-    public List<Trait> getTraitsByTraitMethodScaleName(List<Trait> traits){
+    public List<Trait> getTraitsByTraitMethodScaleName(UUID programId, List<Trait> traits){
 
         //TODO: Get these from the query as well
         BiUserTable createdByUser = BI_USER.as("createdByUser");
@@ -375,8 +375,11 @@ public class TraitDAO extends TraitDao {
             Result<Record> records = dsl.select()
                     .from(newTraits)
                     .join(TRAIT).on(TRAIT.TRAIT_NAME.like(newTraits.field("new_trait_name")))
+                    .join(PROGRAM_ONTOLOGY).on(TRAIT.PROGRAM_ONTOLOGY_ID.eq(PROGRAM_ONTOLOGY.ID))
+                    .join(PROGRAM).on(PROGRAM_ONTOLOGY.PROGRAM_ID.eq(PROGRAM.ID))
                     .join(METHOD).on(TRAIT.METHOD_ID.eq(METHOD.ID)).and(METHOD.METHOD_NAME.like(newTraits.field("new_method_name")))
                     .join(SCALE).on(TRAIT.SCALE_ID.eq(SCALE.ID)).and(SCALE.SCALE_NAME.like(newTraits.field("new_scale_name")))
+                    .where(PROGRAM.ID.eq(programId))
                     .fetch();
 
 
@@ -393,10 +396,14 @@ public class TraitDAO extends TraitDao {
         return traitResults;
     }
 
-    public List<Trait> getTraitsByAbbreviation(List<String> abbreviations) {
+    public List<Trait> getTraitsByAbbreviation(UUID programId, List<String> abbreviations) {
 
         Result<Record> records = dsl.select()
-                .from(TRAIT).where(TRAIT.ABBREVIATIONS.cast(String[].class).contains(abbreviations.toArray(String[]::new)))
+                .from(TRAIT)
+                .join(PROGRAM_ONTOLOGY).on(TRAIT.PROGRAM_ONTOLOGY_ID.eq(PROGRAM_ONTOLOGY.ID))
+                .join(PROGRAM).on(PROGRAM_ONTOLOGY.PROGRAM_ID.eq(PROGRAM.ID))
+                .where(TRAIT.ABBREVIATIONS.cast(String[].class).contains(abbreviations.toArray(String[]::new)))
+                .and(PROGRAM.ID.eq(programId))
                 .fetch();
 
         List<Trait> traitResults = new ArrayList<>();

--- a/src/main/java/org/breedinginsight/services/TraitService.java
+++ b/src/main/java/org/breedinginsight/services/TraitService.java
@@ -127,8 +127,8 @@ public class TraitService {
 
         // Ignore duplicate traits
         ValidationErrors duplicateErrors = new ValidationErrors();
-        List<Trait> duplicateTraits = traitValidator.checkDuplicateTraitsExistingByName(traits);
-        List<Trait> duplicateTraitsByAbbrev = traitValidator.checkDuplicateTraitsExistingByAbbreviation(traits);
+        List<Trait> duplicateTraits = traitValidator.checkDuplicateTraitsExistingByName(programId, traits);
+        List<Trait> duplicateTraitsByAbbrev = traitValidator.checkDuplicateTraitsExistingByAbbreviation(programId, traits);
         List<Integer> traitIndexToRemove = new ArrayList<>();
         for (Trait duplicateTrait: duplicateTraits){
 

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
@@ -127,12 +127,12 @@ public class TraitValidatorService {
         return errors;
     }
 
-    public List<Trait> checkDuplicateTraitsExistingByName(List<Trait> traits){
+    public List<Trait> checkDuplicateTraitsExistingByName(UUID programId, List<Trait> traits){
 
         List<Trait> duplicates = new ArrayList<>();
 
         // Check for existing trait name
-        List<Trait> duplicateNameTraits = checkForDuplicateTraitsByNames(traits);
+        List<Trait> duplicateNameTraits = checkForDuplicateTraitsByNames(programId, traits);
 
         for (int i = 0; i < traits.size(); i++) {
             Trait trait = traits.get(i);
@@ -150,12 +150,12 @@ public class TraitValidatorService {
         return duplicates;
     }
 
-    public List<Trait> checkDuplicateTraitsExistingByAbbreviation(List<Trait> traits){
+    public List<Trait> checkDuplicateTraitsExistingByAbbreviation(UUID programId, List<Trait> traits){
 
         List<Trait> duplicates = new ArrayList<>();
 
         // Check for existing trait abbreviations
-        List<Trait> duplicateAbbreviationTraits = checkForDuplicatesTraitsByAbbreviation(traits);
+        List<Trait> duplicateAbbreviationTraits = checkForDuplicatesTraitsByAbbreviation(programId, traits);
 
         for (int i = 0; i < traits.size(); i++){
             Trait trait = traits.get(i);
@@ -249,11 +249,11 @@ public class TraitValidatorService {
         return errors;
     }
 
-    private List<Trait> checkForDuplicateTraitsByNames(List<Trait> traits) {
-        return traitDAO.getTraitsByTraitMethodScaleName(traits);
+    private List<Trait> checkForDuplicateTraitsByNames(UUID programId, List<Trait> traits) {
+        return traitDAO.getTraitsByTraitMethodScaleName(programId, traits);
     }
 
-    private List<Trait> checkForDuplicatesTraitsByAbbreviation(List<Trait> traits) {
+    private List<Trait> checkForDuplicatesTraitsByAbbreviation(UUID programId, List<Trait> traits) {
 
         Set<String> abbreviationSet = new HashSet<>();
         for (Trait trait: traits) {
@@ -264,7 +264,7 @@ public class TraitValidatorService {
 
         List<Trait> matchingTraits = new ArrayList<>();
         if (abbreviationSet.size() > 0){
-            matchingTraits = traitDAO.getTraitsByAbbreviation(List.of(abbreviationSet.toArray(String[]::new)));
+            matchingTraits = traitDAO.getTraitsByAbbreviation(programId, List.of(abbreviationSet.toArray(String[]::new)));
         }
 
         return matchingTraits;

--- a/src/test/java/org/breedinginsight/api/auth/AuthServiceLoginHandlerUnitTest.java
+++ b/src/test/java/org/breedinginsight/api/auth/AuthServiceLoginHandlerUnitTest.java
@@ -25,6 +25,7 @@ import io.micronaut.http.context.ServerRequestContext;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.simple.cookies.SimpleCookies;
 import io.micronaut.test.annotation.MicronautTest;
+import io.micronaut.test.annotation.MockBean;
 import org.breedinginsight.DatabaseTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -33,6 +34,7 @@ import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -58,14 +60,16 @@ public class AuthServiceLoginHandlerUnitTest extends DatabaseTest {
         SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
         cookies.put("redirect-login", returnUrlCookie);
         doReturn(cookies).when(request).getCookies();
-        ServerRequestContext.set(request);
+        AuthServiceLoginHandler authServiceSpy = spy(authServiceLoginHandler);
+        when(authServiceSpy.getCurrentRequest()).thenReturn(Optional.of(request));
 
         Cookie jwtToken = Cookie.of("phylo-token", "test");
         List<Cookie> securityCookies = List.of(jwtToken);
 
-        HttpResponse response = authServiceLoginHandler.loginSuccessWithCookies(securityCookies);
+        HttpResponse response = authServiceSpy.loginSuccessWithCookies(securityCookies);
 
         checkAssertions(response, jwtToken, defaultUrl);
+
     }
 
     @Test
@@ -77,13 +81,15 @@ public class AuthServiceLoginHandlerUnitTest extends DatabaseTest {
         SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
         cookies.put("redirect-login", returnUrlCookie);
         doReturn(cookies).when(request).getCookies();
-        ServerRequestContext.set(request);
+        AuthServiceLoginHandler authServiceSpy = spy(authServiceLoginHandler);
+        when(authServiceSpy.getCurrentRequest()).thenReturn(Optional.of(request));
 
         Cookie jwtToken = Cookie.of("phylo-token", "test");
         List<Cookie> securityCookies = List.of(jwtToken);
 
-        HttpResponse response = authServiceLoginHandler.loginSuccessWithCookies(securityCookies);
+        HttpResponse response = authServiceSpy.loginSuccessWithCookies(securityCookies);
 
+        reset(request);
         checkAssertions(response, jwtToken, expectedUrl);
     }
 
@@ -96,13 +102,15 @@ public class AuthServiceLoginHandlerUnitTest extends DatabaseTest {
         SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
         cookies.put("redirect-login", returnUrlCookie);
         doReturn(cookies).when(request).getCookies();
-        ServerRequestContext.set(request);
+        AuthServiceLoginHandler authServiceSpy = spy(authServiceLoginHandler);
+        when(authServiceSpy.getCurrentRequest()).thenReturn(Optional.of(request));
 
         Cookie jwtToken = Cookie.of("phylo-token", "test");
         List<Cookie> securityCookies = List.of(jwtToken);
 
-        HttpResponse response = authServiceLoginHandler.loginSuccessWithCookies(securityCookies);
+        HttpResponse response = authServiceSpy.loginSuccessWithCookies(securityCookies);
 
+        reset(request);
         checkAssertions(response, jwtToken, expectedUrl);
     }
 
@@ -112,13 +120,15 @@ public class AuthServiceLoginHandlerUnitTest extends DatabaseTest {
         HttpRequest request = mock(HttpRequest.class, CALLS_REAL_METHODS);
         SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
         doReturn(cookies).when(request).getCookies();
-        ServerRequestContext.set(request);
+        AuthServiceLoginHandler authServiceSpy = spy(authServiceLoginHandler);
+        when(authServiceSpy.getCurrentRequest()).thenReturn(Optional.of(request));
 
         Cookie jwtToken = Cookie.of("phylo-token", "test");
         List<Cookie> securityCookies = List.of(jwtToken);
 
-        HttpResponse response = authServiceLoginHandler.loginSuccessWithCookies(securityCookies);
+        HttpResponse response = authServiceSpy.loginSuccessWithCookies(securityCookies);
 
+        reset(request);
         checkAssertions(response, jwtToken, defaultUrl);
     }
 

--- a/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
@@ -293,7 +293,7 @@ public class TraitControllerIntegrationTest extends BrAPITest {
 
         JsonArray data = result.getAsJsonArray("data");
 
-        assertEquals(validTraits.size(), data.size(), "Duplicate traits were not ignored");
+        assertEquals(validTraits.size(), data.size(), "Traits were ignored, but should not be");
 
     }
 

--- a/src/test/java/org/breedinginsight/services/validators/TraitValidatorIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/services/validators/TraitValidatorIntegrationTest.java
@@ -91,8 +91,8 @@ public class TraitValidatorIntegrationTest extends DatabaseTest {
         trait1.setScale(scale1);
         trait1.setMethod(method1);
 
-        List<Trait> duplicateTraits = traitValidator.checkDuplicateTraitsExistingByName(List.of(trait1));
-        List<Trait> duplicateTraitsByAbbrev = traitValidator.checkDuplicateTraitsExistingByAbbreviation(List.of(trait1));
+        List<Trait> duplicateTraits = traitValidator.checkDuplicateTraitsExistingByName(validProgram.getId(), List.of(trait1));
+        List<Trait> duplicateTraitsByAbbrev = traitValidator.checkDuplicateTraitsExistingByAbbreviation(validProgram.getId(), List.of(trait1));
 
         assertEquals(1, duplicateTraits.size(), "Wrong number of duplicate traits by name returned");
         assertEquals(1, duplicateTraitsByAbbrev.size(), "Wrong number of duplicate traits by abbreviation returned");
@@ -113,8 +113,8 @@ public class TraitValidatorIntegrationTest extends DatabaseTest {
         trait1.setScale(scale1);
         trait1.setMethod(method1);
 
-        List<Trait> duplicateTraits = traitValidator.checkDuplicateTraitsExistingByName(List.of(trait1));
-        List<Trait> duplicateTraitsByAbbrev = traitValidator.checkDuplicateTraitsExistingByAbbreviation(List.of(trait1));
+        List<Trait> duplicateTraits = traitValidator.checkDuplicateTraitsExistingByName(validProgram.getId(), List.of(trait1));
+        List<Trait> duplicateTraitsByAbbrev = traitValidator.checkDuplicateTraitsExistingByAbbreviation(validProgram.getId(), List.of(trait1));
 
         assertEquals(0, duplicateTraits.size(), "Wrong number of duplicate traits by name returned");
         assertEquals(0, duplicateTraitsByAbbrev.size(), "Wrong number of duplicate traits by abbreviation returned");

--- a/src/test/resources/sql/TraitControllerIntegrationTest.sql
+++ b/src/test/resources/sql/TraitControllerIntegrationTest.sql
@@ -58,3 +58,18 @@ join bi_user on bi_user.name = 'system' limit 1
 delete from trait;
 delete from method;
 delete from scale;
+
+-- name: InsertOtherProgram
+insert into program (species_id, name, created_by, updated_by)
+select species.id, 'Other Test Program', bi_user.id, bi_user.id from species
+join bi_user on bi_user.name = 'system' limit 1
+
+-- name: InsertOtherProgramObservationLevel
+insert into program_observation_level(program_id, name, created_by, updated_by)
+select program.id, 'Plant', bi_user.id, bi_user.id from program
+join bi_user on bi_user.name = 'system' and program.name = 'Other Test Program' limit 1
+
+-- name: InsertOtherProgramOntology
+insert into program_ontology (program_id, created_by, updated_by)
+select program.id, bi_user.id, bi_user.id from program
+join bi_user on bi_user.name = 'system' and program.name = 'Other Test Program' limit 1


### PR DESCRIPTION
Fixes a bug where the trait duplicate checks were checking against the whole database. The check should be within a program. 

Added a test for the bug as well. 

Also includes a fix for the tests where `AuthServiceLoginHandlerUnitTest` was polluting tests that came after it by manually setting the current request on `ServerRequestContext`. 