### PR TITLE
[BI-617] - Sort/paginate/filter for trait upload

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2405,6 +2405,16 @@ paths:
           explode: false
           schema:
             type: string
+        - in: query
+          description: Field to sort the results by.
+          name: sortField
+          required: false
+          schema:
+            type: string
+            enum: [name, abbreviations, mainAbbreviation, synonyms, description, level, status, methodName, methodDescription, methodClass, methodFormula, scaleName, scaleClass, scaleDecimalPlaces, scaleLowerLimit, scaleUpperLimit, scaleCategories, createdAt, updatedAt, createdByUserId, createdByUserName, updatedByUserId, updatedByUserName]
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/sortOrder'
       responses:
         "200":
           description: OK
@@ -2501,6 +2511,65 @@ paths:
                 type: string
               example: ERROR - 2018-10-08T20:15:11Z - The requested object DbId is
                 not found
+  /programs/{programId}/trait-upload/search:
+    post:
+      tags:
+        - uploads
+      parameters:
+        - name: programId
+          in: path
+          description: Id of program to get trait upload for
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - in: query
+          description: Field to sort the results by.
+          name: sortField
+          required: false
+          schema:
+            type: string
+            enum: [name, abbreviations, mainAbbreviation, synonyms, description, level, status, methodName, methodDescription, methodClass, methodFormula, scaleName, scaleClass, scaleDecimalPlaces, scaleLowerLimit, scaleUpperLimit, scaleCategories, createdAt, updatedAt, createdByUserId, createdByUserName, updatedByUserId, updatedByUserName]
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/sortOrder'
+      summary: Search trait upload
+      description: Search trait upload using filters
+      operationId: searchTraitUpload
+      requestBody:
+        description: Search request
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                filter:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      field:
+                        type: string
+                        enum: [name, abbreviations, mainAbbreviation, synonyms, description, level, status, methodName, methodDescription, methodClass, methodFormula, scaleName, scaleClass, scaleDecimalPlaces, scaleLowerLimit, scaleUpperLimit, scaleCategories, createdAt, updatedAt, createdByUserId, createdByUserName, updatedByUserId, updatedByUserName]
+                      value:
+                        type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/traitUploadResponse'
+              examples:
+                traitUploadResponse:
+                  $ref: '#/components/examples/traitUploadData'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        "404":
+          $ref: '#/components/responses/404NotFound'
   /health:
     get:
       tags:

--- a/src/main/java/org/breedinginsight/api/v1/controller/TraitUploadController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/TraitUploadController.java
@@ -105,7 +105,7 @@ public class TraitUploadController {
         Optional<ProgramUpload<Trait>> programUpload = traitUploadService.getTraitUpload(programId, actingUser);
 
         if(programUpload.isPresent()) {
-            return ResponseUtils.getQueryResponse(programUpload.get(), traitQueryMapper, queryParams);
+            return ResponseUtils.getUploadQueryResponse(programUpload.get(), traitQueryMapper, queryParams);
         } else {
             log.info("Trait upload not found");
             return HttpResponse.notFound();
@@ -124,7 +124,7 @@ public class TraitUploadController {
         Optional<ProgramUpload<Trait>> programUpload = traitUploadService.getTraitUpload(programId, actingUser);
 
         if(programUpload.isPresent()) {
-            return ResponseUtils.getQueryResponse(programUpload.get(), traitQueryMapper, searchRequest, queryParams);
+            return ResponseUtils.getUploadQueryResponse(programUpload.get(), traitQueryMapper, searchRequest, queryParams);
         } else {
             log.info("Trait upload not found");
             return HttpResponse.notFound();

--- a/src/main/java/org/breedinginsight/api/v1/controller/TraitUploadController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/TraitUploadController.java
@@ -27,13 +27,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.brapi.client.v2.model.exceptions.HttpBadRequestException;
 import org.breedinginsight.api.auth.AuthenticatedUser;
 import org.breedinginsight.api.auth.SecurityService;
+import org.breedinginsight.api.model.v1.request.query.QueryParams;
 import org.breedinginsight.api.model.v1.response.Response;
+import org.breedinginsight.api.model.v1.validators.QueryValid;
 import org.breedinginsight.api.v1.controller.metadata.AddMetadata;
 import org.breedinginsight.model.ProgramUpload;
+import org.breedinginsight.model.Trait;
 import org.breedinginsight.services.TraitUploadService;
 import org.breedinginsight.services.exceptions.*;
+import org.breedinginsight.utilities.response.ResponseUtils;
+import org.breedinginsight.utilities.response.mappers.TraitQueryMapper;
 
 import javax.inject.Inject;
+import javax.validation.Valid;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -41,10 +47,16 @@ import java.util.UUID;
 @Controller("/${micronaut.bi.api.version}")
 public class TraitUploadController {
 
-    @Inject
     private TraitUploadService traitUploadService;
-    @Inject
     private SecurityService securityService;
+    private TraitQueryMapper traitQueryMapper;
+
+    public TraitUploadController(TraitUploadService traitUploadService, SecurityService securityService,
+                                 TraitQueryMapper traitQueryMapper) {
+        this.traitUploadService = traitUploadService;
+        this.securityService = securityService;
+        this.traitQueryMapper = traitQueryMapper;
+    }
 
     // only allowing one trait upload to exist (per user per program) so put is more appropriate than post
     // singleton resource since only one trait upload can exist
@@ -80,17 +92,22 @@ public class TraitUploadController {
         }
     }
 
-    @Get("/programs/{programId}/trait-upload")
+    @Get("/programs/{programId}/trait-upload{?queryParams*}")
     @Produces(MediaType.APPLICATION_JSON)
-    @AddMetadata
     @Secured(SecurityRule.IS_AUTHENTICATED)
-    public HttpResponse<Response<ProgramUpload>> getTraitUpload(@PathVariable UUID programId) {
+    public HttpResponse<Response<ProgramUpload>> getTraitUpload(
+            @PathVariable UUID programId,
+            @QueryValue @QueryValid(using = TraitQueryMapper.class) @Valid QueryParams queryParams) {
 
         AuthenticatedUser actingUser = securityService.getUser();
-        Optional<ProgramUpload> programUpload = traitUploadService.getTraitUpload(programId, actingUser);
+        Optional<ProgramUpload<Trait>> optionalProgramUpload = traitUploadService.getTraitUpload(programId, actingUser);
 
-        if(programUpload.isPresent()) {
-            Response<ProgramUpload> response = new Response(programUpload.get());
+        if(optionalProgramUpload.isPresent()) {
+            ProgramUpload programUpload = optionalProgramUpload.get();
+
+            Response<ProgramUpload> response = new Response(programUpload);
+            ResponseUtils.getQueryResponse(programUpload.getParsedData(), traitQueryMapper, queryParams);
+
             return HttpResponse.ok(response);
         } else {
             log.info("Trait upload not found");

--- a/src/main/java/org/breedinginsight/model/ProgramUpload.java
+++ b/src/main/java/org/breedinginsight/model/ProgramUpload.java
@@ -30,6 +30,8 @@ import lombok.experimental.SuperBuilder;
 import org.breedinginsight.dao.db.tables.pojos.BatchUploadEntity;
 import org.jooq.Record;
 
+import java.util.List;
+
 import static org.breedinginsight.dao.db.Tables.BATCH_UPLOAD;
 
 @Getter
@@ -39,17 +41,22 @@ import static org.breedinginsight.dao.db.Tables.BATCH_UPLOAD;
 @SuperBuilder
 @NoArgsConstructor
 @JsonIgnoreProperties(value = { "createdBy", "updatedBy", "programId", "userId", "id"})
-public class ProgramUpload extends BatchUploadEntity {
+public class ProgramUpload<T> extends BatchUploadEntity {
 
     private Program program;
     private User user;
     private User createdByUser;
     private User updatedByUser;
+    private List<T> parsedData;
 
     // JSONB not working with jackson
     @JsonProperty("data")
     @JsonInclude(JsonInclude.Include.ALWAYS)
     public Trait[] getDataJson() throws JsonProcessingException {
+        if (parsedData != null) {
+            return (Trait[]) parsedData.toArray();
+        }
+
         ObjectMapper objMapper = new ObjectMapper();
         return objMapper.readValue(super.getData().data(), Trait[].class);
     }

--- a/src/main/java/org/breedinginsight/model/ProgramUpload.java
+++ b/src/main/java/org/breedinginsight/model/ProgramUpload.java
@@ -40,6 +40,7 @@ import static org.breedinginsight.dao.db.Tables.BATCH_UPLOAD;
 @Accessors(chain=true)
 @ToString
 @NoArgsConstructor
+@SuperBuilder(builderMethodName = "uploadBuilder")
 @JsonIgnoreProperties(value = { "createdBy", "updatedBy", "programId", "userId", "id"})
 public class ProgramUpload<T> extends BatchUploadEntity {
 
@@ -71,17 +72,17 @@ public class ProgramUpload<T> extends BatchUploadEntity {
 
     public static <T> ProgramUpload<T> parseSQLRecord(Record record) {
 
-        ProgramUpload<T> programUpload = new ProgramUpload<>();
-        programUpload.setId(record.getValue(BATCH_UPLOAD.ID));
-        programUpload.setProgramId(record.getValue(BATCH_UPLOAD.PROGRAM_ID));
-        programUpload.setUserId(record.getValue(BATCH_UPLOAD.USER_ID));
-        programUpload.setData(record.getValue(BATCH_UPLOAD.DATA));
-        programUpload.setType(record.getValue(BATCH_UPLOAD.TYPE));
-        programUpload.setCreatedAt(record.getValue(BATCH_UPLOAD.CREATED_AT));
-        programUpload.setUpdatedAt(record.getValue(BATCH_UPLOAD.UPDATED_AT));
-        programUpload.setCreatedBy(record.getValue(BATCH_UPLOAD.CREATED_BY));
-        programUpload.setUpdatedBy(record.getValue(BATCH_UPLOAD.UPDATED_BY));
-        return programUpload;
+        return ProgramUpload.<T>uploadBuilder()
+                    .id(record.getValue(BATCH_UPLOAD.ID))
+                    .programId(record.getValue(BATCH_UPLOAD.PROGRAM_ID))
+                    .userId(record.getValue(BATCH_UPLOAD.USER_ID))
+                    .data(record.getValue(BATCH_UPLOAD.DATA))
+                    .type(record.getValue(BATCH_UPLOAD.TYPE))
+                    .createdAt(record.getValue(BATCH_UPLOAD.CREATED_AT))
+                    .updatedAt(record.getValue(BATCH_UPLOAD.UPDATED_AT))
+                    .createdBy(record.getValue(BATCH_UPLOAD.CREATED_BY))
+                    .updatedBy(record.getValue(BATCH_UPLOAD.UPDATED_BY))
+                    .build();
     }
 
 }

--- a/src/main/java/org/breedinginsight/model/ProgramUpload.java
+++ b/src/main/java/org/breedinginsight/model/ProgramUpload.java
@@ -16,6 +16,7 @@
  */
 package org.breedinginsight.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,7 +39,6 @@ import static org.breedinginsight.dao.db.Tables.BATCH_UPLOAD;
 @Setter
 @Accessors(chain=true)
 @ToString
-@SuperBuilder
 @NoArgsConstructor
 @JsonIgnoreProperties(value = { "createdBy", "updatedBy", "programId", "userId", "id"})
 public class ProgramUpload<T> extends BatchUploadEntity {
@@ -47,16 +47,12 @@ public class ProgramUpload<T> extends BatchUploadEntity {
     private User user;
     private User createdByUser;
     private User updatedByUser;
-    private List<T> parsedData;
-
-    // JSONB not working with jackson
     @JsonProperty("data")
     @JsonInclude(JsonInclude.Include.ALWAYS)
-    public Trait[] getDataJson() throws JsonProcessingException {
-        if (parsedData != null) {
-            return (Trait[]) parsedData.toArray();
-        }
+    private List<T> parsedData;
 
+    @JsonIgnore
+    public Trait[] getDataJson() throws JsonProcessingException {
         ObjectMapper objMapper = new ObjectMapper();
         return objMapper.readValue(super.getData().data(), Trait[].class);
     }
@@ -73,21 +69,19 @@ public class ProgramUpload<T> extends BatchUploadEntity {
         this.setUpdatedBy(uploadEntity.getUpdatedBy());
     }
 
-    public static ProgramUpload parseSQLRecord(Record record) {
+    public static <T> ProgramUpload<T> parseSQLRecord(Record record) {
 
-        ProgramUpload upload = ProgramUpload.builder()
-                .id(record.getValue(BATCH_UPLOAD.ID))
-                .programId(record.getValue(BATCH_UPLOAD.PROGRAM_ID))
-                .userId(record.getValue(BATCH_UPLOAD.USER_ID))
-                .data(record.getValue(BATCH_UPLOAD.DATA))
-                .type(record.getValue(BATCH_UPLOAD.TYPE))
-                .createdAt(record.getValue(BATCH_UPLOAD.CREATED_AT))
-                .updatedAt(record.getValue(BATCH_UPLOAD.UPDATED_AT))
-                .createdBy(record.getValue(BATCH_UPLOAD.CREATED_BY))
-                .updatedBy(record.getValue(BATCH_UPLOAD.UPDATED_BY))
-                .build();
-
-        return upload;
+        ProgramUpload<T> programUpload = new ProgramUpload<>();
+        programUpload.setId(record.getValue(BATCH_UPLOAD.ID));
+        programUpload.setProgramId(record.getValue(BATCH_UPLOAD.PROGRAM_ID));
+        programUpload.setUserId(record.getValue(BATCH_UPLOAD.USER_ID));
+        programUpload.setData(record.getValue(BATCH_UPLOAD.DATA));
+        programUpload.setType(record.getValue(BATCH_UPLOAD.TYPE));
+        programUpload.setCreatedAt(record.getValue(BATCH_UPLOAD.CREATED_AT));
+        programUpload.setUpdatedAt(record.getValue(BATCH_UPLOAD.UPDATED_AT));
+        programUpload.setCreatedBy(record.getValue(BATCH_UPLOAD.CREATED_BY));
+        programUpload.setUpdatedBy(record.getValue(BATCH_UPLOAD.UPDATED_BY));
+        return programUpload;
     }
 
 }

--- a/src/main/java/org/breedinginsight/services/TraitUploadService.java
+++ b/src/main/java/org/breedinginsight/services/TraitUploadService.java
@@ -153,7 +153,10 @@ public class TraitUploadService {
 
         // Insert and update
         programUploadDao.insert(uploadEntity);
-        return programUploadDao.getUploadById(uploadEntity.getId()).get();
+
+        ProgramUpload<Trait> programUpload = programUploadDao.getUploadById(uploadEntity.getId()).get();
+        programUpload.setParsedData(parseUpload(programUpload));
+        return programUpload;
     }
 
     public Optional<ProgramUpload<Trait>> getTraitUpload(UUID programId, AuthenticatedUser actingUser) {
@@ -167,12 +170,7 @@ public class TraitUploadService {
         }
 
         ProgramUpload programUpload = (ProgramUpload<Trait>) uploads.get(0);
-        try {
-            programUpload.setParsedData(Arrays.asList(programUpload.getDataJson()));
-        } catch (JsonProcessingException e) {
-            throw new HttpServerException("Unable to parse traits json");
-        }
-
+        programUpload.setParsedData(parseUpload(programUpload));
         return Optional.of(programUpload);
     }
 
@@ -187,6 +185,17 @@ public class TraitUploadService {
                 .orElseThrow(() -> new DoesNotExistException("user not in program"));
 
         programUploadDao.deleteUploads(programId, actingUser.getId(), UploadType.TRAIT);
+
+    }
+
+    private List<Trait> parseUpload(ProgramUpload<Trait> programUpload) {
+
+        try {
+            Trait[] traits = programUpload.getDataJson();
+            return Arrays.asList(traits);
+        } catch (JsonProcessingException e) {
+            throw new HttpServerException("Unable to parse traits json");
+        }
 
     }
 

--- a/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
+++ b/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
@@ -57,13 +57,13 @@ public class ResponseUtils {
     }
 
     // All
-    public static <T> HttpResponse<Response<ProgramUpload>> getUploadQueryResponse(
+    public static HttpResponse<Response<ProgramUpload>> getUploadQueryResponse(
             ProgramUpload upload, AbstractQueryMapper mapper, SearchRequest searchRequest, QueryParams queryParams) {
         return processUploadSearchResponse(upload, searchRequest, queryParams, mapper, new Metadata());
     }
 
     // Pagination and sort only
-    public static <T> HttpResponse<Response<ProgramUpload>> getUploadQueryResponse(
+    public static HttpResponse<Response<ProgramUpload>> getUploadQueryResponse(
             ProgramUpload upload, AbstractQueryMapper mapper, QueryParams queryParams) {
         return processUploadSearchResponse(upload, null, queryParams, mapper, new Metadata());
     }

--- a/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
+++ b/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
@@ -57,15 +57,15 @@ public class ResponseUtils {
     }
 
     // All
-    public static <T> HttpResponse<Response<ProgramUpload>> getQueryResponse(
+    public static <T> HttpResponse<Response<ProgramUpload>> getUploadQueryResponse(
             ProgramUpload upload, AbstractQueryMapper mapper, SearchRequest searchRequest, QueryParams queryParams) {
-        return processSearchResponse(upload, searchRequest, queryParams, mapper, new Metadata());
+        return processUploadSearchResponse(upload, searchRequest, queryParams, mapper, new Metadata());
     }
 
     // Pagination and sort only
-    public static <T> HttpResponse<Response<ProgramUpload>> getQueryResponse(
+    public static <T> HttpResponse<Response<ProgramUpload>> getUploadQueryResponse(
             ProgramUpload upload, AbstractQueryMapper mapper, QueryParams queryParams) {
-        return processSearchResponse(upload, null, queryParams, mapper, new Metadata());
+        return processUploadSearchResponse(upload, null, queryParams, mapper, new Metadata());
     }
 
     public static <T> HttpResponse<Response<T>> getSingleResponse(Object data) {
@@ -85,7 +85,7 @@ public class ResponseUtils {
         return HttpResponse.ok(new Response(metadata, new DataResponse(paginationResult.getLeft())));
     }
 
-    private static <T> HttpResponse<Response<ProgramUpload>> processSearchResponse(
+    private static <T> HttpResponse<Response<ProgramUpload>> processUploadSearchResponse(
             ProgramUpload upload, SearchRequest searchRequest, QueryParams queryParams, AbstractQueryMapper mapper, Metadata metadata) {
 
         List data = upload.getParsedData();

--- a/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
+++ b/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
@@ -30,6 +30,7 @@ import org.breedinginsight.api.model.v1.response.metadata.Pagination;
 import org.breedinginsight.api.model.v1.response.metadata.Status;
 import org.breedinginsight.api.model.v1.response.metadata.StatusCode;
 import org.breedinginsight.api.v1.controller.metadata.SortOrder;
+import org.breedinginsight.model.ProgramUpload;
 import org.breedinginsight.utilities.response.mappers.AbstractQueryMapper;
 import org.breedinginsight.utilities.response.mappers.FilterField;
 
@@ -55,6 +56,18 @@ public class ResponseUtils {
         return processSearchResponse(data, null, queryParams, mapper, new Metadata());
     }
 
+    // All
+    public static <T> HttpResponse<Response<ProgramUpload>> getQueryResponse(
+            ProgramUpload upload, AbstractQueryMapper mapper, SearchRequest searchRequest, QueryParams queryParams) {
+        return processSearchResponse(upload, searchRequest, queryParams, mapper, new Metadata());
+    }
+
+    // Pagination and sort only
+    public static <T> HttpResponse<Response<ProgramUpload>> getQueryResponse(
+            ProgramUpload upload, AbstractQueryMapper mapper, QueryParams queryParams) {
+        return processSearchResponse(upload, null, queryParams, mapper, new Metadata());
+    }
+
     public static <T> HttpResponse<Response<T>> getSingleResponse(Object data) {
         Metadata metadata = constructMetadata(new Metadata(), new Pagination(1,1,1,1));
         return HttpResponse.ok(new Response(metadata, data));
@@ -70,6 +83,21 @@ public class ResponseUtils {
         Pair<List, Pagination> paginationResult = paginateData(data, queryParams);
         metadata = constructMetadata(metadata, paginationResult.getRight());
         return HttpResponse.ok(new Response(metadata, new DataResponse(paginationResult.getLeft())));
+    }
+
+    private static <T> HttpResponse<Response<ProgramUpload>> processSearchResponse(
+            ProgramUpload upload, SearchRequest searchRequest, QueryParams queryParams, AbstractQueryMapper mapper, Metadata metadata) {
+
+        List data = upload.getParsedData();
+        if (searchRequest != null){
+            data = search(data, searchRequest, mapper);
+        }
+
+        data = sort(data, queryParams, mapper);
+        Pair<List, Pagination> paginationResult = paginateData(data, queryParams);
+        metadata = constructMetadata(metadata, paginationResult.getRight());
+        upload.setParsedData(paginationResult.getLeft());
+        return HttpResponse.ok(new Response(metadata, upload));
     }
 
     private static List sort(List data, QueryParams queryParams, AbstractQueryMapper mapper) {


### PR DESCRIPTION
Updated trait upload services to parse the JSONB data from the database before returning to controller. For the sorting/filtering/pagination we needed something we could read and act on, so that seemed like the most logically course. It doesn't change the way the data is returned. 

There is one more point of failure in the upload process though. If for some reason the data was not stored properly during the file upload, there will be a failure when parsing this. But, that should never happen since the JSONB being stored in the database is rendered from Trait objects to begin with. 