### PR TITLE
[BI-626] - Handle login timeout error

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,6 +57,9 @@ micronaut:
             jwks-uri: ${oauth.openId.jwksUri:`https://sandbox.orcid.org/oauth/jwks`}
             user-info:
               url: ${oauth.openId.userInfoUrl:`https://sandbox.orcid.org/oauth/userinfo`}
+      state:
+        cookie:
+          cookie-max-age: 10m
     token:
       jwt:
         enabled: true
@@ -117,6 +120,8 @@ web:
       url: ${web.base-url:`http://localhost:8080`}/program-selection
     failure:
       url: ${web.base-url:`http://localhost:8080`}/401
+    error:
+      url: ${web.base-url:`http://localhost:8080`}?loginError=true
   logout:
     url: ${web.base-url:`http://localhost:8080`}
 


### PR DESCRIPTION
Fixes issue with the nonce token (a token in the openid handshake that identifies a request upon return to open id requestor) expiring during the login process. The token still expires, but a bad token validation is handled and the user is notified on the front page to try again. I increase the expiration time to 10 minutes (it was 5 minutes). 

I also included a way to log out of open id before beginning the login process. This should be able to handle any Open ID provider if they have a logout URI. The logout url isn't required, and the process skips over that part if the logout attempt fails, or if the url isn't provided in the config. 

# Dependent PRs
https://github.com/Breeding-Insight/bi-web/pull/50

# Testing

1. Try changing the cookie expiration to 1s and check that you get the right page (see below)
2. Try logging in with an OrcID without a BI account, make sure you still get the right not authorized page. Make sure you can log into a good OrcID account after that. 
3. Try logging into an OrcID account, then log out, and then try logging in again. Make sure the orcid page pops up. 

# The way things should look

Here is the message the user gets when the authentication has timed out. 

![screencapture-localhost-8080-2020-10-19-15_28_55](https://user-images.githubusercontent.com/17887341/96508306-65bfea00-1228-11eb-96c1-8454631e6143.png)

Here is a loading wheel I added to the OrcID button after you click it. I added this because we now have two calls in the login process, a BI backend health check and an orcid logout. If they take a few beats it lets the user know we are doing stuff. 
![screencapture-localhost-8080-401-2020-10-19-16_33_04](https://user-images.githubusercontent.com/17887341/96508554-c6e7bd80-1228-11eb-86de-006ac6a6db32.png)

Unchanged is our not authorized screen.  
![screencapture-localhost-8080-2020-10-19-15_27_48](https://user-images.githubusercontent.com/17887341/96508364-7a03e700-1228-11eb-83d8-8b88b444329a.png)

