### PR TITLE
[BI-714] .env variables in default file are out of date

### DIFF
--- a/.env
+++ b/.env
@@ -28,14 +28,14 @@ API_INTERNAL_TEST_PORT=8082
 BRAPI_SERVER_PORT=8083
 
 # Brapi Server Variables
-BRAPI_CORE_URL=http://localhost:8083/
-BRAPI_PHENO_URL=http://localhost:8083/
-BRAPI_GENO_URL=http://localhost:8083/
+BRAPI_CORE_URL=http://brapiserver:8080/
+BRAPI_PHENO_URL=http://brapiserver:8080/
+BRAPI_GENO_URL=http://brapiserver:8080/
 BRAPI_REFERENCE_SOURCE=breeding-insight.org
 
 WEB_BASE_URL=http://localhost:8080
 
 # Email server
-EMAIL_RELAY_HOST=localhost
+EMAIL_RELAY_HOST=mailhog
 EMAIL_RELAY_PORT=1025
 EMAIL_FROM=bidevteam@cornell.edu


### PR DESCRIPTION
# Brapi Clients Variables
BRAPI_CORE_URL=http://brapiserver:8080
BRAPI_PHENO_URL=http://brapiserver:8080
BRAPI_GENO_URL=http://brapiserver:8080

# Email server
EMAIL_RELAY_HOST=mailhog