### PR TITLE
[BI-280] - Add brapi program create and update on program create and update

### DIFF
--- a/src/main/java/org/breedinginsight/api/v1/controller/brapi/BrAPIServiceFilter.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/brapi/BrAPIServiceFilter.java
@@ -40,7 +40,7 @@ import javax.inject.Inject;
 import java.util.Map;
 import java.util.UUID;
 
-@Filter("/**/programs/**")
+@Filter(patterns = {"/**/programs/**", "/**/programs"})
 public class BrAPIServiceFilter extends OncePerRequestHttpServerFilter {
 
 
@@ -95,7 +95,11 @@ public class BrAPIServiceFilter extends OncePerRequestHttpServerFilter {
                             return Flowable.error(new HttpInternalServerError("Unable to process request"));
                         }
                     } else {
-                        // The filter is not meant for this request
+                        // We'll get here for /programs. Use client defaults to begin with, they can change their
+                        // brapi service later.
+                        brAPIClientProvider.setCoreClient(defaultBrAPICoreUrl);
+                        brAPIClientProvider.setPhenoClient(defaultBrAPIPhenoUrl);
+                        brAPIClientProvider.setGenoClient(defaultBrAPIGenoUrl);
                         return chain.proceed(request);
                     }
                 });

--- a/src/main/java/org/breedinginsight/daos/ProgramDAO.java
+++ b/src/main/java/org/breedinginsight/daos/ProgramDAO.java
@@ -138,6 +138,7 @@ public class ProgramDAO extends ProgramDao {
                 .commonCropName(program.getSpecies().getCommonName())
                 .externalReferences(List.of(externalReference))
                 .objective(program.getObjective())
+                .documentationURL(program.getDocumentationUrl())
                 .build();
 
         // POST programs to each brapi service
@@ -184,6 +185,7 @@ public class ProgramDAO extends ProgramDao {
             brApiProgram.setAbbreviation(program.getAbbreviation());
             brApiProgram.setCommonCropName(program.getSpecies().getCommonName());
             brApiProgram.setObjective(program.getObjective());
+            brApiProgram.setDocumentationURL(program.getDocumentationUrl());
 
             try {
                 programsAPI.updateProgram(brApiProgram);

--- a/src/main/java/org/breedinginsight/daos/ProgramDAO.java
+++ b/src/main/java/org/breedinginsight/daos/ProgramDAO.java
@@ -17,6 +17,18 @@
 
 package org.breedinginsight.daos;
 
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.server.exceptions.HttpServerException;
+import io.micronaut.http.server.exceptions.InternalServerException;
+import org.brapi.client.v2.model.exceptions.APIException;
+import org.brapi.client.v2.model.exceptions.HttpException;
+import org.brapi.client.v2.modules.core.ProgramsAPI;
+import org.brapi.client.v2.modules.phenotype.VariablesAPI;
+import org.brapi.v2.core.model.BrApiExternalReference;
+import org.brapi.v2.core.model.BrApiProgram;
+import org.brapi.v2.core.model.request.ProgramsRequest;
+import org.brapi.v2.phenotyping.model.BrApiVariable;
+import org.breedinginsight.api.model.v1.request.ProgramRequest;
 import org.breedinginsight.dao.db.tables.BiUserTable;
 import org.breedinginsight.dao.db.tables.daos.ProgramDao;
 import org.breedinginsight.dao.db.tables.pojos.ProgramEntity;
@@ -24,12 +36,15 @@ import org.breedinginsight.model.Program;
 import org.breedinginsight.model.ProgramBrAPIEndpoints;
 import org.breedinginsight.model.Species;
 import org.breedinginsight.model.User;
+import org.breedinginsight.services.brapi.BrAPIClientType;
+import org.breedinginsight.services.brapi.BrAPIProvider;
 import org.jooq.*;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.breedinginsight.dao.db.Tables.*;
@@ -38,10 +53,15 @@ import static org.breedinginsight.dao.db.Tables.*;
 public class ProgramDAO extends ProgramDao {
 
     private DSLContext dsl;
+    private BrAPIProvider brAPIProvider;
+    @Property(name = "brapi.server.reference-source")
+    private String referenceSource;
+
     @Inject
-    public ProgramDAO(Configuration config, DSLContext dsl) {
+    public ProgramDAO(Configuration config, DSLContext dsl, BrAPIProvider brAPIProvider) {
         super(config);
         this.dsl = dsl;
+        this.brAPIProvider = brAPIProvider;
     }
 
     public List<Program> get(List<UUID> programIds){
@@ -103,5 +123,65 @@ public class ProgramDAO extends ProgramDao {
     public ProgramBrAPIEndpoints getProgramBrAPIEndpoints() {
         return new ProgramBrAPIEndpoints();
     }
+
+    public void createProgramBrAPI(Program program, User actingUser) {
+
+        BrApiExternalReference externalReference = BrApiExternalReference.builder()
+                .referenceID(program.getId().toString())
+                .referenceSource(referenceSource)
+                .build();
+
+        BrApiProgram brApiProgram = BrApiProgram.builder()
+                .programName(program.getName())
+                .abbreviation(program.getAbbreviation())
+                .commonCropName(program.getSpecies().getCommonName())
+                .externalReferences(List.of(externalReference))
+                .objective(program.getObjective())
+                .build();
+
+        // POST programs to each brapi service
+        // TODO: If there is a failure after the first brapi service, roll back all before the failure.
+        try {
+            List<ProgramsAPI> programsAPIS = brAPIProvider.getAllUniqueProgramsAPI();
+            for (ProgramsAPI programsAPI: programsAPIS){
+                programsAPI.createProgram(brApiProgram);
+            }
+        } catch (HttpException | APIException e) {
+            throw new InternalServerException(e.getMessage());
+        }
+
+    }
+
+    public void updateProgramBrAPI(Program program, User actingUser) {
+
+        ProgramsAPI programsAPI = brAPIProvider.getProgramsAPI(BrAPIClientType.CORE);
+
+        ProgramsRequest searchRequest = ProgramsRequest.builder()
+                .externalReferenceID(program.getId().toString())
+                .externalReferenceSource(referenceSource)
+                .build();
+
+        List<BrApiProgram> brApiProgram = new ArrayList<>();
+        try {
+            brApiProgram = programsAPI.getPrograms(searchRequest);
+        } catch (HttpException | APIException e) {
+            throw new HttpServerException("Could not find program in BrAPI service.");
+        }
+
+        // Get BrAPI program by external reference id
+        BrApiExternalReference externalReference = BrApiExternalReference.builder()
+                .referenceID(program.getId().toString())
+                .referenceSource(referenceSource)
+                .build();
+
+        BrApiProgram brApiProgram = BrApiProgram.builder()
+                .programName(program.getName())
+                .abbreviation(program.getAbbreviation())
+                .commonCropName(program.getSpecies().getCommonName())
+                .externalReferences(List.of(externalReference))
+                .objective(program.getObjective())
+                .build();
+    }
+
 }
 

--- a/src/main/java/org/breedinginsight/services/ProgramService.java
+++ b/src/main/java/org/breedinginsight/services/ProgramService.java
@@ -17,6 +17,7 @@
 
 package org.breedinginsight.services;
 
+import io.micronaut.http.server.exceptions.InternalServerException;
 import lombok.extern.slf4j.Slf4j;
 import org.breedinginsight.api.auth.AuthenticatedUser;
 import org.breedinginsight.api.model.v1.request.ProgramRequest;
@@ -41,16 +42,22 @@ import java.util.UUID;
 @Singleton
 public class ProgramService {
 
-    @Inject
     private ProgramDAO dao;
-    @Inject
     private ProgramOntologyDAO programOntologyDAO;
-    @Inject
     private ProgramObservationLevelDAO programObservationLevelDAO;
-    @Inject
     private SpeciesService speciesService;
-    @Inject
     private DSLContext dsl;
+
+    @Inject
+    public ProgramService(ProgramDAO dao, ProgramOntologyDAO programOntologyDAO,
+                          ProgramObservationLevelDAO programObservationLevelDAO, SpeciesService speciesService,
+                          DSLContext dsl) {
+        this.dao = dao;
+        this.programOntologyDAO = programOntologyDAO;
+        this.programObservationLevelDAO = programObservationLevelDAO;
+        this.speciesService = speciesService;
+        this.dsl = dsl;
+    }
 
     public Optional<Program> getById(UUID programId) {
 
@@ -95,6 +102,7 @@ public class ProgramService {
 
             // Insert and update
             dao.insert(programEntity);
+            Program createdProgram = dao.get(programEntity.getId()).get(0);
 
             ProgramOntologyEntity programOntologyEntity = ProgramOntology.builder()
                     .programId(programEntity.getId())
@@ -112,11 +120,16 @@ public class ProgramService {
                     .build();
             programObservationLevelDAO.insert(programObservationLevelEntity);
 
-            //TODO: Add program and ontology to brapi services.
+            // Add program to brapi service
+            dao.createProgramBrAPI(createdProgram);
+
+            //TODO: Ontology to brapi services once supported by brapi
             //TODO: Add species to brapi service if it doesn't exist
 
-            return dao.get(programEntity.getId()).get(0);
+            return createdProgram;
         });
+
+
 
 
         return program;
@@ -147,6 +160,11 @@ public class ProgramService {
 
         dao.update(programEntity);
         Program program = dao.get(programEntity.getId()).get(0);
+
+        // Update program in brapi service
+        dao.updateProgramBrAPI(program);
+
+        //TODO: Add species to brapi service if it doesn't exist
 
         return program;
     }

--- a/src/main/java/org/breedinginsight/services/brapi/BrAPIProvider.java
+++ b/src/main/java/org/breedinginsight/services/brapi/BrAPIProvider.java
@@ -18,6 +18,7 @@
 package org.breedinginsight.services.brapi;
 
 import org.brapi.client.v2.BrAPIClient;
+import org.brapi.client.v2.modules.core.ProgramsAPI;
 import org.brapi.client.v2.modules.phenotype.TraitsAPI;
 import org.brapi.client.v2.modules.phenotype.VariablesAPI;
 
@@ -57,5 +58,17 @@ public class BrAPIProvider {
         return variablesAPIS;
     }
 
+    public ProgramsAPI getProgramsAPI(BrAPIClientType clientType) {
+        BrAPIClient brAPIClient = brAPIClientProvider.get().getClient(clientType);
+        return new ProgramsAPI(brAPIClient);
+    }
 
+    public List<ProgramsAPI> getAllUniqueProgramsAPI(){
+        Set<BrAPIClient> clients = brAPIClientProvider.get().getAllUniqueClients();
+        List<ProgramsAPI> programsAPIS = new ArrayList<>();
+        for (BrAPIClient client: clients){
+            programsAPIS.add(new ProgramsAPI(client));
+        }
+        return programsAPIS;
+    }
 }

--- a/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
@@ -34,6 +34,7 @@ import io.micronaut.test.annotation.MockBean;
 import io.reactivex.Flowable;
 import junit.framework.AssertionFailedError;
 import lombok.SneakyThrows;
+import org.breedinginsight.BrAPITest;
 import org.breedinginsight.DatabaseTest;
 import org.breedinginsight.TestUtils;
 import org.breedinginsight.api.auth.AuthenticatedUser;
@@ -68,7 +69,7 @@ import static org.mockito.Mockito.mock;
 @MicronautTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class ProgramControllerIntegrationTest extends DatabaseTest {
+public class ProgramControllerIntegrationTest extends BrAPITest {
 
     private FannyPack fp;
 

--- a/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
@@ -35,7 +35,6 @@ import io.reactivex.Flowable;
 import junit.framework.AssertionFailedError;
 import lombok.SneakyThrows;
 import org.breedinginsight.BrAPITest;
-import org.breedinginsight.DatabaseTest;
 import org.breedinginsight.TestUtils;
 import org.breedinginsight.api.auth.AuthenticatedUser;
 import org.breedinginsight.api.model.v1.request.*;
@@ -72,8 +71,10 @@ import static org.mockito.Mockito.mock;
 public class ProgramControllerIntegrationTest extends BrAPITest {
 
     private FannyPack fp;
+    private FannyPack brapiFp;
 
-    private Program validProgram;
+    private ProgramEntity validProgram;
+    private ProgramEntity otherProgram;
     private User validUser;
     private Species validSpecies;
     private Role validRole;
@@ -143,7 +144,10 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
         // Skip our emails
         doNothing().when(emailUtil()).sendEmail(any(String.class), any(String.class), any(String.class));
 
+        brapiFp = FannyPack.fill("src/test/resources/sql/brapi/species.sql");
         fp = FannyPack.fill("src/test/resources/sql/ProgramControllerIntegrationTest.sql");
+
+        super.getBrapiDsl().execute(brapiFp.get("InsertSpecies"));
 
         Optional<User> optionalUser = userService.getByOrcid(TestTokenValidator.TEST_USER_ORCID);
         testUser = optionalUser.get();
@@ -168,11 +172,9 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
         actingUser = getActingUser();
 
         // Insert and get program for tests
-        try {
-            validProgram = insertAndFetchTestProgram();
-        } catch (Exception e){
-            throw new Exception(e.toString());
-        }
+        dsl.execute(fp.get("InsertOtherProgram"));
+        otherProgram = programDao.fetchByName("Other Test Program").get(0);
+
         // Insert and get location for tests
         try {
             validLocation = insertAndFetchTestLocation();
@@ -216,29 +218,10 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
                 .build();
 
         try {
-            ProgramLocation location = programLocationService.create(actingUser, validProgram.getId(), locationRequest);
+            ProgramLocation location = programLocationService.create(actingUser, otherProgram.getId(), locationRequest);
             return location;
         } catch (UnprocessableEntityException e){
             throw new Exception("Unable to create test location");
-        }
-    }
-
-    public Program insertAndFetchTestProgram() throws Exception{
-        SpeciesRequest speciesRequest = SpeciesRequest.builder()
-                .id(validSpecies.getId())
-                .build();
-        ProgramRequest programRequest = ProgramRequest.builder()
-                .name("Test Program")
-                .abbreviation("test")
-                .documentationUrl("localhost:8080")
-                .objective("To test things")
-                .species(speciesRequest)
-                .build();
-        try {
-            Program program = programService.create(programRequest, actingUser);
-            return program;
-        } catch (UnprocessableEntityException e){
-            throw new Exception("Unable to create test program");
         }
     }
 
@@ -288,1502 +271,8 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
         return new AuthenticatedUser("test_user", systemRoles, id);
     }
 
-    //region Program Location Tests
-    @Test
-    public void postProgramsLocationsInvalidProgram() {
-        JsonObject requestBody = validProgramLocationRequest();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+invalidProgram+"/locations", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-    @Test
-    public void postProgramsLocationsInvalidCountry() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        JsonObject country = new JsonObject();
-        country.addProperty("id", invalidCountry);
-        requestBody.add("country", country);
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgram.getId().toString()+"/locations", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    @Test
-    public void postProgramsLocationsInvalidEnvironmentType() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        JsonObject environmentType = new JsonObject();
-        environmentType.addProperty("id", invalidEnvironment);
-        requestBody.add("environmentType", environmentType);
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgram.getId().toString()+"/locations", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    @Test
-    public void postProgramsLocationsInvalidTopography() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        JsonObject topography = new JsonObject();
-        topography.addProperty("id", invalidTopography);
-        requestBody.add("topography", topography);
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgram.getId().toString()+"/locations", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    @Test
-    public void postProgramsLocationsInvalidAccessibility() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        JsonObject accessibility = new JsonObject();
-        accessibility.addProperty("id", invalidAccessibility);
-        requestBody.add("accessibility", accessibility);
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgram.getId().toString()+"/locations", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    @Test
-    public void postProgramsLocationsMissingBody() {
-        JsonObject requestBody = new JsonObject();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
-    }
-
-    public JsonObject validProgramLocationRequest() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        return requestBody;
-    }
-
-    @Test
-    @SneakyThrows
-    public void postProgramsLocationsIgnoresBodyProgramId() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        requestBody.addProperty("programId", invalidLocation);
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        assertEquals(requestBody.get("name").getAsString(), result.get("name").getAsString(),"Wrong name");
-        assertEquals(validProgramId, result.get("programId").getAsString(), "programId does not match path programId");
-
-        String locationId = result.get("id").getAsString();
-        programLocationService.delete(UUID.fromString(locationId));
-    }
-
-    @Test
-    @SneakyThrows
-    public void postProgramsLocationsOnlyNameSuccess() {
-        JsonObject requestBody = validProgramLocationRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        assertEquals(requestBody.get("name").getAsString(), result.get("name").getAsString(),"Wrong name");
-        String locationId = result.get("id").getAsString();
-
-        // Check that the coordinates is [NULL] in DB
-        Optional<ProgramLocation> programLocation = programLocationService.getById(UUID.fromString(validProgramId), UUID.fromString(locationId));
-        assertNull(programLocation.get().getCoordinates());
-
-        programLocationService.delete(UUID.fromString(locationId));
-    }
-
-    public JsonObject validProgramLocationCoordinatePointRequest() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        JsonObject coordinates = new JsonObject();
-        JsonObject geometry = new JsonObject();
-        JsonArray coordinatesArray = new JsonArray();
-        coordinatesArray.add(-76.506042);
-        coordinatesArray.add(42.417373);
-        coordinatesArray.add(123);
-        geometry.add("coordinates", coordinatesArray);
-        geometry.addProperty("type", "Point");
-        coordinates.add("geometry", geometry);
-        coordinates.addProperty("type", "Feature");
-        requestBody.add("coordinates", coordinates);
-        return requestBody;
-    }
-
-    public JsonObject validProgramLocationCoordinatePolygonRequest() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        JsonObject coordinates = new JsonObject();
-        JsonObject geometry = new JsonObject();
-        JsonArray coordinatesArray = new JsonArray();
-        JsonArray polyArray = new JsonArray();
-        JsonArray coordinate1 = new JsonArray();
-        coordinate1.add(-76.5);
-        coordinate1.add(42.4);
-        JsonArray coordinate2 = new JsonArray();
-        coordinate2.add(-76.6);
-        coordinate2.add(42.5);
-        JsonArray coordinate3 = new JsonArray();
-        coordinate3.add(-76.4);
-        coordinate3.add(42.3);
-        polyArray.add(coordinate1);
-        polyArray.add(coordinate2);
-        polyArray.add(coordinate3);
-        polyArray.add(coordinate1);
-        coordinatesArray.add(polyArray);
-        geometry.add("coordinates", coordinatesArray);
-        geometry.addProperty("type", "Polygon");
-        coordinates.add("geometry", geometry);
-        coordinates.addProperty("type", "Feature");
-        requestBody.add("coordinates", coordinates);
-        return requestBody;
-    }
-
-    public JsonObject validProgramLocationCoordinateLineStringRequest() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        JsonObject coordinates = new JsonObject();
-        JsonObject geometry = new JsonObject();
-        JsonArray coordinatesArray = new JsonArray();
-        JsonArray coordinate1 = new JsonArray();
-        coordinate1.add(-76.5);
-        coordinate1.add(42.4);
-        JsonArray coordinate2 = new JsonArray();
-        coordinate2.add(-76.6);
-        coordinate2.add(42.5);
-        coordinatesArray.add(coordinate1);
-        coordinatesArray.add(coordinate2);
-        geometry.add("coordinates", coordinatesArray);
-        geometry.addProperty("type", "LineString");
-        coordinates.add("geometry", geometry);
-        coordinates.addProperty("type", "Feature");
-        requestBody.add("coordinates", coordinates);
-        return requestBody;
-    }
-
-    public JsonObject validProgramLocationCoordinatePointBadLatRequest() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        JsonObject coordinates = new JsonObject();
-        JsonObject geometry = new JsonObject();
-        JsonArray coordinatesArray = new JsonArray();
-        coordinatesArray.add(-76.506042);
-        coordinatesArray.add(100.417373);
-        coordinatesArray.add(123);
-        geometry.add("coordinates", coordinatesArray);
-        geometry.addProperty("type", "Point");
-        coordinates.add("geometry", geometry);
-        coordinates.addProperty("type", "Feature");
-        requestBody.add("coordinates", coordinates);
-        return requestBody;
-    }
-
-    @Test
-    @SneakyThrows
-    public void postProgramsLocationsCoordinatesPointSuccess() {
-        JsonObject requestBody = validProgramLocationCoordinatePointRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-
-
-        String locationId = result.get("id").getAsString();
-        programLocationService.delete(UUID.fromString(locationId));
-    }
-
-    @Test
-    @SneakyThrows
-    public void postProgramsLocationsCoordinatesPolygonSuccess() {
-        JsonObject requestBody = validProgramLocationCoordinatePolygonRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-
-
-        String locationId = result.get("id").getAsString();
-        programLocationService.delete(UUID.fromString(locationId));
-    }
-
-    @Test
-    public void postProgramsLocationsCoordinatesLineStringFailed() {
-        JsonObject requestBody = validProgramLocationCoordinateLineStringRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    @Test
-    public void postProgramsLocationsCoordinatesInvalidLatLonFailed() {
-        JsonObject requestBody = validProgramLocationCoordinatePointBadLatRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-
-    }
-
-    @Test
-    public void putProgramsLocationsInvalidLocation() {
-        JsonObject requestBody = validProgramLocationRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgramId+"/locations/"+invalidLocation, requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-    @Test
-    public void putProgramsLocationsInvalidCountry() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        JsonObject country = new JsonObject();
-        country.addProperty("id", invalidCountry);
-        requestBody.add("country", country);
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgram.getId().toString()+"/locations/"+validLocation.getId().toString(), requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    @Test
-    public void putProgramsLocationsInvalidEnvironmentType() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        JsonObject environmentType = new JsonObject();
-        environmentType.addProperty("id", invalidEnvironment);
-        requestBody.add("environmentType", environmentType);
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgram.getId().toString()+"/locations/"+validLocation.getId().toString(), requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    @Test
-    public void putProgramsLocationsInvalidTopography() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        JsonObject topography = new JsonObject();
-        topography.addProperty("id", invalidTopography);
-        requestBody.add("topography", topography);
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgram.getId().toString()+"/locations/"+validLocation.getId().toString(), requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    @Test
-    public void putProgramsLocationsInvalidAccessibility() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        JsonObject accessibility = new JsonObject();
-        accessibility.addProperty("id", invalidAccessibility);
-        requestBody.add("accessibility", accessibility);
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgram.getId().toString()+"/locations/"+validLocation.getId().toString(), requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    @Test
-    public void putProgramsLocationsMissingBody() {
-        JsonObject requestBody = new JsonObject();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgramId+"/locations/"+validLocation.getId().toString(), requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
-    }
-
-    @Test
-    public void putProgramsLocationsCoordinatesLineStringFailed() {
-        JsonObject requestBody = validProgramLocationCoordinateLineStringRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgramId+"/locations/"+validLocation.getId().toString(), requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    @Test
-    public void putProgramsLocationsCoordinatesInvalidLatLonFailed() {
-        JsonObject requestBody = validProgramLocationCoordinatePointBadLatRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgramId+"/locations/"+validLocation.getId().toString(), requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    @Test
-    @SneakyThrows
-    public void putProgramsLocationsCoordinatesPointSuccess() {
-
-        ProgramLocation location = insertAndFetchTestLocation();
-        String locationId = location.getId().toString();
-
-        JsonObject requestBody = validProgramLocationCoordinatePointRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgramId+"/locations/"+locationId, requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        programLocationService.delete(UUID.fromString(locationId));
-    }
-
-    @Test
-    @SneakyThrows
-    public void putProgramsLocationsCoordinatesPolygonSuccess() {
-        ProgramLocation location = insertAndFetchTestLocation();
-        String locationId = location.getId().toString();
-
-        JsonObject requestBody = validProgramLocationCoordinatePolygonRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgramId+"/locations/"+locationId, requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        programLocationService.delete(UUID.fromString(locationId));
-
-    }
-
-    @Test
-    @SneakyThrows
-    public void putProgramsLocationsIgnoresBodyProgramId() {
-        ProgramLocation location = insertAndFetchTestLocation();
-        String locationId = location.getId().toString();
-
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "Field 1");
-        requestBody.addProperty("programId", invalidLocation);
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgramId+"/locations/"+locationId, requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        assertEquals(requestBody.get("name").getAsString(), result.get("name").getAsString(),"Wrong name");
-        assertEquals(validProgramId, result.get("programId").getAsString(), "programId does not match path programId");
-
-        programLocationService.delete(UUID.fromString(locationId));
-    }
-
-
-    @Test
-    @SneakyThrows
-    public void putProgramsLocationsOnlyNameSuccess() {
-        ProgramLocation location = insertAndFetchTestLocation();
-        String locationId = location.getId().toString();
-
-        JsonObject requestBody = validProgramLocationRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgramId+"/locations/"+locationId, requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
-        assertEquals(1, meta.getAsJsonObject("pagination").get("totalCount").getAsInt(),"Wrong totalCount");
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        assertEquals("Field 1", result.get("name").getAsString(), "Wrong name");
-
-        // Check that the coordinates is [NULL] in DB
-        Optional<ProgramLocation> programLocation = programLocationService.getById(UUID.fromString(validProgramId), UUID.fromString(locationId));
-        assertNull(programLocation.get().getCoordinates());
-
-        programLocationService.delete(UUID.fromString(locationId));
-    }
-
-    @SneakyThrows
-    public void checkValidLocation(JsonObject programLocation) {
-
-        JsonObject country = programLocation.getAsJsonObject("country");
-        assertEquals(validLocation.getCountry().getId().toString(), country.get("id").getAsString(), "Wrong country id");
-        assertEquals(validLocation.getCountry().getName(), country.get("name").getAsString(), "Wrong country name");
-        assertEquals(validLocation.getCountry().getAlpha_2Code(), country.get("alpha2Code").getAsString(), "Wrong country alpha 2 code");
-        assertEquals(validLocation.getCountry().getAlpha_3Code(), country.get("alpha3Code").getAsString(), "Wrong country alpha 3 code");
-        JsonObject accessibility = programLocation.getAsJsonObject("accessibility");
-        assertEquals(validLocation.getAccessibility().getId().toString(), accessibility.get("id").getAsString(), "Wrong accessibility id");
-        assertEquals(validLocation.getAccessibility().getName(), accessibility.get("name").getAsString(), "Wrong accessibility name");
-        JsonObject environment = programLocation.getAsJsonObject("environmentType");
-        assertEquals(validLocation.getEnvironmentType().getId().toString(), environment.get("id").getAsString(), "Wrong environment type id");
-        assertEquals(validLocation.getEnvironmentType().getName(), environment.get("name").getAsString(), "Wrong environment type name");
-        JsonObject topography = programLocation.getAsJsonObject("topography");
-        assertEquals(validLocation.getTopography().getId().toString(), topography.get("id").getAsString(), "Wrong topography id");
-        assertEquals(validLocation.getTopography().getName(), topography.get("name").getAsString(), "Wrong topography type name");
-        assertEquals(validLocation.getId().toString(), programLocation.get("id").getAsString(), "Wrong location id");
-        assertEquals(validLocation.getProgramId().toString(), programLocation.get("programId").getAsString(), "Wrong program id");
-        assertEquals(validLocation.getName(), programLocation.get("name").getAsString(), "Wrong name");
-        assertEquals(validLocation.getAbbreviation(), programLocation.get("abbreviation").getAsString(), "Wrong abbreviation");
-
-        assertEquals(validLocation.getCoordinateDescription(), programLocation.get("coordinateDescription").getAsString(), "Wrong coordinate description");
-        assertEquals(validLocation.getCoordinateUncertainty(), programLocation.get("coordinateUncertainty").getAsBigDecimal(), "Wrong coordinate uncertainty");
-        assertEquals(validLocation.getDocumentationUrl(), programLocation.get("documentationUrl").getAsString(), "Wrong documentation url");
-        assertEquals(validLocation.getExposure(), programLocation.get("exposure").getAsString(), "Wrong exposure");
-        assertEquals(validLocation.getSlope(), programLocation.get("slope").getAsBigDecimal(), "Wrong slope");
-
-        JsonObject coords = programLocation.get("coordinates").getAsJsonObject();
-        ObjectMapper objMapper = new ObjectMapper();
-        Feature feature = objMapper.readValue(new Gson().toJson(coords), Feature.class);
-        assertEquals(validLocation.getCoordinatesJson(), feature, "Wrong coordinates");
-
-    }
-
-    @Test
-    @Order(1)
-    public void getProgramsLocationsSuccess() {
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+validProgramId+"/locations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
-        assertEquals(1, meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), "Wrong totalCount");
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        JsonArray data = result.getAsJsonArray("data");
-        JsonObject programLocation = data.get(0).getAsJsonObject();
-        checkValidLocation(programLocation);
-    }
-
-    @Test
-    public void getProgramsLocationsSingleSuccess() {
-        String validProgramId = validProgram.getId().toString();
-        String validLocationId = validLocation.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+validProgramId+"/locations/"+validLocationId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
-        assertEquals(1, meta.getAsJsonObject("pagination").get("totalCount").getAsInt(),"Wrong totalCount");
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        checkValidLocation(result);
-    }
-
-    @Test
-    public void getProgramsLocationsSingleInvalidId() {
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+validProgram.getId().toString()+"/locations/"+invalidLocation)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-    @Test
-    @SneakyThrows
-    public void getProgramsLocationsSingleWrongProgramId() {
-
-        Program wrongProgram = insertAndFetchTestProgram();
-        String programId = wrongProgram.getId().toString();
-        String validLocationId = validLocation.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+programId+"/locations/"+validLocationId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-
-        dsl.execute(fp.get("DeleteProgram"), wrongProgram.getId().toString(), wrongProgram.getId().toString(), wrongProgram.getId().toString());
-    }
-
-    @Test
-    public void getProgramsLocationsInvalidProgramId() {
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+invalidProgram+"/locations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-
-
-    @Test
-    public void archiveProgramsLocationsNotExistingLocationId() {
-        Flowable<HttpResponse<String>> call = client.exchange(
-                DELETE("/programs/"+validProgram.getId().toString()+"/locations/"+invalidLocation)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-    @Test
-    public void archiveProgramsLocationsNotExistingProgramId() {
-        Flowable<HttpResponse<String>> call = client.exchange(
-                DELETE("/programs/"+invalidProgram+"/locations/"+validLocation.getId().toString())
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-    @Test
-    @SneakyThrows
-    public void archiveProgramsLocationsWrongProgramId() {
-        Program wrongProgram = insertAndFetchTestProgram();
-        String programId = wrongProgram.getId().toString();
-        String validLocationId = validLocation.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                DELETE("/programs/"+programId+"/locations/"+validLocationId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-
-        dsl.execute(fp.get("DeleteProgram"), wrongProgram.getId().toString(), wrongProgram.getId().toString(), wrongProgram.getId().toString());
-    }
-
-    @Test
-    @SneakyThrows
-    public void archiveProgramsLocations() {
-
-        ProgramLocation location = insertAndFetchTestLocation();
-        String validProgramId = validProgram.getId().toString();
-        String locationId = location.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                DELETE("/programs/"+validProgramId+"/locations/"+locationId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String>  response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        // GET single to make sure active flag is changed
-        call = client.exchange(
-                GET("/programs/"+validProgramId+"/locations/"+locationId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        assertEquals(false, result.get("active").getAsBoolean(), "active should be false");
-
-        // GET all to make sure it doesn't show in list
-        call = client.exchange(
-                GET("/programs/"+validProgramId+"/locations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
-        // will have validLocation only for other tests but not the location added in this test
-        assertEquals(1, meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), "Should only be one location for valid");
-
-        programLocationService.delete(UUID.fromString(locationId));
-    }
-
-    //endregion
-
-    //region Program User Tests
-    @Test
-    public void postProgramsUsersInvalidProgram() {
-        JsonObject requestBody = validProgramUserRequest();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+invalidProgram+"/users", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-    @Test
-    void postProgramsUsersInvalidUserId() {
-        JsonObject requestBody = invalidUserProgramUserRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/users/", requestBody.toString()).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    @Test
-    public void postProgramsUsersDuplicateUser() {
-        JsonObject requestBody = new JsonObject();
-
-        JsonObject user = new JsonObject();
-        user.addProperty("name", "test");
-        user.addProperty("email", "test@test.com");
-
-        JsonArray roles = new JsonArray();
-        JsonObject role = new JsonObject();
-        role.addProperty("id", validRole.getId().toString());
-        roles.add(role);
-        requestBody.add("user", user);
-        requestBody.add("roles", roles);
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/users", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.CONFLICT, e.getStatus());
-    }
-
-    @Test
-    public void postProgramsUsersMissingBody() {
-        JsonObject requestBody = new JsonObject();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/users", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
-    }
-
-    @Test
-    public void postProgramsUsersOnlyName() {
-        JsonObject requestBody = new JsonObject();
-        requestBody.addProperty("name", "test");
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/users", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
-    }
-
-    @Test
-    @SneakyThrows
-    public void postProgramsUsersDuplicateRoles() {
-        String validProgramId = validProgram.getId().toString();
-        JsonObject requestBody = new JsonObject();
-        JsonObject user = new JsonObject();
-        user.addProperty("id", validUser.getId().toString());
-        JsonObject role = new JsonObject();
-        role.addProperty("id", validRole.getId().toString());
-        JsonArray roles = new JsonArray();
-        roles.add(role);
-        roles.add(role);
-        requestBody.add("user", user);
-        requestBody.add("roles", roles);
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/users", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        JsonArray rolesRx = result.getAsJsonArray("roles");
-
-        assertEquals(rolesRx.size(), 1, "Wrong number of roles");
-
-        JsonObject roleRx = rolesRx.get(0).getAsJsonObject();
-
-        assertEquals(roleRx.get("id").getAsString(),validRole.getId().toString(), "Wrong role id");
-        assertEquals(roleRx.get("domain").getAsString(),validRole.getDomain(), "Wrong domain");
-
-        programUserService.removeProgramUser(validProgram.getId(), validUser.getId());
-
-    }
-
-    @Test
-    public void postProgramsUsersInvalidRole() {
-        String validProgramId = validProgram.getId().toString();
-        JsonObject requestBody = invalidRoleProgramUserRequest();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/users", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    @Test
-    @SneakyThrows
-    public void putProgramsUsersDuplicateRoles() {
-        String validProgramId = validProgram.getId().toString();
-        JsonObject requestBody = new JsonObject();
-        JsonObject user = new JsonObject();
-        user.addProperty("id", validUser.getId().toString());
-        JsonObject role = new JsonObject();
-        role.addProperty("id", validRole.getId().toString());
-        JsonArray roles = new JsonArray();
-        roles.add(role);
-        roles.add(role);
-        requestBody.add("user", user);
-        requestBody.add("roles", roles);
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/users", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        JsonArray rolesRx = result.getAsJsonArray("roles");
-
-        assertEquals(rolesRx.size(), 1, "Wrong number of roles");
-
-        JsonObject roleRx = rolesRx.get(0).getAsJsonObject();
-
-        assertEquals(roleRx.get("id").getAsString(),validRole.getId().toString(), "Wrong role id");
-        assertEquals(roleRx.get("domain").getAsString(),validRole.getDomain(), "Wrong domain");
-
-        programUserService.removeProgramUser(validProgram.getId(), validUser.getId());
-    }
-
-    @Test
-    public void putProgramsUsersInvalidRole() {
-        String validProgramId = validProgram.getId().toString();
-        JsonObject requestBody = invalidRoleProgramUserRequest();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/users", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
-    }
-
-    public JsonObject validProgramUserRequest() {
-        JsonObject requestBody = new JsonObject();
-        JsonObject user = new JsonObject();
-        user.addProperty("id", validUser.getId().toString());
-        JsonObject role = new JsonObject();
-        role.addProperty("id", validRole.getId().toString());
-        JsonArray roles = new JsonArray();
-        roles.add(role);
-        requestBody.add("user", user);
-        requestBody.add("roles", roles);
-        return requestBody;
-    }
-
-    public JsonObject invalidRoleProgramUserRequest() {
-        JsonObject requestBody = new JsonObject();
-        JsonObject user = new JsonObject();
-        user.addProperty("id", validUser.getId().toString());
-        JsonObject role = new JsonObject();
-        role.addProperty("id", invalidRole);
-        JsonArray roles = new JsonArray();
-        roles.add(role);
-        requestBody.add("user", user);
-        requestBody.add("roles", roles);
-        return requestBody;
-    }
-
-    public JsonObject invalidUserProgramUserRequest() {
-        JsonObject requestBody = new JsonObject();
-        JsonObject user = new JsonObject();
-        user.addProperty("id", invalidUser);
-        JsonObject role = new JsonObject();
-        role.addProperty("id", validRole.getId().toString());
-        JsonArray roles = new JsonArray();
-        roles.add(role);
-        requestBody.add("user", user);
-        requestBody.add("roles", roles);
-        return requestBody;
-    }
-
-    @Test
-    @Order(1)
-    public void postProgramsUsersOnlyIdSuccess() {
-        JsonObject requestBody = validProgramUserRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/"+validProgramId+"/users", requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-    }
-
-    @Test
-    @Order(2)
-    void getProgramsUsersSuccess() {
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+validProgramId+"/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
-        assertEquals(meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), 1, "Wrong totalCount");
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        JsonArray data = result.getAsJsonArray("data");
-        JsonObject programUser = data.get(0).getAsJsonObject();
-        JsonObject user = programUser.getAsJsonObject("user");
-        assertEquals(user.get("id").getAsString(),validUser.getId().toString(), "Wrong user id");
-        assertEquals(user.get("name").getAsString(),validUser.getName(), "Wrong name");
-        assertEquals(user.get("email").getAsString(),validUser.getEmail(), "Wrong email");
-        JsonArray roles = programUser.getAsJsonArray("roles");
-        JsonObject role = roles.get(0).getAsJsonObject();
-        assertEquals(role.get("id").getAsString(),validRole.getId().toString(), "Wrong role id");
-        assertEquals(role.get("domain").getAsString(),validRole.getDomain(), "Wrong domain");
-        JsonObject program = programUser.getAsJsonObject("program");
-        assertEquals(validProgram.getId().toString(), program.get("id").getAsString(), "Wrong program id");
-        assertEquals(validProgram.getName(), program.get("name").getAsString(), "Wrong program name");
-        assertEquals(validProgram.getAbbreviation(), program.get("abbreviation").getAsString(), "Wrong program abbreviation");
-        assertEquals(validProgram.getObjective(), program.get("objective").getAsString(), "Wrong program objective");
-    }
-
-    @Test
-    @Order(3)
-    void getProgramsUsersSingleSuccess() {
-        String validProgramId = validProgram.getId().toString();
-        String validUserId = validUser.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+validProgramId+"/users/"+validUserId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
-        assertEquals(meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), 1, "Wrong totalCount");
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        JsonObject user = result.getAsJsonObject("user");
-        assertEquals(user.get("id").getAsString(),validUser.getId().toString(), "Wrong user id");
-        assertEquals(user.get("name").getAsString(),validUser.getName(), "Wrong name");
-        assertEquals(user.get("email").getAsString(),validUser.getEmail(), "Wrong email");
-        JsonArray roles = result.getAsJsonArray("roles");
-        JsonObject role = roles.get(0).getAsJsonObject();
-        assertEquals(role.get("id").getAsString(),validRole.getId().toString(), "Wrong role id");
-        assertEquals(role.get("domain").getAsString(),validRole.getDomain(), "Wrong domain");
-        JsonObject program = result.getAsJsonObject("program");
-        assertEquals(validProgram.getId().toString(), program.get("id").getAsString(), "Wrong program id");
-        assertEquals(validProgram.getName(), program.get("name").getAsString(), "Wrong program name");
-        assertEquals(validProgram.getAbbreviation(), program.get("abbreviation").getAsString(), "Wrong program abbreviation");
-        assertEquals(validProgram.getObjective(), program.get("objective").getAsString(), "Wrong program objective");
-    }
-
-    @Test
-    @Order(4)
-    @SneakyThrows
-    void getProgramsUsersMultipleUsersSingleRoleSuccess() {
-
-        // create a second user to test with
-        // don't have test database setup yet so doing it this way for now
-        String validProgramId = validProgram.getId().toString();
-
-        UserIdRequest userRequest = UserIdRequest.builder().name("Test2").email("test2@test.com").build();
-        RoleRequest roleRequest = RoleRequest.builder().id(validRole.getId()).build();
-        ArrayList<RoleRequest> rolesList = new ArrayList<>();
-        rolesList.add(roleRequest);
-
-        ProgramUserRequest request = ProgramUserRequest.builder().user(userRequest).roles(rolesList).build();
-        ProgramUser test2 = programUserService.addProgramUser(actingUser, validProgram.getId(), request);
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+validProgramId+"/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
-        assertEquals(2, meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), "Wrong totalCount");
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        JsonArray data = result.getAsJsonArray("data");
-
-        // may be brittle relying on the ordering
-        //JsonObject programUser = data.get(1).getAsJsonObject();
-        Boolean validUserSeen = false;
-        Boolean test2Seen = false;
-        for (JsonElement jsonProgramUser: data.getAsJsonArray()) {
-            JsonObject programUser = (JsonObject) jsonProgramUser;
-            JsonObject user = programUser.getAsJsonObject("user");
-            User checkUser;
-            if (user.get("id").getAsString().equals(validUser.getId().toString())){
-                validUserSeen = true;
-                checkUser = validUser;
-            } else if (user.get("id").getAsString().equals(test2.getUser().getId().toString())) {
-                test2Seen = true;
-                checkUser = test2.getUser();
-            } else {
-                throw new AssertionFailedError("Unexpected user was returned.");
-            }
-
-            assertEquals(checkUser.getId().toString(), user.get("id").getAsString(), "Wrong user id");
-            assertEquals(checkUser.getName(), user.get("name").getAsString(), "Wrong name");
-            assertEquals(checkUser.getEmail(), user.get("email").getAsString(), "Wrong email");
-            JsonArray roles = programUser.getAsJsonArray("roles");
-            JsonObject role = roles.get(0).getAsJsonObject();
-            assertEquals(validRole.getId().toString(), role.get("id").getAsString(), "Wrong role id");
-            assertEquals(validRole.getDomain(), role.get("domain").getAsString(), "Wrong domain");
-        }
-
-        if (!validUserSeen || !test2Seen){
-            throw new AssertionFailedError("Both users were not returned");
-        }
-
-        // remove user from program and delete user from system
-        programUserService.removeProgramUser(validProgram.getId(), test2.getUser().getId());
-        userService.delete(test2.getUser().getId());
-    }
-
-    @Test
-    @Order(5)
-    public void putProgramsUsersOnlyIdSuccess() {
-        JsonObject requestBody = new JsonObject();
-        JsonObject user = new JsonObject();
-        user.addProperty("id", validUser.getId().toString());
-        JsonObject role = new JsonObject();
-        role.addProperty("id", validRole.getId().toString());
-        JsonArray roles = new JsonArray();
-        roles.add(role);
-        requestBody.add("user", user);
-        requestBody.add("roles", roles);
-        String validProgramId = validProgram.getId().toString();
-        String validUserId = validUser.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgramId+"/users/"+validUserId, requestBody.toString())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-    }
-
-    public void putProgramsUsersNonExistentActiveUser() {
-        String validProgramId = validProgram.getId().toString();
-        String validUserId = validUser.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+validProgramId+"/users/"+validUserId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "non-existent-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, e.getStatus());
-    }
-    @Test
-    public void archiveProgramsUsersNotExistingProgramId() {
-        Flowable<HttpResponse<String>> call = client.exchange(
-                DELETE("/programs/"+invalidProgram+"/users/"+invalidProgram).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-    @Test
-    public void archiveProgramsUsersNotExistingUserId() {
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                DELETE("/programs/"+validProgramId+"/users/"+invalidUser).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-    @Test
-    @SneakyThrows
-    @Order(6)
-    public void archiveProgramsUsersSuccess() {
-        String validProgramId = validProgram.getId().toString();
-        String validUserId = validUser.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                DELETE("/programs/" + validProgramId + "/users/" + validUserId).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        // Remove program user for following tests since endpoint only archives it.
-        programUserService.removeProgramUser(validProgram.getId(), validUser.getId());
-    }
-
-    @Test
-    @SneakyThrows
-    @Order(7)
-    public void getUsersInactiveNotReturned() {
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+validProgramId+"/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
-        assertEquals(meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), 0, "Wrong totalCount");
-    }
-
-    @Test
-    void getProgramsUsersInvalidProgramId() {
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+invalidProgram+"/users").cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-    @Test
-    @Order(7)
-    void getProgramsUsersNoUsers() {
-        String validProgramId = validProgram.getId().toString();
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+validProgramId+"/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
-        assertEquals(meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), 0, "Wrong totalCount");
-
-        JsonArray result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").getAsJsonArray("data");
-        assertEquals(result.size(),0, "Wrong size");
-
-    }
-
-    @Test
-    void getProgramsUsersSingleInvalidProgramId() {
-        String validUserId = validUser.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+invalidProgram+"/users/"+validUserId).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-    @Test
-    void getProgramsUsersSingleInvalidUserId() {
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/"+validProgramId+"/users/"+invalidUser).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-    @Test
-    void putProgramsUsersInvalidProgramId() {
-        JsonObject requestBody = validProgramUserRequest();
-        String validUserId = validUser.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+invalidProgram+"/users/"+validUserId, requestBody.toString()).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-    @Test
-    void putProgramsUsersInvalidUserId() {
-        JsonObject requestBody = validProgramUserRequest();
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgramId+"/users/"+invalidUser, requestBody.toString()).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
-
-    @Test
-    void putProgramsUsersMissingBody() {
-        String validProgramId = validProgram.getId().toString();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                PUT("/programs/"+validProgramId+"/users/"+invalidUser, "").cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
-    }
-
-    @Test
-    @Order(8)
-    @SneakyThrows
-    public void getProgramUsersQuery() {
-        FannyPack userFp = FannyPack.fill("src/test/resources/sql/UserControllerIntegrationTest.sql");
-        dsl.execute(userFp.get("InsertProgram"));
-        dsl.execute(userFp.get("InsertManyUsers"));
-        dsl.execute(fp.get("InsertManyProgramUsers"),
-                validProgram.getId().toString(), validProgram.getId().toString(),
-                validProgram.getId().toString(), validProgram.getId().toString());
-        List<ProgramUser> allProgramUsers = programUserService.getProgramUsers(validProgram.getId());
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/" + validProgram.getId() + "/users?page=1&pageSize=30&sortField=roles&sortOrder=ASC").cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        JsonArray data = result.get("data").getAsJsonArray();
-
-        assertEquals(allProgramUsers.size(), data.size(), "Wrong page size");
-        TestUtils.checkStringListSorting(getRoles(data), SortOrder.ASC);
-
-        JsonObject pagination = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata").getAsJsonObject("pagination");
-        assertEquals((int) Math.ceil(allProgramUsers.size()/30.0), pagination.get("totalPages").getAsInt(), "Wrong number of pages");
-        assertEquals(allProgramUsers.size(), pagination.get("totalCount").getAsInt(), "Wrong total count");
-        assertEquals(1, pagination.get("currentPage").getAsInt(), "Wrong current page");
-    }
-
-    @Test
-    @Order(9)
-    public void searchProgramUsers() {
-
-        List<ProgramUser> allProgramUsers = programUserDAO.getAllProgramUsers();
-        SearchRequest searchRequest = new SearchRequest();
-        searchRequest.setFilter(new ArrayList<>());
-        searchRequest.getFilter().add(new FilterRequest("roles", "breed"));
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs/" + validProgram.getId() + "/users/search?page=1&pageSize=20&sortField=roles&sortOrder=ASC", searchRequest).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        JsonArray data = result.get("data").getAsJsonArray();
-
-        // Expect 12, user12, user20->user29
-        assertEquals(12, data.size(), "Wrong page size");
-        TestUtils.checkStringListSorting(getRoles(data), SortOrder.ASC);
-
-        JsonObject pagination = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata").getAsJsonObject("pagination");
-        assertEquals(1, pagination.get("totalPages").getAsInt(), "Wrong number of pages");
-        assertEquals(12, pagination.get("totalCount").getAsInt(), "Wrong total count");
-        assertEquals(1, pagination.get("currentPage").getAsInt(), "Wrong current page");
-    }
-
-    private List<List<String>> getRoles(JsonArray data) {
-        List<List<String>> roleResults = new ArrayList<>();
-        for (JsonElement el : data) {
-            JsonObject programUser = (JsonObject) el;
-            JsonArray roles = programUser.get("roles").getAsJsonArray();
-            List<String> userRoles = new ArrayList<>();
-            for (JsonElement roleEl : roles) {
-                JsonObject role = (JsonObject) roleEl;
-                userRoles.add(role.get("domain").getAsString());
-            }
-            Collections.sort(userRoles);
-            roleResults.add(userRoles);
-        }
-        return roleResults;
-    }
-
-    //endregion
-
     //region Program Tests
-    public void checkValidProgram(Program program, JsonObject programJson){
+    public void checkValidProgram(ProgramEntity program, JsonObject programJson){
 
         assertEquals(program.getName(), programJson.get("name").getAsString(), "Wrong name");
         assertEquals(program.getAbbreviation(), programJson.get("abbreviation").getAsString(), "Wrong abbreviation");
@@ -1791,26 +280,26 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
         assertEquals(program.getObjective(), programJson.get("objective").getAsString(), "Wrong objective");
 
         JsonObject species = programJson.getAsJsonObject("species");
-        assertEquals(program.getSpecies().getId().toString(), species.get("id").getAsString(), "Wrong species");
+        assertEquals(program.getSpeciesId().toString(), species.get("id").getAsString(), "Wrong species");
 
         JsonObject createdByUser = programJson.getAsJsonObject("createdByUser");
-        assertEquals(program.getCreatedByUser().getId().toString(), createdByUser.get("id").getAsString(), "Wrong created by user");
+        assertEquals(program.getCreatedBy().toString(), createdByUser.get("id").getAsString(), "Wrong created by user");
 
         JsonObject updatedByUser = programJson.getAsJsonObject("updatedByUser");
-        assertEquals(program.getUpdatedByUser().getId().toString(), updatedByUser.get("id").getAsString(), "Wrong updated by user");
+        assertEquals(program.getUpdatedBy().toString(), updatedByUser.get("id").getAsString(), "Wrong updated by user");
     }
 
-    public void checkMinimalValidProgram(Program program, JsonObject programJson){
+    public void checkMinimalValidProgram(ProgramEntity program, JsonObject programJson){
         assertEquals(program.getName(), programJson.get("name").getAsString(), "Wrong name");
 
         JsonObject species = programJson.getAsJsonObject("species");
-        assertEquals(program.getSpecies().getId().toString(), species.get("id").getAsString(), "Wrong species");
+        assertEquals(program.getSpeciesId().toString(), species.get("id").getAsString(), "Wrong species");
 
         JsonObject createdByUser = programJson.getAsJsonObject("createdByUser");
-        assertEquals(program.getCreatedByUser().getId().toString(), createdByUser.get("id").getAsString(), "Wrong created by user");
+        assertEquals(program.getCreatedBy().toString(), createdByUser.get("id").getAsString(), "Wrong created by user");
 
         JsonObject updatedByUser = programJson.getAsJsonObject("updatedByUser");
-        assertEquals(program.getUpdatedByUser().getId().toString(), updatedByUser.get("id").getAsString(), "Wrong updated by user");
+        assertEquals(program.getUpdatedBy().toString(), updatedByUser.get("id").getAsString(), "Wrong updated by user");
     }
 
     @Test
@@ -1830,7 +319,49 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
         JsonArray data = result.getAsJsonArray("data");
         JsonObject programResult = data.get(0).getAsJsonObject();
 
-        checkValidProgram(validProgram, programResult);
+        checkValidProgram(otherProgram, programResult);
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(2)
+    public void postProgramsFullBodySuccess() throws Exception {
+
+        SpeciesRequest speciesRequest = SpeciesRequest.builder()
+                .id(validSpecies.getId())
+                .commonName(validSpecies.getCommonName())
+                .build();
+
+        Program program = Program.builder()
+                .name("Test Program")
+                .abbreviation("Test")
+                .documentationUrl("localhost")
+                .objective("Testing things")
+                .species(validSpecies)
+                .speciesId(validSpecies.getId())
+                .build();
+
+        ProgramRequest validRequest = ProgramRequest.builder()
+                .name("Test Program")
+                .abbreviation("Test")
+                .documentationUrl("localhost")
+                .objective("Testing things")
+                .species(speciesRequest)
+                .build();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs", gson.toJson(validRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        validProgram = programDao.fetchById(UUID.fromString(result.get("id").getAsString())).get(0);
+
+        checkMinimalValidProgram(validProgram, result);
     }
 
     @Test
@@ -1951,45 +482,7 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
         assertTrue(createdProgram.isPresent(), "Created program was not found");
         Program program = createdProgram.get();
 
-        checkMinimalValidProgram(program, result);
-
-        dsl.execute(fp.get("DeleteProgram"), program.getId().toString(), program.getId().toString(), program.getId().toString());
-    }
-
-    @Test
-    @SneakyThrows
-    public void postProgramsFullBodySuccess() throws Exception {
-
-        SpeciesRequest speciesRequest = SpeciesRequest.builder()
-                .id(validSpecies.getId())
-                .commonName(validSpecies.getCommonName())
-                .build();
-
-        ProgramRequest validRequest = ProgramRequest.builder()
-                .name(validProgram.getName())
-                .abbreviation("Test")
-                .documentationUrl("localhost")
-                .objective("Testing things")
-                .species(speciesRequest)
-                .build();
-
-        Flowable<HttpResponse<String>> call = client.exchange(
-                POST("/programs", gson.toJson(validRequest))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.OK, response.getStatus());
-
-        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
-        String newProgramId = result.getAsJsonPrimitive("id").getAsString();
-
-        Optional<Program> createdProgram = programService.getById(UUID.fromString(newProgramId));
-        assertTrue(createdProgram.isPresent(), "Created program was not found");
-        Program program = createdProgram.get();
-
-        checkMinimalValidProgram(program, result);
+        checkMinimalValidProgram(validProgram, result);
 
         dsl.execute(fp.get("DeleteProgram"), program.getId().toString(), program.getId().toString(), program.getId().toString());
     }
@@ -2089,16 +582,16 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
     }
 
     @Test
-    public void putProgramsMinimalBodySuccess() throws Exception {
+    @Order(3)
+    public void putProgramsMinimalBodySuccess() {
 
         SpeciesRequest speciesRequest = SpeciesRequest.builder()
                 .id(validSpecies.getId())
                 .build();
 
-        Program alteredProgram = validProgram;
-        alteredProgram.setName("changed");
+        validProgram.setName("changed");
         ProgramRequest validRequest = ProgramRequest.builder()
-                .name(alteredProgram.getName())
+                .name(validProgram.getName())
                 .species(speciesRequest)
                 .build();
 
@@ -2113,11 +606,11 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
 
         JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
 
-        checkMinimalValidProgram(alteredProgram, result);
-
+        checkMinimalValidProgram(validProgram, result);
     }
 
     @Test
+    @Order(4)
     public void putProgramsFullBodySuccess() {
 
         SpeciesRequest speciesRequest = SpeciesRequest.builder()
@@ -2125,22 +618,21 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
                 .commonName(validSpecies.getCommonName())
                 .build();
 
-        Program alteredProgram = validProgram;
-        alteredProgram.setName("changed");
-        alteredProgram.setAbbreviation("changed abbreviation");
-        alteredProgram.setObjective("changed objective");
-        alteredProgram.setDocumentationUrl("changed doc url");
+        validProgram.setName("changed");
+        validProgram.setAbbreviation("changed abbreviation");
+        validProgram.setObjective("changed objective");
+        validProgram.setDocumentationUrl("changed doc url");
 
         ProgramRequest validRequest = ProgramRequest.builder()
-                .name(alteredProgram.getName())
-                .abbreviation(alteredProgram.getAbbreviation())
-                .documentationUrl(alteredProgram.getDocumentationUrl())
-                .objective(alteredProgram.getObjective())
+                .name(validProgram.getName())
+                .abbreviation(validProgram.getAbbreviation())
+                .documentationUrl(validProgram.getDocumentationUrl())
+                .objective(validProgram.getObjective())
                 .species(speciesRequest)
                 .build();
 
         Flowable<HttpResponse<String>> call = client.exchange(
-                PUT(String.format("/programs/%s", alteredProgram.getId()), gson.toJson(validRequest))
+                PUT(String.format("/programs/%s", validProgram.getId()), gson.toJson(validRequest))
                         .contentType(MediaType.APPLICATION_JSON)
                         .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
         );
@@ -2150,7 +642,7 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
 
         JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
 
-        checkMinimalValidProgram(alteredProgram, result);
+        checkMinimalValidProgram(validProgram, result);
     }
 
     @Test
@@ -2218,7 +710,7 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
     }
 
     @Test
-    @Order(2)
+    @Order(5)
     public void getProgramQuery() {
         dsl.execute(fp.get("InsertManyPrograms"));
         List<ProgramEntity> allPrograms = programDao.findAll();
@@ -2243,7 +735,7 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
     }
 
     @Test
-    @Order(3)
+    @Order(6)
     public void searchPrograms() {
 
         List<ProgramEntity> allPrograms = programDao.findAll();
@@ -2273,5 +765,1517 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
 
     //endregion
 
+    //region Program Location Tests
+    @Test
+    @Order(4)
+    public void postProgramsLocationsInvalidProgram() {
+        JsonObject requestBody = validProgramLocationRequest();
 
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+invalidProgram+"/locations", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void postProgramsLocationsInvalidCountry() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        JsonObject country = new JsonObject();
+        country.addProperty("id", invalidCountry);
+        requestBody.add("country", country);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgram.getId().toString()+"/locations", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void postProgramsLocationsInvalidEnvironmentType() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        JsonObject environmentType = new JsonObject();
+        environmentType.addProperty("id", invalidEnvironment);
+        requestBody.add("environmentType", environmentType);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgram.getId().toString()+"/locations", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void postProgramsLocationsInvalidTopography() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        JsonObject topography = new JsonObject();
+        topography.addProperty("id", invalidTopography);
+        requestBody.add("topography", topography);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgram.getId().toString()+"/locations", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void postProgramsLocationsInvalidAccessibility() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        JsonObject accessibility = new JsonObject();
+        accessibility.addProperty("id", invalidAccessibility);
+        requestBody.add("accessibility", accessibility);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgram.getId().toString()+"/locations", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void postProgramsLocationsMissingBody() {
+        JsonObject requestBody = new JsonObject();
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
+    }
+
+    public JsonObject validProgramLocationRequest() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        return requestBody;
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(4)
+    public void postProgramsLocationsIgnoresBodyProgramId() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        requestBody.addProperty("programId", invalidLocation);
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        assertEquals(requestBody.get("name").getAsString(), result.get("name").getAsString(),"Wrong name");
+        assertEquals(validProgramId, result.get("programId").getAsString(), "programId does not match path programId");
+
+        String locationId = result.get("id").getAsString();
+        programLocationService.delete(UUID.fromString(locationId));
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(4)
+    public void postProgramsLocationsOnlyNameSuccess() {
+        JsonObject requestBody = validProgramLocationRequest();
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        assertEquals(requestBody.get("name").getAsString(), result.get("name").getAsString(),"Wrong name");
+        String locationId = result.get("id").getAsString();
+
+        // Check that the coordinates is [NULL] in DB
+        Optional<ProgramLocation> programLocation = programLocationService.getById(UUID.fromString(validProgramId), UUID.fromString(locationId));
+        assertNull(programLocation.get().getCoordinates());
+
+        programLocationService.delete(UUID.fromString(locationId));
+    }
+
+    public JsonObject validProgramLocationCoordinatePointRequest() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        JsonObject coordinates = new JsonObject();
+        JsonObject geometry = new JsonObject();
+        JsonArray coordinatesArray = new JsonArray();
+        coordinatesArray.add(-76.506042);
+        coordinatesArray.add(42.417373);
+        coordinatesArray.add(123);
+        geometry.add("coordinates", coordinatesArray);
+        geometry.addProperty("type", "Point");
+        coordinates.add("geometry", geometry);
+        coordinates.addProperty("type", "Feature");
+        requestBody.add("coordinates", coordinates);
+        return requestBody;
+    }
+
+    public JsonObject validProgramLocationCoordinatePolygonRequest() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        JsonObject coordinates = new JsonObject();
+        JsonObject geometry = new JsonObject();
+        JsonArray coordinatesArray = new JsonArray();
+        JsonArray polyArray = new JsonArray();
+        JsonArray coordinate1 = new JsonArray();
+        coordinate1.add(-76.5);
+        coordinate1.add(42.4);
+        JsonArray coordinate2 = new JsonArray();
+        coordinate2.add(-76.6);
+        coordinate2.add(42.5);
+        JsonArray coordinate3 = new JsonArray();
+        coordinate3.add(-76.4);
+        coordinate3.add(42.3);
+        polyArray.add(coordinate1);
+        polyArray.add(coordinate2);
+        polyArray.add(coordinate3);
+        polyArray.add(coordinate1);
+        coordinatesArray.add(polyArray);
+        geometry.add("coordinates", coordinatesArray);
+        geometry.addProperty("type", "Polygon");
+        coordinates.add("geometry", geometry);
+        coordinates.addProperty("type", "Feature");
+        requestBody.add("coordinates", coordinates);
+        return requestBody;
+    }
+
+    public JsonObject validProgramLocationCoordinateLineStringRequest() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        JsonObject coordinates = new JsonObject();
+        JsonObject geometry = new JsonObject();
+        JsonArray coordinatesArray = new JsonArray();
+        JsonArray coordinate1 = new JsonArray();
+        coordinate1.add(-76.5);
+        coordinate1.add(42.4);
+        JsonArray coordinate2 = new JsonArray();
+        coordinate2.add(-76.6);
+        coordinate2.add(42.5);
+        coordinatesArray.add(coordinate1);
+        coordinatesArray.add(coordinate2);
+        geometry.add("coordinates", coordinatesArray);
+        geometry.addProperty("type", "LineString");
+        coordinates.add("geometry", geometry);
+        coordinates.addProperty("type", "Feature");
+        requestBody.add("coordinates", coordinates);
+        return requestBody;
+    }
+
+    public JsonObject validProgramLocationCoordinatePointBadLatRequest() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        JsonObject coordinates = new JsonObject();
+        JsonObject geometry = new JsonObject();
+        JsonArray coordinatesArray = new JsonArray();
+        coordinatesArray.add(-76.506042);
+        coordinatesArray.add(100.417373);
+        coordinatesArray.add(123);
+        geometry.add("coordinates", coordinatesArray);
+        geometry.addProperty("type", "Point");
+        coordinates.add("geometry", geometry);
+        coordinates.addProperty("type", "Feature");
+        requestBody.add("coordinates", coordinates);
+        return requestBody;
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(4)
+    public void postProgramsLocationsCoordinatesPointSuccess() {
+        JsonObject requestBody = validProgramLocationCoordinatePointRequest();
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+
+
+        String locationId = result.get("id").getAsString();
+        programLocationService.delete(UUID.fromString(locationId));
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(4)
+    public void postProgramsLocationsCoordinatesPolygonSuccess() {
+        JsonObject requestBody = validProgramLocationCoordinatePolygonRequest();
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+
+
+        String locationId = result.get("id").getAsString();
+        programLocationService.delete(UUID.fromString(locationId));
+    }
+
+    @Test
+    @Order(4)
+    public void postProgramsLocationsCoordinatesLineStringFailed() {
+        JsonObject requestBody = validProgramLocationCoordinateLineStringRequest();
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void postProgramsLocationsCoordinatesInvalidLatLonFailed() {
+        JsonObject requestBody = validProgramLocationCoordinatePointBadLatRequest();
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/locations", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+
+    }
+
+    @Test
+    @Order(4)
+    public void putProgramsLocationsInvalidLocation() {
+        JsonObject requestBody = validProgramLocationRequest();
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+validProgramId+"/locations/"+invalidLocation, requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void putProgramsLocationsInvalidCountry() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        JsonObject country = new JsonObject();
+        country.addProperty("id", invalidCountry);
+        requestBody.add("country", country);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+otherProgram.getId().toString()+"/locations/"+validLocation.getId().toString(), requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void putProgramsLocationsInvalidEnvironmentType() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        JsonObject environmentType = new JsonObject();
+        environmentType.addProperty("id", invalidEnvironment);
+        requestBody.add("environmentType", environmentType);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+otherProgram.getId().toString()+"/locations/"+validLocation.getId().toString(), requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void putProgramsLocationsInvalidTopography() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        JsonObject topography = new JsonObject();
+        topography.addProperty("id", invalidTopography);
+        requestBody.add("topography", topography);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+otherProgram.getId().toString()+"/locations/"+validLocation.getId().toString(), requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void putProgramsLocationsInvalidAccessibility() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        JsonObject accessibility = new JsonObject();
+        accessibility.addProperty("id", invalidAccessibility);
+        requestBody.add("accessibility", accessibility);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+otherProgram.getId().toString()+"/locations/"+validLocation.getId().toString(), requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void putProgramsLocationsMissingBody() {
+        JsonObject requestBody = new JsonObject();
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+validProgramId+"/locations/"+validLocation.getId().toString(), requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void putProgramsLocationsCoordinatesLineStringFailed() {
+        JsonObject requestBody = validProgramLocationCoordinateLineStringRequest();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+otherProgram.getId().toString()+"/locations/"+validLocation.getId().toString(), requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void putProgramsLocationsCoordinatesInvalidLatLonFailed() {
+        JsonObject requestBody = validProgramLocationCoordinatePointBadLatRequest();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+otherProgram.getId().toString()+"/locations/"+validLocation.getId().toString(), requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(4)
+    public void putProgramsLocationsCoordinatesPointSuccess() {
+
+        ProgramLocation location = insertAndFetchTestLocation();
+        String locationId = location.getId().toString();
+
+        JsonObject requestBody = validProgramLocationCoordinatePointRequest();
+        String validProgramId = otherProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+validProgramId+"/locations/"+locationId, requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        programLocationService.delete(UUID.fromString(locationId));
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(4)
+    public void putProgramsLocationsCoordinatesPolygonSuccess() {
+        ProgramLocation location = insertAndFetchTestLocation();
+        String locationId = location.getId().toString();
+
+        JsonObject requestBody = validProgramLocationCoordinatePolygonRequest();
+        String validProgramId = otherProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+validProgramId+"/locations/"+locationId, requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        programLocationService.delete(UUID.fromString(locationId));
+
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(4)
+    public void putProgramsLocationsIgnoresBodyProgramId() {
+        ProgramLocation location = insertAndFetchTestLocation();
+        String locationId = location.getId().toString();
+
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "Field 1");
+        requestBody.addProperty("programId", invalidLocation);
+        String validProgramId = otherProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+validProgramId+"/locations/"+locationId, requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        assertEquals(requestBody.get("name").getAsString(), result.get("name").getAsString(),"Wrong name");
+        assertEquals(validProgramId, result.get("programId").getAsString(), "programId does not match path programId");
+
+        programLocationService.delete(UUID.fromString(locationId));
+    }
+
+
+    @Test
+    @SneakyThrows
+    @Order(4)
+    public void putProgramsLocationsOnlyNameSuccess() {
+        ProgramLocation location = insertAndFetchTestLocation();
+        String locationId = location.getId().toString();
+
+        JsonObject requestBody = validProgramLocationRequest();
+        String validProgramId = otherProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+validProgramId+"/locations/"+locationId, requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
+        assertEquals(1, meta.getAsJsonObject("pagination").get("totalCount").getAsInt(),"Wrong totalCount");
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        assertEquals("Field 1", result.get("name").getAsString(), "Wrong name");
+
+        // Check that the coordinates is [NULL] in DB
+        Optional<ProgramLocation> programLocation = programLocationService.getById(UUID.fromString(validProgramId), UUID.fromString(locationId));
+        assertNull(programLocation.get().getCoordinates());
+
+        programLocationService.delete(UUID.fromString(locationId));
+    }
+
+    @SneakyThrows
+    public void checkValidLocation(JsonObject programLocation) {
+
+        JsonObject country = programLocation.getAsJsonObject("country");
+        assertEquals(validLocation.getCountry().getId().toString(), country.get("id").getAsString(), "Wrong country id");
+        assertEquals(validLocation.getCountry().getName(), country.get("name").getAsString(), "Wrong country name");
+        assertEquals(validLocation.getCountry().getAlpha_2Code(), country.get("alpha2Code").getAsString(), "Wrong country alpha 2 code");
+        assertEquals(validLocation.getCountry().getAlpha_3Code(), country.get("alpha3Code").getAsString(), "Wrong country alpha 3 code");
+        JsonObject accessibility = programLocation.getAsJsonObject("accessibility");
+        assertEquals(validLocation.getAccessibility().getId().toString(), accessibility.get("id").getAsString(), "Wrong accessibility id");
+        assertEquals(validLocation.getAccessibility().getName(), accessibility.get("name").getAsString(), "Wrong accessibility name");
+        JsonObject environment = programLocation.getAsJsonObject("environmentType");
+        assertEquals(validLocation.getEnvironmentType().getId().toString(), environment.get("id").getAsString(), "Wrong environment type id");
+        assertEquals(validLocation.getEnvironmentType().getName(), environment.get("name").getAsString(), "Wrong environment type name");
+        JsonObject topography = programLocation.getAsJsonObject("topography");
+        assertEquals(validLocation.getTopography().getId().toString(), topography.get("id").getAsString(), "Wrong topography id");
+        assertEquals(validLocation.getTopography().getName(), topography.get("name").getAsString(), "Wrong topography type name");
+        assertEquals(validLocation.getId().toString(), programLocation.get("id").getAsString(), "Wrong location id");
+        assertEquals(validLocation.getProgramId().toString(), programLocation.get("programId").getAsString(), "Wrong program id");
+        assertEquals(validLocation.getName(), programLocation.get("name").getAsString(), "Wrong name");
+        assertEquals(validLocation.getAbbreviation(), programLocation.get("abbreviation").getAsString(), "Wrong abbreviation");
+
+        assertEquals(validLocation.getCoordinateDescription(), programLocation.get("coordinateDescription").getAsString(), "Wrong coordinate description");
+        assertEquals(validLocation.getCoordinateUncertainty(), programLocation.get("coordinateUncertainty").getAsBigDecimal(), "Wrong coordinate uncertainty");
+        assertEquals(validLocation.getDocumentationUrl(), programLocation.get("documentationUrl").getAsString(), "Wrong documentation url");
+        assertEquals(validLocation.getExposure(), programLocation.get("exposure").getAsString(), "Wrong exposure");
+        assertEquals(validLocation.getSlope(), programLocation.get("slope").getAsBigDecimal(), "Wrong slope");
+
+        JsonObject coords = programLocation.get("coordinates").getAsJsonObject();
+        ObjectMapper objMapper = new ObjectMapper();
+        Feature feature = objMapper.readValue(new Gson().toJson(coords), Feature.class);
+        assertEquals(validLocation.getCoordinatesJson(), feature, "Wrong coordinates");
+
+    }
+
+    @Test
+    @Order(4)
+    public void getProgramsLocationsSuccess() {
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/"+otherProgram.getId().toString()+"/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
+        assertEquals(1, meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), "Wrong totalCount");
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        JsonArray data = result.getAsJsonArray("data");
+        JsonObject programLocation = data.get(0).getAsJsonObject();
+        checkValidLocation(programLocation);
+    }
+
+    @Test
+    @Order(4)
+    public void getProgramsLocationsSingleSuccess() {
+        String validLocationId = validLocation.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/"+otherProgram.getId().toString()+"/locations/"+validLocationId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
+        assertEquals(1, meta.getAsJsonObject("pagination").get("totalCount").getAsInt(),"Wrong totalCount");
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        checkValidLocation(result);
+    }
+
+    @Test
+    @Order(4)
+    public void getProgramsLocationsSingleInvalidId() {
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/"+validProgram.getId().toString()+"/locations/"+invalidLocation)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(4)
+    public void getProgramsLocationsSingleWrongProgramId() {
+
+        String programId = validProgram.getId().toString();
+        String validLocationId = validLocation.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/"+programId+"/locations/"+validLocationId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void getProgramsLocationsInvalidProgramId() {
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/"+invalidProgram+"/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+
+
+    @Test
+    @Order(4)
+    public void archiveProgramsLocationsNotExistingLocationId() {
+        Flowable<HttpResponse<String>> call = client.exchange(
+                DELETE("/programs/"+otherProgram.getId().toString()+"/locations/"+invalidLocation)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @Order(4)
+    public void archiveProgramsLocationsNotExistingProgramId() {
+        Flowable<HttpResponse<String>> call = client.exchange(
+                DELETE("/programs/"+invalidProgram+"/locations/"+validLocation.getId().toString())
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(4)
+    public void archiveProgramsLocationsWrongProgramId() {
+        String programId = validProgram.getId().toString();
+        String validLocationId = validLocation.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                DELETE("/programs/"+programId+"/locations/"+validLocationId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(4)
+    public void archiveProgramsLocations() {
+
+        ProgramLocation location = insertAndFetchTestLocation();
+        String locationId = location.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                DELETE("/programs/"+otherProgram.getId().toString()+"/locations/"+locationId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String>  response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        // GET single to make sure active flag is changed
+        call = client.exchange(
+                GET("/programs/"+otherProgram.getId().toString()+"/locations/"+locationId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        assertEquals(false, result.get("active").getAsBoolean(), "active should be false");
+
+        // GET all to make sure it doesn't show in list
+        call = client.exchange(
+                GET("/programs/"+otherProgram.getId().toString()+"/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
+        // will have validLocation only for other tests but not the location added in this test
+        assertEquals(1, meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), "Should only be one location for valid");
+
+        programLocationService.delete(UUID.fromString(locationId));
+    }
+
+    //endregion
+
+    //region Program User Tests
+    @Test
+    @Order(5)
+    public void postProgramsUsersInvalidProgram() {
+        JsonObject requestBody = validProgramUserRequest();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+invalidProgram+"/users", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @Order(5)
+    void postProgramsUsersInvalidUserId() {
+        JsonObject requestBody = invalidUserProgramUserRequest();
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/users/", requestBody.toString()).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    @Test
+    @Order(5)
+    public void postProgramsUsersDuplicateUser() {
+        JsonObject requestBody = new JsonObject();
+
+        JsonObject user = new JsonObject();
+        user.addProperty("name", "test");
+        user.addProperty("email", "test@test.com");
+
+        JsonArray roles = new JsonArray();
+        JsonObject role = new JsonObject();
+        role.addProperty("id", validRole.getId().toString());
+        roles.add(role);
+        requestBody.add("user", user);
+        requestBody.add("roles", roles);
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/users", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.CONFLICT, e.getStatus());
+    }
+
+    @Test
+    @Order(5)
+    public void postProgramsUsersMissingBody() {
+        JsonObject requestBody = new JsonObject();
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/users", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
+    }
+
+    @Test
+    @Order(5)
+    public void postProgramsUsersOnlyName() {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("name", "test");
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/users", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(5)
+    public void postProgramsUsersDuplicateRoles() {
+        String validProgramId = otherProgram.getId().toString();
+        JsonObject requestBody = new JsonObject();
+        JsonObject user = new JsonObject();
+        user.addProperty("id", validUser.getId().toString());
+        JsonObject role = new JsonObject();
+        role.addProperty("id", validRole.getId().toString());
+        JsonArray roles = new JsonArray();
+        roles.add(role);
+        roles.add(role);
+        requestBody.add("user", user);
+        requestBody.add("roles", roles);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/users", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        JsonArray rolesRx = result.getAsJsonArray("roles");
+
+        assertEquals(rolesRx.size(), 1, "Wrong number of roles");
+
+        JsonObject roleRx = rolesRx.get(0).getAsJsonObject();
+
+        assertEquals(roleRx.get("id").getAsString(),validRole.getId().toString(), "Wrong role id");
+        assertEquals(roleRx.get("domain").getAsString(),validRole.getDomain(), "Wrong domain");
+    }
+
+    @Test
+    @Order(5)
+    public void postProgramsUsersInvalidRole() {
+        String validProgramId = validProgram.getId().toString();
+        JsonObject requestBody = invalidRoleProgramUserRequest();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/users", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    @Test
+    @Order(5)
+    public void postProgramsUsersOnlyIdSuccess() {
+        JsonObject requestBody = validProgramUserRequest();
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/users", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(6)
+    public void putProgramsUsersDuplicateRoles() {
+        String validProgramId = validProgram.getId().toString();
+        JsonObject requestBody = new JsonObject();
+        JsonObject user = new JsonObject();
+        user.addProperty("id", validUser.getId().toString());
+        JsonObject role = new JsonObject();
+        role.addProperty("id", validRole.getId().toString());
+        JsonArray roles = new JsonArray();
+        roles.add(role);
+        roles.add(role);
+        requestBody.add("user", user);
+        requestBody.add("roles", roles);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+validProgramId+"/users/" + validUser.getId().toString(), requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        JsonArray rolesRx = result.getAsJsonArray("roles");
+
+        assertEquals(rolesRx.size(), 1, "Wrong number of roles");
+
+        JsonObject roleRx = rolesRx.get(0).getAsJsonObject();
+
+        assertEquals(roleRx.get("id").getAsString(),validRole.getId().toString(), "Wrong role id");
+        assertEquals(roleRx.get("domain").getAsString(),validRole.getDomain(), "Wrong domain");
+    }
+
+    @Test
+    @Order(6)
+    public void putProgramsUsersInvalidRole() {
+        String validProgramId = validProgram.getId().toString();
+        JsonObject requestBody = invalidRoleProgramUserRequest();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/"+validProgramId+"/users", requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
+    }
+
+    public JsonObject validProgramUserRequest() {
+        JsonObject requestBody = new JsonObject();
+        JsonObject user = new JsonObject();
+        user.addProperty("id", validUser.getId().toString());
+        JsonObject role = new JsonObject();
+        role.addProperty("id", validRole.getId().toString());
+        JsonArray roles = new JsonArray();
+        roles.add(role);
+        requestBody.add("user", user);
+        requestBody.add("roles", roles);
+        return requestBody;
+    }
+
+    public JsonObject invalidRoleProgramUserRequest() {
+        JsonObject requestBody = new JsonObject();
+        JsonObject user = new JsonObject();
+        user.addProperty("id", validUser.getId().toString());
+        JsonObject role = new JsonObject();
+        role.addProperty("id", invalidRole);
+        JsonArray roles = new JsonArray();
+        roles.add(role);
+        requestBody.add("user", user);
+        requestBody.add("roles", roles);
+        return requestBody;
+    }
+
+    public JsonObject invalidUserProgramUserRequest() {
+        JsonObject requestBody = new JsonObject();
+        JsonObject user = new JsonObject();
+        user.addProperty("id", invalidUser);
+        JsonObject role = new JsonObject();
+        role.addProperty("id", validRole.getId().toString());
+        JsonArray roles = new JsonArray();
+        roles.add(role);
+        requestBody.add("user", user);
+        requestBody.add("roles", roles);
+        return requestBody;
+    }
+
+
+
+    @Test
+    @Order(6)
+    void getProgramsUsersSuccess() {
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/"+validProgramId+"/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
+        assertEquals(1, meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), "Wrong totalCount");
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        JsonArray data = result.getAsJsonArray("data");
+        JsonObject programUser = data.get(0).getAsJsonObject();
+        JsonObject user = programUser.getAsJsonObject("user");
+        assertEquals(user.get("id").getAsString(),validUser.getId().toString(), "Wrong user id");
+        assertEquals(user.get("name").getAsString(),validUser.getName(), "Wrong name");
+        assertEquals(user.get("email").getAsString(),validUser.getEmail(), "Wrong email");
+        JsonArray roles = programUser.getAsJsonArray("roles");
+        JsonObject role = roles.get(0).getAsJsonObject();
+        assertEquals(role.get("id").getAsString(),validRole.getId().toString(), "Wrong role id");
+        assertEquals(role.get("domain").getAsString(),validRole.getDomain(), "Wrong domain");
+        JsonObject program = programUser.getAsJsonObject("program");
+        assertEquals(validProgram.getId().toString(), program.get("id").getAsString(), "Wrong program id");
+        assertEquals(validProgram.getName(), program.get("name").getAsString(), "Wrong program name");
+        assertEquals(validProgram.getAbbreviation(), program.get("abbreviation").getAsString(), "Wrong program abbreviation");
+        assertEquals(validProgram.getObjective(), program.get("objective").getAsString(), "Wrong program objective");
+    }
+
+    @Test
+    @Order(6)
+    void getProgramsUsersSingleSuccess() {
+        String validProgramId = validProgram.getId().toString();
+        String validUserId = validUser.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/"+validProgramId+"/users/"+validUserId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
+        assertEquals(meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), 1, "Wrong totalCount");
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        JsonObject user = result.getAsJsonObject("user");
+        assertEquals(user.get("id").getAsString(),validUser.getId().toString(), "Wrong user id");
+        assertEquals(user.get("name").getAsString(),validUser.getName(), "Wrong name");
+        assertEquals(user.get("email").getAsString(),validUser.getEmail(), "Wrong email");
+        JsonArray roles = result.getAsJsonArray("roles");
+        JsonObject role = roles.get(0).getAsJsonObject();
+        assertEquals(role.get("id").getAsString(),validRole.getId().toString(), "Wrong role id");
+        assertEquals(role.get("domain").getAsString(),validRole.getDomain(), "Wrong domain");
+        JsonObject program = result.getAsJsonObject("program");
+        assertEquals(validProgram.getId().toString(), program.get("id").getAsString(), "Wrong program id");
+        assertEquals(validProgram.getName(), program.get("name").getAsString(), "Wrong program name");
+        assertEquals(validProgram.getAbbreviation(), program.get("abbreviation").getAsString(), "Wrong program abbreviation");
+        assertEquals(validProgram.getObjective(), program.get("objective").getAsString(), "Wrong program objective");
+    }
+
+    @Test
+    @Order(6)
+    public void archiveProgramsUsersNotExistingProgramId() {
+        Flowable<HttpResponse<String>> call = client.exchange(
+                DELETE("/programs/"+invalidProgram+"/users/"+invalidProgram).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @Order(6)
+    public void archiveProgramsUsersNotExistingUserId() {
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                DELETE("/programs/"+validProgramId+"/users/"+invalidUser).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @Order(7)
+    @SneakyThrows
+    void getProgramsUsersMultipleUsersSingleRoleSuccess() {
+
+        // create a second user to test with
+        // don't have test database setup yet so doing it this way for now
+        String validProgramId = validProgram.getId().toString();
+
+        UserIdRequest userRequest = UserIdRequest.builder().name("Test2").email("test2@test.com").build();
+        RoleRequest roleRequest = RoleRequest.builder().id(validRole.getId()).build();
+        ArrayList<RoleRequest> rolesList = new ArrayList<>();
+        rolesList.add(roleRequest);
+
+        ProgramUserRequest request = ProgramUserRequest.builder().user(userRequest).roles(rolesList).build();
+        ProgramUser test2 = programUserService.addProgramUser(actingUser, validProgram.getId(), request);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/"+validProgramId+"/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
+        assertEquals(2, meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), "Wrong totalCount");
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        JsonArray data = result.getAsJsonArray("data");
+
+        // may be brittle relying on the ordering
+        //JsonObject programUser = data.get(1).getAsJsonObject();
+        Boolean validUserSeen = false;
+        Boolean test2Seen = false;
+        for (JsonElement jsonProgramUser: data.getAsJsonArray()) {
+            JsonObject programUser = (JsonObject) jsonProgramUser;
+            JsonObject user = programUser.getAsJsonObject("user");
+            User checkUser;
+            if (user.get("id").getAsString().equals(validUser.getId().toString())){
+                validUserSeen = true;
+                checkUser = validUser;
+            } else if (user.get("id").getAsString().equals(test2.getUser().getId().toString())) {
+                test2Seen = true;
+                checkUser = test2.getUser();
+            } else {
+                throw new AssertionFailedError("Unexpected user was returned.");
+            }
+
+            assertEquals(checkUser.getId().toString(), user.get("id").getAsString(), "Wrong user id");
+            assertEquals(checkUser.getName(), user.get("name").getAsString(), "Wrong name");
+            assertEquals(checkUser.getEmail(), user.get("email").getAsString(), "Wrong email");
+            JsonArray roles = programUser.getAsJsonArray("roles");
+            JsonObject role = roles.get(0).getAsJsonObject();
+            assertEquals(validRole.getId().toString(), role.get("id").getAsString(), "Wrong role id");
+            assertEquals(validRole.getDomain(), role.get("domain").getAsString(), "Wrong domain");
+        }
+
+        if (!validUserSeen || !test2Seen){
+            throw new AssertionFailedError("Both users were not returned");
+        }
+
+        // remove user from program and delete user from system
+        programUserService.removeProgramUser(validProgram.getId(), test2.getUser().getId());
+        userService.delete(test2.getUser().getId());
+    }
+
+    @Test
+    @Order(7)
+    public void putProgramsUsersOnlyIdSuccess() {
+        JsonObject requestBody = new JsonObject();
+        JsonObject user = new JsonObject();
+        user.addProperty("id", validUser.getId().toString());
+        JsonObject role = new JsonObject();
+        role.addProperty("id", validRole.getId().toString());
+        JsonArray roles = new JsonArray();
+        roles.add(role);
+        requestBody.add("user", user);
+        requestBody.add("roles", roles);
+        String validProgramId = validProgram.getId().toString();
+        String validUserId = validUser.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+validProgramId+"/users/"+validUserId, requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(8)
+    public void archiveProgramsUsersSuccess() {
+        String validProgramId = validProgram.getId().toString();
+        String validUserId = validUser.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                DELETE("/programs/" + validProgramId + "/users/" + validUserId).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        // Remove program user for following tests since endpoint only archives it.
+        programUserService.removeProgramUser(validProgram.getId(), validUser.getId());
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(9)
+    public void getUsersInactiveNotReturned() {
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/"+validProgramId+"/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
+        assertEquals(meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), 0, "Wrong totalCount");
+    }
+
+    @Test
+    @Order(9)
+    void getProgramsUsersInvalidProgramId() {
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/"+invalidProgram+"/users").cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @Order(9)
+    void getProgramsUsersNoUsers() {
+        String validProgramId = validProgram.getId().toString();
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/"+validProgramId+"/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject meta = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata");
+        assertEquals(meta.getAsJsonObject("pagination").get("totalCount").getAsInt(), 0, "Wrong totalCount");
+
+        JsonArray result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").getAsJsonArray("data");
+        assertEquals(result.size(),0, "Wrong size");
+
+    }
+
+    @Test
+    @Order(9)
+    void getProgramsUsersSingleInvalidProgramId() {
+        String validUserId = validUser.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/"+invalidProgram+"/users/"+validUserId).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @Order(9)
+    void getProgramsUsersSingleInvalidUserId() {
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/"+validProgramId+"/users/"+invalidUser).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @Order(9)
+    void putProgramsUsersInvalidProgramId() {
+        JsonObject requestBody = validProgramUserRequest();
+        String validUserId = validUser.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+invalidProgram+"/users/"+validUserId, requestBody.toString()).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @Order(9)
+    void putProgramsUsersInvalidUserId() {
+        JsonObject requestBody = validProgramUserRequest();
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+validProgramId+"/users/"+invalidUser, requestBody.toString()).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+
+    @Test
+    @Order(9)
+    void putProgramsUsersMissingBody() {
+        String validProgramId = validProgram.getId().toString();
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                PUT("/programs/"+validProgramId+"/users/"+invalidUser, "").cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
+            HttpResponse<String> response = call.blockingFirst();
+        });
+        assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
+    }
+
+    @Test
+    @Order(10)
+    @SneakyThrows
+    public void getProgramUsersQuery() {
+        FannyPack userFp = FannyPack.fill("src/test/resources/sql/UserControllerIntegrationTest.sql");
+        dsl.execute(userFp.get("InsertProgram"));
+        dsl.execute(userFp.get("InsertManyUsers"));
+        dsl.execute(fp.get("InsertManyProgramUsers"),
+                validProgram.getId().toString(), validProgram.getId().toString(),
+                validProgram.getId().toString(), validProgram.getId().toString());
+        List<ProgramUser> allProgramUsers = programUserService.getProgramUsers(validProgram.getId());
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/" + validProgram.getId() + "/users?page=1&pageSize=30&sortField=roles&sortOrder=ASC").cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        JsonArray data = result.get("data").getAsJsonArray();
+
+        assertEquals(allProgramUsers.size(), data.size(), "Wrong page size");
+        TestUtils.checkStringListSorting(getRoles(data), SortOrder.ASC);
+
+        JsonObject pagination = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata").getAsJsonObject("pagination");
+        assertEquals((int) Math.ceil(allProgramUsers.size()/30.0), pagination.get("totalPages").getAsInt(), "Wrong number of pages");
+        assertEquals(allProgramUsers.size(), pagination.get("totalCount").getAsInt(), "Wrong total count");
+        assertEquals(1, pagination.get("currentPage").getAsInt(), "Wrong current page");
+    }
+
+    @Test
+    @Order(11)
+    public void searchProgramUsers() {
+
+        List<ProgramUser> allProgramUsers = programUserDAO.getAllProgramUsers();
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.setFilter(new ArrayList<>());
+        searchRequest.getFilter().add(new FilterRequest("roles", "breed"));
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/" + validProgram.getId() + "/users/search?page=1&pageSize=20&sortField=roles&sortOrder=ASC", searchRequest).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        JsonArray data = result.get("data").getAsJsonArray();
+
+        // Expect 12, user12, user20->user29
+        assertEquals(12, data.size(), "Wrong page size");
+        TestUtils.checkStringListSorting(getRoles(data), SortOrder.ASC);
+
+        JsonObject pagination = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("metadata").getAsJsonObject("pagination");
+        assertEquals(1, pagination.get("totalPages").getAsInt(), "Wrong number of pages");
+        assertEquals(12, pagination.get("totalCount").getAsInt(), "Wrong total count");
+        assertEquals(1, pagination.get("currentPage").getAsInt(), "Wrong current page");
+    }
+
+    private List<List<String>> getRoles(JsonArray data) {
+        List<List<String>> roleResults = new ArrayList<>();
+        for (JsonElement el : data) {
+            JsonObject programUser = (JsonObject) el;
+            JsonArray roles = programUser.get("roles").getAsJsonArray();
+            List<String> userRoles = new ArrayList<>();
+            for (JsonElement roleEl : roles) {
+                JsonObject role = (JsonObject) roleEl;
+                userRoles.add(role.get("domain").getAsString());
+            }
+            Collections.sort(userRoles);
+            roleResults.add(userRoles);
+        }
+        return roleResults;
+    }
+
+    //endregion
 }

--- a/src/test/resources/sql/ProgramControllerIntegrationTest.sql
+++ b/src/test/resources/sql/ProgramControllerIntegrationTest.sql
@@ -16,6 +16,11 @@
  * limitations under the License.
  */
 
+-- name: InsertOtherProgram
+insert into program (species_id, name, abbreviation, documentation_url, objective, created_by, updated_by)
+select species.id, 'Other Test Program', 'test', 'localhost:8080', 'To test things', bi_user.id, bi_user.id from species
+join bi_user on bi_user.name = 'Test User' limit 1
+
 -- name: DeleteProgram
 delete from program_ontology where program_id = ?::uuid;
 delete from program_observation_level where program_id = ?::uuid;

--- a/src/test/resources/sql/TraitControllerIntegrationTest.sql
+++ b/src/test/resources/sql/TraitControllerIntegrationTest.sql
@@ -17,8 +17,8 @@
  */
 
 -- name: InsertProgram
-insert into program (species_id, name, created_by, updated_by)
-select species.id, 'Test Program', bi_user.id, bi_user.id from species
+insert into program (species_id, name, abbreviation, documentation_url, objective, created_by, updated_by)
+select species.id, 'Test Program', 'test', 'localhost:8080', 'To test things', bi_user.id, bi_user.id from species
 join bi_user on bi_user.name = 'system' limit 1
 
 -- name: InsertProgramObservationLevel


### PR DESCRIPTION
Creates brapi program on program create. Updates brapi program on program update. 

When the program is created, it is posted to the default brapi service. When we add the functionality to allow the program to sync with their own brapi service, the program and all other existing data will need to be created in that service. 

I did some rework on the program integration tests because the brapi integration broke a lot of them. Some general clean up is also included because those tests are a pain to use and debug. 