### PR TITLE
[BI-685] - Map backend trait validation errors to front end

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2209,6 +2209,21 @@ paths:
                         errorMessage: "Missing scale data type"
                         httpStatus: "UNPROCESSABLE_ENTITY"
                         httpStatusCode: 422
+                      - field: "scale.categories"
+                        errorMessage: "Scale categories contain errors"
+                        httpStatus: "UNPROCESSABLE_ENTITY"
+                        httpStatusCode: 422
+                        rowErrors:
+                          - rowIndex: 0
+                            errors:
+                              - field: "scale.categories.label"
+                                errorMessage: "Missing value"
+                                httpStatus: "UNPROCESSABLE_ENTITY"
+                                httpStatusCode: 422
+                              - field: "scale.categories.value"
+                                errorMessage: "Missing value"
+                                httpStatus: "UNPROCESSABLE_ENTITY"
+                                httpStatusCode: 422
   /programs/{programId}/traits/search:
     post:
       tags:
@@ -4385,6 +4400,28 @@ components:
                     httpStatusCode:
                       type: integer
                       description: "Http error code"
+                    rowErrors:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          errors:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                field:
+                                  type: string
+                                  description: "Field name that is the source of the error"
+                                errorMessage:
+                                  type: string
+                                  description: "A description fo the error"
+                                httpStatus:
+                                  type: string
+                                  description: "Text representation fo the error code"
+                                httpStatusCode:
+                                  type: integer
+                                  description: "Http error code"
     observationLevelResponse:
       required:
         - metadata

--- a/src/main/java/org/breedinginsight/daos/TraitDAO.java
+++ b/src/main/java/org/breedinginsight/daos/TraitDAO.java
@@ -380,7 +380,7 @@ public class TraitDAO extends TraitDao {
 
             Result<Record> records = dsl.select()
                     .from(newTraits)
-                    .join(TRAIT).on(TRAIT.TRAIT_NAME.likeIgnoreCase(newTraits.field("new_trait_name")))
+                    .join(TRAIT).on(TRAIT.TRAIT_NAME.upper().equalIgnoreCase(newTraits.field("new_trait_name")))
                     .join(PROGRAM_ONTOLOGY).on(TRAIT.PROGRAM_ONTOLOGY_ID.eq(PROGRAM_ONTOLOGY.ID))
                     .join(PROGRAM).on(PROGRAM_ONTOLOGY.PROGRAM_ID.eq(PROGRAM.ID))
                     .join(SCALE).on(TRAIT.SCALE_ID.eq(SCALE.ID))

--- a/src/main/java/org/breedinginsight/daos/TraitDAO.java
+++ b/src/main/java/org/breedinginsight/daos/TraitDAO.java
@@ -383,11 +383,17 @@ public class TraitDAO extends TraitDao {
                     .join(TRAIT).on(TRAIT.TRAIT_NAME.likeIgnoreCase(newTraits.field("new_trait_name")))
                     .join(PROGRAM_ONTOLOGY).on(TRAIT.PROGRAM_ONTOLOGY_ID.eq(PROGRAM_ONTOLOGY.ID))
                     .join(PROGRAM).on(PROGRAM_ONTOLOGY.PROGRAM_ID.eq(PROGRAM.ID))
+                    .join(SCALE).on(TRAIT.SCALE_ID.eq(SCALE.ID))
+                    .join(METHOD).on(TRAIT.METHOD_ID.eq(METHOD.ID))
                     .where(PROGRAM.ID.eq(programId))
                     .fetch();
 
             for (Record record: records) {
                 Trait trait = Trait.parseSqlRecord(record);
+                Scale scale = Scale.parseSqlRecord(record);
+                Method method = Method.parseSqlRecord(record);
+                trait.setScale(scale);
+                trait.setMethod(method);
                 traitResults.add(trait);
             }
         }

--- a/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
@@ -85,7 +85,7 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getBadScaleCategory() {
-        return new ValidationError("scale.categories", "Scale categories contain errors", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Scale categories", "Scale categories contain errors", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
@@ -203,7 +203,7 @@ public class TraitValidatorService {
         for (Integer i = 0; i < traits.size(); i++) {
             Trait trait = traits.get(i);
             if (trait.getTraitName() != null){
-                String key = String.format("%s", trait.getTraitName().toLowerCase());
+                String key = trait.getTraitName().toLowerCase();
                 if (namesMap.containsKey(key)) {
                     namesMap.get(key).add(i);
                 } else {


### PR DESCRIPTION
Changes unique trait check to be determined on by trait name. 

Updates to the validation errors so that you can indefinitely nest errors. This was needed to parse errors for specific categories. Here is an example of the new error format:

![screencapture-jsonviewer-stack-hu-2020-12-14-13_33_37](https://user-images.githubusercontent.com/17887341/102120797-0558bd80-3e11-11eb-8817-e7009a06f651.png)
