### PR TITLE
Changing startup/shutdown action to prevent wiping of database

### DIFF
--- a/src/main/resources/brapi/properties/application.properties
+++ b/src/main/resources/brapi/properties/application.properties
@@ -24,7 +24,7 @@ spring.datasource.password=${BRAPI_DB_PASSWORD}
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.hbm2ddl.import_files=sql/species.sql
 


### PR DESCRIPTION
the `ddl-auto` setting was set to create a new database schema on startup, and drop on shutdown.  Changed the setting value to only update on startup, and nothing on shutdown.