### PR TITLE
[BI-85,BI-646] - POST traits from UI

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2336,6 +2336,36 @@ paths:
                 type: string
               example: ERROR - 2018-10-08T20:15:11Z - The requested object DbId is
                 not found
+  /programs/{programId}/observation-levels:
+    get:
+      tags:
+        - observation levels
+      parameters:
+        - name: programId
+          in: path
+          description: The id of the program
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      summary: Get all observation levels in the program
+      description: Get all observation levels in the program
+      operationId: getObservationLevels
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/observationLevelResponse'
+              examples:
+                observationLevelsResponse:
+                  $ref: '#/components/examples/observationLevelResponse'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        "404":
+          $ref: '#/components/responses/404NotFound'
   /programs/{programId}/trait-upload:
     put:
       tags:
@@ -2610,6 +2640,68 @@ paths:
           $ref: '#/components/responses/401Unauthorized'
         "404":
           $ref: '#/components/responses/404NotFound'
+  /programs/{programId}/trait-upload/{traitUploadId}:
+    post:
+      tags:
+        - uploads
+      parameters:
+        - name: programId
+          in: path
+          description: Id of program to get trait upload for
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: traitUploadId
+          in: path
+          description: Id of the trait upload to save
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      summary: Confirm and save existing trait upload as traits
+      description: Confirm and save existing trait upload as traits
+      operationId: postTraitUpload
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/multipleTraitsResponse'
+              examples:
+                multipleTraitsResponse:
+                  $ref: '#/components/examples/arrayOfTraits'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '422':
+          description: Multi-error UnprocessableEntity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/validatorErrorResponse"
+              example:
+                rowErrors:
+                  - rowIndex: 0
+                    errors:
+                      - column: "Trait level"
+                        errorMessage: "Missing trait name"
+                        httpStatus: "UNPROCESSABLE_ENTITY"
+                        httpStatusCode: 422
+                      - column: "Trait abbreviations"
+                        errorMessage: "Abbreviations already exist"
+                        httpStatus: "CONFLICT"
+                        httpStatusCode: 409
+                      - column: "Scale class"
+                        errorMessage: "Missing scale class"
+                        httpStatus: "UNPROCESSABLE_ENTITY"
+                        httpStatusCode: 422
   /health:
     get:
       tags:
@@ -4293,6 +4385,33 @@ components:
                     httpStatusCode:
                       type: integer
                       description: "Http error code"
+    observationLevelResponse:
+      required:
+        - metadata
+        - result
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/metadata'
+        result:
+          type: object
+          properties:
+            data:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  name:
+                    type: string
+                  createdAt:
+                    type: string
+                    format: datetime
+                  updatedAt:
+                    type: string
+                    format: datetime
   responses:
     "400BadRequest":
       description: Bad Request
@@ -5127,6 +5246,27 @@ components:
               active: true
               systemRoles: []
               programRoles: []
+    observationLevelResponse:
+      value:
+        metadata:
+          datafiles: []
+          pagination:
+            currentPage: 1
+            pageSize: 1
+            totalCount: 2
+            totalPages: 1
+          status: []
+        result:
+          data:
+            - id: a2263532-1fa3-29a6-3a66-557f313c8ed6
+              name: Plant
+              createdAt: "2020-06-04T11:05:48-04:00"
+              updatedAt: "2020-06-04T11:05:48-04:00"
+            - id: 37935efa-4c0f-4269-8669-f78d21b26f04
+              name: Plot
+              createdAt: "2020-06-04T11:05:48-04:00"
+              updatedAt: "2020-06-04T11:05:48-04:00"
+
   parameters:
     page:
       description: 'Used to request a specific page of data to be returned.

--- a/src/main/java/org/breedinginsight/api/deserializer/ArrayOfStringDeserializer.java
+++ b/src/main/java/org/breedinginsight/api/deserializer/ArrayOfStringDeserializer.java
@@ -1,0 +1,35 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.api.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ArrayOfStringDeserializer extends JsonDeserializer<String[]> {
+
+    @Override
+    public String[] deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        List<String> filtered = ListOfStringDeserializer.process(p);
+        return filtered.size() > 0 ? filtered.toArray(String[]::new) : null;
+    }
+
+}

--- a/src/main/java/org/breedinginsight/api/deserializer/ListOfStringDeserializer.java
+++ b/src/main/java/org/breedinginsight/api/deserializer/ListOfStringDeserializer.java
@@ -1,0 +1,49 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.api.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.jooq.tools.StringUtils.isBlank;
+
+public class ListOfStringDeserializer extends JsonDeserializer<List<String>> {
+
+    @Override
+    public List<String> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        List<String> filtered = ListOfStringDeserializer.process(p);
+        return filtered.size() > 0 ? filtered : null;
+    }
+
+    public static List<String> process(JsonParser p) throws IOException {
+        List<String> stringList = new ArrayList<>();
+        while (p.nextToken() != JsonToken.END_ARRAY) {
+            String value = p.getValueAsString();
+            if (value != null && !isBlank(value.trim())) {
+                stringList.add(value.trim());
+            }
+        }
+        return stringList;
+    }
+
+}

--- a/src/main/java/org/breedinginsight/api/deserializer/StringDeserializer.java
+++ b/src/main/java/org/breedinginsight/api/deserializer/StringDeserializer.java
@@ -1,0 +1,35 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.api.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+
+import static org.jooq.tools.StringUtils.isBlank;
+
+public class StringDeserializer extends JsonDeserializer<String> {
+
+    @Override
+    public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        String value = p.getValueAsString();
+        return value != null && !isBlank(value.trim()) ? value.trim() : null;
+    }
+}

--- a/src/main/java/org/breedinginsight/api/v1/controller/ProgramController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ProgramController.java
@@ -405,7 +405,7 @@ public class ProgramController {
         }
     }
 
-    @Get("/programs/{programId}/observation_level")
+    @Get("/programs/{programId}/observation-level")
     @Produces(MediaType.APPLICATION_JSON)
     @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
     public HttpResponse<Response<DataResponse<ProgramObservationLevel>>> getProgramObservationLevels(@PathVariable UUID programId)

--- a/src/main/java/org/breedinginsight/api/v1/controller/ProgramController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ProgramController.java
@@ -412,7 +412,7 @@ public class ProgramController {
             throws DoesNotExistException {
         List<ProgramObservationLevel> programObservationLevels = programObservationLevelService.getByProgramId(programId);
 
-        List<org.breedinginsight.api.model.v1.response.metadata.Status> metadataStatus = new ArrayList<>();
+        List<Status> metadataStatus = new ArrayList<>();
         metadataStatus.add(new Status(StatusCode.INFO, "Successful Query"));
         Pagination pagination = new Pagination(programObservationLevels.size(), 1, 1, 0);
         Metadata metadata = new Metadata(pagination, metadataStatus);

--- a/src/main/java/org/breedinginsight/api/v1/controller/ProgramController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ProgramController.java
@@ -405,7 +405,7 @@ public class ProgramController {
         }
     }
 
-    @Get("/programs/{programId}/observation-level")
+    @Get("/programs/{programId}/observation-levels")
     @Produces(MediaType.APPLICATION_JSON)
     @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
     public HttpResponse<Response<DataResponse<ProgramObservationLevel>>> getProgramObservationLevels(@PathVariable UUID programId)

--- a/src/main/java/org/breedinginsight/api/v1/controller/TraitController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/TraitController.java
@@ -124,12 +124,12 @@ public class TraitController {
     public HttpResponse<Response<DataResponse<Trait>>> createTraits(@PathVariable UUID programId, @Body @Valid List<Trait> traits) {
         AuthenticatedUser actingUser = securityService.getUser();
         try {
-            List<Trait> createdTraits = traitService.createTraits(programId, traits, actingUser);
+            List<Trait> createdTraits = traitService.createTraits(programId, traits, actingUser, true);
             List<Status> metadataStatus = new ArrayList<>();
             // Users query successfully
             metadataStatus.add(new Status(StatusCode.INFO, "Successful Query"));
             // Construct our metadata and response
-            Pagination pagination = new Pagination(traits.size(), 1, 1, 0);
+            Pagination pagination = new Pagination(createdTraits.size(), 1, 1, 0);
             Metadata metadata = new Metadata(pagination, metadataStatus);
             Response<DataResponse<Trait>> response = new Response<>(metadata, new DataResponse<>(createdTraits));
             return HttpResponse.ok(response);

--- a/src/main/java/org/breedinginsight/api/v1/controller/TraitUploadController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/TraitUploadController.java
@@ -143,5 +143,23 @@ public class TraitUploadController {
 
     }
 
+    @Post("/programs/{programId}/trait-upload/{traitUploadId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ProgramSecured(roles = {ProgramSecuredRole.BREEDER})
+    public HttpResponse confirmTraitUpload(@PathVariable UUID programId,
+                                           @PathVariable UUID traitUploadId) {
+        try {
+            AuthenticatedUser actingUser = securityService.getUser();
+            traitUploadService.confirmUpload(programId, traitUploadId, actingUser);
+            return HttpResponse.ok();
+        } catch (DoesNotExistException e) {
+            log.info(e.getMessage());
+            return HttpResponse.notFound();
+        } catch (ValidatorException e) {
+            log.info(e.getErrors().toString());
+            HttpResponse response = HttpResponse.status(HttpStatus.UNPROCESSABLE_ENTITY).body(e.getErrors());
+            return response;
+        }
+    }
 
 }

--- a/src/main/java/org/breedinginsight/brapi/v1/services/BrapiObservationVariableService.java
+++ b/src/main/java/org/breedinginsight/brapi/v1/services/BrapiObservationVariableService.java
@@ -68,9 +68,6 @@ public class BrapiObservationVariableService {
         TraitDataType traitDataType;
 
         switch (dataType) {
-            case CODE:
-                traitDataType = TraitDataType.CODE;
-                break;
             case DATE:
                 traitDataType = TraitDataType.DATE;
                 break;

--- a/src/main/java/org/breedinginsight/daos/TraitDAO.java
+++ b/src/main/java/org/breedinginsight/daos/TraitDAO.java
@@ -366,7 +366,7 @@ public class TraitDAO extends TraitDao {
                 .join(updatedByTableAlias).on(TRAIT.UPDATED_BY.eq(updatedByTableAlias.ID));
     }
 
-    public List<Trait> getTraitsByTraitMethodScaleName(UUID programId, List<Trait> traits){
+    public List<Trait> getTraitsByTraitScaleName(UUID programId, List<Trait> traits){
 
         //TODO: Get these from the query as well
         BiUserTable createdByUser = BI_USER.as("createdByUser");
@@ -388,6 +388,7 @@ public class TraitDAO extends TraitDao {
                     .join(PROGRAM_ONTOLOGY).on(TRAIT.PROGRAM_ONTOLOGY_ID.eq(PROGRAM_ONTOLOGY.ID))
                     .join(PROGRAM).on(PROGRAM_ONTOLOGY.PROGRAM_ID.eq(PROGRAM.ID))
                     .join(SCALE).on(TRAIT.SCALE_ID.eq(SCALE.ID)).and(SCALE.SCALE_NAME.like(newTraits.field("new_scale_name")))
+                    .join(METHOD).on(TRAIT.METHOD_ID.eq(METHOD.ID))
                     .where(PROGRAM.ID.eq(programId))
                     .fetch();
 

--- a/src/main/java/org/breedinginsight/model/ProgramUpload.java
+++ b/src/main/java/org/breedinginsight/model/ProgramUpload.java
@@ -41,7 +41,7 @@ import static org.breedinginsight.dao.db.Tables.BATCH_UPLOAD;
 @ToString
 @NoArgsConstructor
 @SuperBuilder(builderMethodName = "uploadBuilder")
-@JsonIgnoreProperties(value = { "createdBy", "updatedBy", "programId", "userId", "id"})
+@JsonIgnoreProperties(value = { "createdBy", "updatedBy", "programId", "userId"})
 public class ProgramUpload<T> extends BatchUploadEntity {
 
     private Program program;

--- a/src/main/java/org/breedinginsight/model/Trait.java
+++ b/src/main/java/org/breedinginsight/model/Trait.java
@@ -17,8 +17,8 @@
 
 package org.breedinginsight.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -26,6 +26,8 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 import lombok.experimental.SuperBuilder;
 import org.brapi.v2.phenotyping.model.BrApiVariable;
+import org.breedinginsight.api.deserializer.ArrayOfStringDeserializer;
+import org.breedinginsight.api.deserializer.ListOfStringDeserializer;
 import org.breedinginsight.dao.db.tables.pojos.TraitEntity;
 import org.jooq.Record;
 
@@ -61,7 +63,14 @@ public class Trait extends TraitEntity {
     @JsonIgnore
     private String entity;
     private String mainAbbreviation;
+    @JsonDeserialize(using = ListOfStringDeserializer.class)
     private List<String> synonyms;
+
+    @Override
+    @JsonDeserialize(using = ArrayOfStringDeserializer.class)
+    public void setAbbreviations(String... abbreviations) {
+        super.setAbbreviations(abbreviations);
+    }
 
     public Trait(TraitEntity traitEntity) {
         this.setId(traitEntity.getId());

--- a/src/main/java/org/breedinginsight/services/ProgramService.java
+++ b/src/main/java/org/breedinginsight/services/ProgramService.java
@@ -126,15 +126,6 @@ public class ProgramService {
                     .build();
             programOntologyDAO.insert(programOntologyEntity);
 
-            //TODO: Remove this insert when we have an endpoint for it
-            ProgramObservationLevelEntity programObservationLevelEntity = ProgramObservationLevelEntity.builder()
-                    .name("Plant")
-                    .programId(programEntity.getId())
-                    .createdBy(actingUser.getId())
-                    .updatedBy(actingUser.getId())
-                    .build();
-            programObservationLevelDAO.insert(programObservationLevelEntity);
-
             // Add program to brapi service
             dao.createProgramBrAPI(createdProgram);
 

--- a/src/main/java/org/breedinginsight/services/TraitUploadService.java
+++ b/src/main/java/org/breedinginsight/services/TraitUploadService.java
@@ -119,8 +119,6 @@ public class TraitUploadService {
             throw new UnsupportedTypeException("Unsupported mime type");
         }
 
-        traitService.assignTraitsProgramObservationLevel(traits, programId);
-
         ValidationErrors validationErrors = new ValidationErrors();
 
         Optional<ValidationErrors> optionalValidationErrors = traitValidator.checkAllTraitValidations(traits, traitValidatorError);
@@ -131,6 +129,8 @@ public class TraitUploadService {
         if (validationErrors.hasErrors()){
             throw new ValidatorException(validationErrors);
         }
+
+        traitService.assignTraitsProgramObservationLevel(traits, programId);
 
         String json = null;
         try {

--- a/src/main/java/org/breedinginsight/services/parsers/trait/TraitFileParser.java
+++ b/src/main/java/org/breedinginsight/services/parsers/trait/TraitFileParser.java
@@ -49,6 +49,8 @@ import javax.inject.Singleton;
 
 import java.util.stream.Collectors;
 
+import static org.jooq.tools.StringUtils.isBlank;
+
 
 // can read file, columns with set of allowable values checked or requirement of particular data format
 // data consistency not checked, must be done by caller
@@ -290,6 +292,7 @@ public class TraitFileParser {
         }
         return Arrays.stream(value.split(LIST_DELIMITER))
                 .map(strVal -> strVal.trim())
+                .filter(s -> !isBlank(s))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
@@ -109,10 +109,4 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
                 "One or more abbreviations is a duplicate of abbreviations. Set of traits with these matching abbreviations found in rows " + matchingRows.toString(),
                 HttpStatus.CONFLICT);
     }
-
-    @Override
-    public ValidationError getTraitLevelDoesNotExist(List<String> availableTraitLevels) {
-        return new ValidationError("Trait level",
-                "Trait level does not exist. Available levels are " + availableTraitLevels.toString(), HttpStatus.NOT_FOUND);
-    }
 }

--- a/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
@@ -85,7 +85,7 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getDuplicateTraitByNamesMsg() {
-        return new ValidationError("Trait name", "Trait name - Scale name - Method name combination already exists", HttpStatus.CONFLICT);
+        return new ValidationError("Trait name", "Trait name - Scale name combination already exists", HttpStatus.CONFLICT);
     }
 
     @Override

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
@@ -85,7 +85,7 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getDuplicateTraitByNamesMsg() {
-        return new ValidationError("traitName", "Trait name - Scale name - Method name combination already exists", HttpStatus.CONFLICT);
+        return new ValidationError("traitName", "Trait name - Scale name combination already exists", HttpStatus.CONFLICT);
     }
 
     @Override

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
@@ -108,10 +108,4 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
                 "One or more abbreviations is a duplicate of abbreviations. Set of traits with these matching abbreviations found in rows " + matchingRows.toString(),
                 HttpStatus.CONFLICT);
     }
-
-    @Override
-    public ValidationError getTraitLevelDoesNotExist(List<String> availableTraitLevels) {
-        return new ValidationError("programObservationLevel.name",
-                "Program Observation Level does not exist. Available levels are " + availableTraitLevels.toString(), HttpStatus.NOT_FOUND);
-    }
 }

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorErrorInterface.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorErrorInterface.java
@@ -19,7 +19,6 @@ package org.breedinginsight.services.validators;
 
 import org.breedinginsight.api.model.v1.response.ValidationError;
 
-import javax.validation.Validation;
 import java.util.List;
 
 public interface TraitValidatorErrorInterface {
@@ -38,5 +37,4 @@ public interface TraitValidatorErrorInterface {
     ValidationError getDuplicateTraitByAbbreviationsMsg();
     ValidationError getDuplicateTraitsByNameInFileMsg(List<Integer> matchingRows);
     ValidationError getDuplicateTraitsByAbbreviationInFileMsg(List<Integer> matchingRows);
-    ValidationError getTraitLevelDoesNotExist(List<String> availableTraitLevels);
 }

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
@@ -240,7 +240,7 @@ public class TraitValidatorService {
     }
 
     private List<Trait> checkForDuplicateTraitsByNames(UUID programId, List<Trait> traits) {
-        return traitDAO.getTraitsByTraitMethodScaleName(programId, traits);
+        return traitDAO.getTraitsByTraitScaleName(programId, traits);
     }
 
     private List<Trait> checkForDuplicatesTraitsByAbbreviation(UUID programId, List<Trait> traits) {

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
@@ -129,8 +129,8 @@ public class TraitValidatorService {
         for (int i = 0; i < traits.size(); i++) {
             Trait trait = traits.get(i);
             Boolean isDuplicate = duplicateNameTraits.stream().filter(duplicateTrait ->
-                    duplicateTrait.getTraitName().toLowerCase().equals(trait.getTraitName().toLowerCase()) &&
-                            duplicateTrait.getScale().getScaleName().toLowerCase().equals(trait.getScale().getScaleName().toLowerCase())
+                    duplicateTrait.getTraitName().toLowerCase().strip().equals(trait.getTraitName().toLowerCase().strip()) &&
+                            duplicateTrait.getScale().getScaleName().toLowerCase().strip().equals(trait.getScale().getScaleName().toLowerCase().strip())
             ).collect(Collectors.toList()).size() > 0;
 
             if (isDuplicate) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,6 +92,8 @@ micronaut:
         path: /logout
 jackson:
   date-format: yyyy-MM-dd'T'HH:mm:ssZ
+  mapper:
+    acceptCaseInsensitiveEnums: true
 flyway:
   datasources:
     default:

--- a/src/main/resources/brapi/sql/species.sql
+++ b/src/main/resources/brapi/sql/species.sql
@@ -20,3 +20,4 @@ INSERT INTO crop (id, crop_name) VALUES ('2', 'Salmon');
 INSERT INTO crop (id, crop_name) VALUES ('3', 'Grape');
 INSERT INTO crop (id, crop_name) VALUES ('4', 'Alfalfa');
 INSERT INTO crop (id, crop_name) VALUES ('5', 'Sweet Potato');
+INSERT INTO crop (id, crop_name) VALUES ('6', 'Trout');

--- a/src/main/resources/db/migration/V0.5.18__remove_code_data_type.sql
+++ b/src/main/resources/db/migration/V0.5.18__remove_code_data_type.sql
@@ -1,0 +1,31 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TYPE data_type RENAME TO data_type_old;
+
+CREATE TYPE "data_type" AS ENUM (
+  'DATE',
+  'DURATION',
+  'NOMINAL',
+  'NUMERICAL',
+  'ORDINAL',
+  'TEXT'
+);
+
+ALTER TABLE scale ALTER COLUMN data_type TYPE data_type USING data_type::text::data_type;
+
+DROP TYPE data_type_old;

--- a/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
@@ -48,7 +48,6 @@ import org.breedinginsight.daos.ProgramUserDAO;
 import org.breedinginsight.daos.UserDAO;
 import org.breedinginsight.model.*;
 import org.breedinginsight.services.*;
-import org.breedinginsight.services.exceptions.UnprocessableEntityException;
 import org.breedinginsight.utilities.email.EmailUtil;
 import org.geojson.Feature;
 import org.geojson.Point;

--- a/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
@@ -2281,6 +2281,22 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
         assertEquals(1, pagination.get("currentPage").getAsInt(), "Wrong current page");
     }
 
+    @Test
+    public void getObservationLevels() {
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/programs/" + otherProgram.getId() + "/observation_level")
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        JsonArray data = result.get("data").getAsJsonArray();
+
+        assertEquals(1, data.size(), "Wrong number of levels returned");
+    }
+
     private List<List<String>> getRoles(JsonArray data) {
         List<List<String>> roleResults = new ArrayList<>();
         for (JsonElement el : data) {

--- a/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
@@ -2284,7 +2284,7 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
     @Test
     public void getObservationLevels() {
         Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/" + otherProgram.getId() + "/observation-level")
+                GET("/programs/" + otherProgram.getId() + "/observation-levels")
                         .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
         );
 

--- a/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ProgramControllerIntegrationTest.java
@@ -2284,7 +2284,7 @@ public class ProgramControllerIntegrationTest extends BrAPITest {
     @Test
     public void getObservationLevels() {
         Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/programs/" + otherProgram.getId() + "/observation_level")
+                GET("/programs/" + otherProgram.getId() + "/observation-level")
                         .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
         );
 

--- a/src/test/java/org/breedinginsight/api/v1/controller/TraitUploadControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/TraitUploadControllerIntegrationTest.java
@@ -115,9 +115,6 @@ public class TraitUploadControllerIntegrationTest extends BrAPITest {
 
         // Retrieve our new data
         validProgram = programDao.findAll().get(0);
-
-        //BiUserEntity user = userDAO.getUserByOrcId(TestTokenValidator.TEST_USER_ORCID).get();
-        //dsl.execute(securityFp.get("InsertProgramRolesBreeder"), user.getId().toString(), validProgram.getId().toString());
     }
 
     @Test

--- a/src/test/resources/sql/ProgramControllerIntegrationTest.sql
+++ b/src/test/resources/sql/ProgramControllerIntegrationTest.sql
@@ -19,7 +19,12 @@
 -- name: InsertOtherProgram
 insert into program (species_id, name, abbreviation, documentation_url, objective, created_by, updated_by)
 select species.id, 'Other Test Program', 'test', 'localhost:8080', 'To test things', bi_user.id, bi_user.id from species
-join bi_user on bi_user.name = 'Test User' limit 1
+join bi_user on bi_user.name = 'Test User' limit 1;
+
+insert into program_observation_level (program_id, name, created_by, updated_by)
+select program.id, 'Plant', bi_user.id, bi_user.id from
+program
+join bi_user on bi_user.name = 'Test User' limit 1;
 
 -- name: DeleteProgram
 delete from program_ontology where program_id = ?::uuid;

--- a/src/test/resources/sql/UploadControllerIntegrationTest.sql
+++ b/src/test/resources/sql/UploadControllerIntegrationTest.sql
@@ -19,7 +19,8 @@
 -- name: InsertProgram
 insert into program (species_id, name, created_by, updated_by)
 select species.id, 'Test Program', bi_user.id, bi_user.id from species
-join bi_user on bi_user.name = 'system' limit 1;
+join bi_user on bi_user.name = 'system' limit 1
+
 
 -- name: InsertProgramUser
 insert into program_user_role(program_id, user_id, role_id, active, created_by, updated_by)

--- a/src/test/resources/sql/brapi/species.sql
+++ b/src/test/resources/sql/brapi/species.sql
@@ -22,3 +22,4 @@ INSERT INTO crop (id, crop_name) VALUES ('2', 'Salmon');
 INSERT INTO crop (id, crop_name) VALUES ('3', 'Grape');
 INSERT INTO crop (id, crop_name) VALUES ('4', 'Alfalfa');
 INSERT INTO crop (id, crop_name) VALUES ('5', 'Sweet Potato');
+INSERT INTO crop (id, crop_name) VALUES ('6', 'Trout');


### PR DESCRIPTION
Some fixes to allow POST traits to work directly from the UI. 

Added an optional deserializer for List<String> and String[] to remove blank strings and nulls from incoming lists. I couldn't figure out how to get it to happen for every List<String>, so I stuck with this method. There is a deserializer for all incoming strings that trims them and replaces them with null if they are blank. 

The trait upload now saves traits by POSTing a confirmation to the trait upload controller, which gets the json from the db and saves that. I could have done this without requiring the upload ID, but having the upload ID makes it more stateless because you are acting on a specific resource. 

Mixes in a bit of BI-686 in this one. I was working on these at the same time so there is a bit of overlap. 