### PR TITLE
[BI-765] - Set up endpoint to GET import configs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,11 @@
             <version>4.3</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.12</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/org/breedinginsight/api/v1/controller/ImportController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ImportController.java
@@ -52,8 +52,6 @@ public class ImportController {
     @Secured(SecurityRule.IS_ANONYMOUS)
     @AddMetadata
     public HttpResponse<Response<DataResponse<ImportConfig>>> getImportTypes() {
-        // TODO: Retrieve all of them.
-        // TODO: Retrieve all of import classes based on annotation in factory
         List<ImportConfig> configs = importManager.getAllTypeConfigs();
 
         //TODO: Add actual page size

--- a/src/main/java/org/breedinginsight/api/v1/controller/ImportController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ImportController.java
@@ -54,7 +54,7 @@ public class ImportController {
     public HttpResponse<Response<DataResponse<ImportConfig>>> getImportTypes() {
         // TODO: Retrieve all of them.
         // TODO: Retrieve all of import classes based on annotation in factory
-        List<ImportConfig> configs = List.of(importManager.getTypeConfig(GermplasmImport.class));
+        List<ImportConfig> configs = importManager.getAllTypeConfigs();
 
         //TODO: Add actual page size
         List<Status> metadataStatus = new ArrayList<>();

--- a/src/main/java/org/breedinginsight/api/v1/controller/ImportController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ImportController.java
@@ -1,0 +1,69 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.api.v1.controller;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.rules.SecurityRule;
+import lombok.extern.slf4j.Slf4j;
+import org.breedinginsight.api.model.v1.response.DataResponse;
+import org.breedinginsight.api.model.v1.response.Response;
+import org.breedinginsight.api.model.v1.response.metadata.Metadata;
+import org.breedinginsight.api.model.v1.response.metadata.Pagination;
+import org.breedinginsight.api.model.v1.response.metadata.Status;
+import org.breedinginsight.api.model.v1.response.metadata.StatusCode;
+import org.breedinginsight.api.v1.controller.metadata.AddMetadata;
+import org.breedinginsight.model.brapi_import.BrAPIImportConfigManager;
+import org.breedinginsight.model.brapi_import.imports.GermplasmImport;
+import org.breedinginsight.model.brapi_import.response.ImportConfig;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Controller("/${micronaut.bi.api.version}")
+public class ImportController {
+
+    @Inject
+    BrAPIImportConfigManager importManager;
+
+    @Get("/import/types")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Secured(SecurityRule.IS_ANONYMOUS)
+    @AddMetadata
+    public HttpResponse<Response<DataResponse<ImportConfig>>> getImportTypes() {
+        // TODO: Retrieve all of them.
+        // TODO: Retrieve all of import classes based on annotation in factory
+        List<ImportConfig> configs = List.of(importManager.getTypeConfig(GermplasmImport.class));
+
+        //TODO: Add actual page size
+        List<Status> metadataStatus = new ArrayList<>();
+        metadataStatus.add(new Status(StatusCode.INFO, "Successful Query"));
+        Pagination pagination = new Pagination(1, 1, 1, 0);
+        Metadata metadata = new Metadata(pagination, metadataStatus);
+
+        Response<DataResponse<ImportConfig>> response = new Response(metadata, new DataResponse<>(configs));
+        return HttpResponse.ok(response);
+    }
+
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/BrAPIImportConfigManager.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/BrAPIImportConfigManager.java
@@ -1,0 +1,168 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import;
+
+import io.micronaut.context.annotation.Context;
+import org.breedinginsight.model.brapi_import.config.*;
+import org.breedinginsight.model.brapi_import.imports.BrAPIImport;
+import org.breedinginsight.model.brapi_import.imports.ImportMetadata;
+import org.breedinginsight.model.brapi_import.response.ImportConfig;
+import org.breedinginsight.model.brapi_import.response.ImportFieldConfig;
+import org.breedinginsight.model.brapi_import.response.ImportObjectConfig;
+import org.breedinginsight.model.brapi_import.response.ImportRelationOptionConfig;
+
+import javax.inject.Singleton;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+@Context
+@Singleton
+public class BrAPIImportConfigManager {
+
+    private List<BrAPIImport> brAPIImports;
+
+    BrAPIImportConfigManager() {
+        // TODO: Get all classes with annotation here and assign to brapiImport
+        // TODO: Write test that checks entire json
+    }
+
+    public List<ImportConfig> getAllTypeConfigs() {
+        List<ImportConfig> configs = new ArrayList<>();
+        for (BrAPIImport brAPIImport: brAPIImports){
+            configs.add(getTypeConfig(brAPIImport.getClass()));
+        }
+        return configs;
+    }
+
+    public ImportConfig getTypeConfig(Class c) {
+
+        Field[] objectFields = c.getDeclaredFields();
+        ImportMetadata metadata = (ImportMetadata) c.getAnnotation(ImportMetadata.class);
+        ImportConfig importConfig = new ImportConfig();
+        importConfig.setId(metadata.id());
+        importConfig.setName(metadata.name());
+        importConfig.setDescription(metadata.description());
+
+        // Construct the objects in brapi
+        List<ImportObjectConfig> importObjectConfigs = new ArrayList<>();
+        for (Field objectField: objectFields) {
+            ImportObjectConfig objectConfig = constructObjectConfig(objectField);
+            importObjectConfigs.add(objectConfig);
+        }
+
+        importConfig.setObjects(importObjectConfigs);
+        return importConfig;
+    }
+
+    private ImportObjectConfig constructObjectConfig(Field objectField) {
+        ImportFieldMetadata fieldMetadata = objectField.getAnnotation(ImportFieldMetadata.class);
+        Class c = objectField.getType();
+        ImportFieldMetadata classMetadata = (ImportFieldMetadata) c.getAnnotation(ImportFieldMetadata.class);
+        ImportFieldRequired required = objectField.getAnnotation(ImportFieldRequired.class);
+        ImportObjectConfig config = new ImportObjectConfig();
+        config.setId(fieldMetadata != null ? fieldMetadata.id() : classMetadata.id());
+        config.setName(fieldMetadata != null ? fieldMetadata.name() : classMetadata.name());
+        config.setDescription(fieldMetadata != null ? fieldMetadata.description() : classMetadata.description());
+        config.setRequired(required != null);
+
+        List<ImportFieldConfig> fieldConfigs = getObjectFields(objectField.getType());
+        config.setFields(fieldConfigs);
+
+        return config;
+    }
+
+    private List<ImportFieldConfig> getObjectFields(Class c) {
+
+        List<ImportFieldConfig> fieldConfigs = new ArrayList<>();
+        Field[] fields = c.getDeclaredFields();
+        // Go through the fields of the object. Might need some recursion here
+        for (Field field: fields) {
+
+            // Construct field based on type
+            ImportType fieldType = field.getAnnotation(ImportType.class);
+            ImportFieldConfig fieldConfig;
+            if (fieldType.type() == ImportFieldType.LIST){
+                fieldConfig = constructListField(field);
+            } else if (fieldType.type() == ImportFieldType.RELATIONSHIP) {
+                fieldConfig = constructRelationField(field);
+            } else {
+                fieldConfig = constructFieldConfig(field);
+            }
+
+            fieldConfigs.add(fieldConfig);
+        }
+        return fieldConfigs;
+    }
+
+    private ImportFieldConfig constructFieldConfig(Field field) {
+
+        ImportFieldMetadata metadata = field.getAnnotation(ImportFieldMetadata.class);
+        ImportType fieldType = field.getAnnotation(ImportType.class);
+        ImportFieldRequired required = field.getAnnotation(ImportFieldRequired.class);
+        ImportFieldConfig fieldConfig = new ImportFieldConfig();
+        fieldConfig.setId(metadata.id());
+        fieldConfig.setName(metadata.name());
+        fieldConfig.setDescription(metadata.description());
+        fieldConfig.setType(fieldType.type());
+        fieldConfig.setRequired(required != null);
+        return fieldConfig;
+    }
+
+    private ImportFieldConfig constructRelationField(Field field) {
+        ImportFieldConfig fieldConfig = constructFieldConfig(field);
+
+        ImportFieldRelations relations = field.getAnnotation(ImportFieldRelations.class);
+        List<ImportRelationOptionConfig> relationConfigs = new ArrayList<>();
+        for (ImportFieldRelation relation: relations.relations()) {
+            ImportRelationOptionConfig relationConfig = new ImportRelationOptionConfig();
+            relationConfig.setId(relation.type().getId());
+            relationConfig.setName(relation.type().getName());
+            relationConfig.setDescription(relation.description() != null ? relation.description() : relation.type().getDefaultDescription());
+
+            // Relation type specific logic
+            if (relation.type() == ImportRelationType.DB_LOOKUP) {
+                relationConfig.setImportFields(relation.importFields());
+            }
+
+            relationConfigs.add(relationConfig);
+        }
+
+        fieldConfig.setRelationOptions(relationConfigs);
+        return fieldConfig;
+    }
+
+    private ImportFieldConfig constructListField(Field field) {
+        ImportFieldConfig fieldConfig = constructFieldConfig(field);
+        ImportType fieldType = field.getAnnotation(ImportType.class);
+        Class listType = fieldType.clazz();
+
+        // Get descriptions of the class
+        ImportFieldMetadata classMetadata = (ImportFieldMetadata) listType.getAnnotation(ImportFieldMetadata.class);
+        ImportObjectConfig listObject = new ImportObjectConfig();
+        listObject.setId(classMetadata.id());
+        listObject.setName(classMetadata.name());
+        listObject.setDescription(classMetadata.description());
+        List<ImportFieldConfig> fields = getObjectFields(listType);
+        listObject.setFields(fields);
+
+        fieldConfig.setListObject(listObject);
+
+        return fieldConfig;
+    }
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/BrAPIImportConfigManager.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/BrAPIImportConfigManager.java
@@ -25,27 +25,30 @@ import org.breedinginsight.model.brapi_import.response.ImportConfig;
 import org.breedinginsight.model.brapi_import.response.ImportFieldConfig;
 import org.breedinginsight.model.brapi_import.response.ImportObjectConfig;
 import org.breedinginsight.model.brapi_import.response.ImportRelationOptionConfig;
+import org.reflections.Reflections;
 
 import javax.inject.Singleton;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Context
 @Singleton
 public class BrAPIImportConfigManager {
 
-    private List<BrAPIImport> brAPIImports;
+    private Set<Class<?>> brAPIImports;
 
     BrAPIImportConfigManager() {
-        // TODO: Get all classes with annotation here and assign to brapiImport
-        // TODO: Write test that checks entire json
+        // Get all imports
+        Reflections reflections = new Reflections("org.breedinginsight");
+        brAPIImports = reflections.getTypesAnnotatedWith(ImportMetadata.class);
     }
 
     public List<ImportConfig> getAllTypeConfigs() {
         List<ImportConfig> configs = new ArrayList<>();
-        for (BrAPIImport brAPIImport: brAPIImports){
-            configs.add(getTypeConfig(brAPIImport.getClass()));
+        for (Class brAPIImport: brAPIImports){
+            configs.add(getTypeConfig(brAPIImport));
         }
         return configs;
     }

--- a/src/main/java/org/breedinginsight/model/brapi_import/BrAPIImportConfigManager.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/BrAPIImportConfigManager.java
@@ -19,7 +19,6 @@ package org.breedinginsight.model.brapi_import;
 
 import io.micronaut.context.annotation.Context;
 import org.breedinginsight.model.brapi_import.config.*;
-import org.breedinginsight.model.brapi_import.imports.BrAPIImport;
 import org.breedinginsight.model.brapi_import.imports.ImportMetadata;
 import org.breedinginsight.model.brapi_import.response.ImportConfig;
 import org.breedinginsight.model.brapi_import.response.ImportFieldConfig;
@@ -79,6 +78,7 @@ public class BrAPIImportConfigManager {
         ImportFieldMetadata classMetadata = (ImportFieldMetadata) c.getAnnotation(ImportFieldMetadata.class);
         ImportFieldRequired required = objectField.getAnnotation(ImportFieldRequired.class);
         ImportObjectConfig config = new ImportObjectConfig();
+        // Use the default metadata on the class if their isn't anything on the field level
         config.setId(fieldMetadata != null ? fieldMetadata.id() : classMetadata.id());
         config.setName(fieldMetadata != null ? fieldMetadata.name() : classMetadata.name());
         config.setDescription(fieldMetadata != null ? fieldMetadata.description() : classMetadata.description());
@@ -136,7 +136,7 @@ public class BrAPIImportConfigManager {
             ImportRelationOptionConfig relationConfig = new ImportRelationOptionConfig();
             relationConfig.setId(relation.type().getId());
             relationConfig.setName(relation.type().getName());
-            relationConfig.setDescription(relation.description() != null ? relation.description() : relation.type().getDefaultDescription());
+            relationConfig.setDescription(!relation.description().isEmpty() ? relation.description() : relation.type().getDefaultDescription());
 
             // Relation type specific logic
             if (relation.type() == ImportRelationType.DB_LOOKUP) {

--- a/src/main/java/org/breedinginsight/model/brapi_import/base/Cross.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/base/Cross.java
@@ -1,0 +1,21 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.base;
+
+public class Cross {
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/base/Cross.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/base/Cross.java
@@ -17,5 +17,25 @@
 
 package org.breedinginsight.model.brapi_import.base;
 
+import org.breedinginsight.model.brapi_import.config.*;
+
+import java.util.List;
+
+@ImportFieldMetadata(id="Cross", name="Cross",
+        description = "A cross connects two germplasm objects to form a pedigree.")
 public class Cross {
+
+    @ImportType(type= ImportFieldType.TEXT)
+    @ImportFieldMetadata(id="crossName", name="Cross Name",
+            description = "Name of the cross.")
+    private String crossName;
+
+    @ImportType(type= ImportFieldType.RELATIONSHIP)
+    @ImportFieldRelations(relations={
+            @ImportFieldRelation(type = ImportRelationType.FILE_LOOKUP),
+            @ImportFieldRelation(type = ImportRelationType.DB_LOOKUP, importFields={"germplasmDbId"})
+    })
+    @ImportFieldMetadata(id="femaleParent", name="Female Parent",
+            description = "Name of the cross.")
+    private ImportRelation femaleParent;
 }

--- a/src/main/java/org/breedinginsight/model/brapi_import/base/ExternalReference.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/base/ExternalReference.java
@@ -31,7 +31,7 @@ public class ExternalReference {
     private String referenceID;
 
     @ImportType(type=ImportFieldType.TEXT)
-    @ImportFieldMetadata(id="referenceID", name="External Reference Source",
-            description = "This describes the source of the external reference ID.")
+    @ImportFieldMetadata(id="referenceSource", name="External Reference Source",
+            description = "This describes the source of the external reference.")
     private String referenceSource;
 }

--- a/src/main/java/org/breedinginsight/model/brapi_import/base/ExternalReference.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/base/ExternalReference.java
@@ -1,0 +1,37 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.base;
+
+import org.breedinginsight.model.brapi_import.config.ImportFieldMetadata;
+import org.breedinginsight.model.brapi_import.config.ImportFieldType;
+import org.breedinginsight.model.brapi_import.config.ImportType;
+
+@ImportFieldMetadata(id="ExternalReference", name="External Reference",
+        description = "An object that tracks connections to external data sets.")
+public class ExternalReference {
+
+    @ImportType(type= ImportFieldType.TEXT)
+    @ImportFieldMetadata(id="referenceID", name="External Reference ID",
+            description = "An id to an external reference. This is commonly used to save original ids of datasets that are imported, for later reference.")
+    private String referenceID;
+
+    @ImportType(type=ImportFieldType.TEXT)
+    @ImportFieldMetadata(id="referenceID", name="External Reference Source",
+            description = "This describes the source of the external reference ID.")
+    private String referenceSource;
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/base/Germplasm.java
@@ -1,0 +1,38 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.base;
+
+import lombok.Getter;
+import org.breedinginsight.model.brapi_import.config.ImportFieldMetadata;
+import org.breedinginsight.model.brapi_import.config.ImportFieldType;
+import org.breedinginsight.model.brapi_import.config.ImportType;
+
+@Getter
+@ImportFieldMetadata(id="Germplasm", name="Germplasm",
+        description = "A germplasm object corresponds to a non-physical entity and is used to track a unique genetic composition. This is commonly used for populations.")
+public class Germplasm {
+
+    @ImportType(type= ImportFieldType.TEXT)
+    @ImportFieldMetadata(id="germplasmName", name="Germplasm Name", description = "Name of germplasm")
+    private String germplasmName;
+
+    @ImportType(type=ImportFieldType.LIST, clazz=ExternalReference.class)
+    @ImportFieldMetadata(id="externalReferences", name="External References",
+            description = "External references to track external IDs.")
+    private ExternalReference[] externalReferences;
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldMetadata.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldMetadata.java
@@ -1,0 +1,32 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.TYPE})
+public @interface ImportFieldMetadata {
+    // Can be used on the class level, or overwritten by an annotation on the field level
+    String id();
+    String name();
+    String description();
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldRelation.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldRelation.java
@@ -1,0 +1,24 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.config;
+
+public @interface ImportFieldRelation {
+    String description();
+    ImportRelationType type();
+    String[] importFields();
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldRelation.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldRelation.java
@@ -18,7 +18,8 @@
 package org.breedinginsight.model.brapi_import.config;
 
 public @interface ImportFieldRelation {
-    String description();
+    String description() default "";
     ImportRelationType type();
-    String[] importFields();
+    // Used for database lookups
+    String[] importFields() default {};
 }

--- a/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldRelations.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldRelations.java
@@ -1,0 +1,29 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ImportFieldRelations {
+    ImportFieldRelation[] relations();
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldRequired.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldRequired.java
@@ -1,0 +1,28 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ImportFieldRequired {
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldType.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldType.java
@@ -17,13 +17,16 @@
 
 package org.breedinginsight.model.brapi_import.config;
 
+import lombok.Getter;
+
+@Getter
 public enum ImportFieldType {
-    TEXT("Text"),
-    NUMERICAL("Numerical"),
-    INTEGER("Integer"),
-    DATE("Date"),
-    LIST("List"),
-    RELATIONSHIP("Relationship");
+    TEXT("TEXT"),
+    NUMERICAL("NUMERICAL"),
+    INTEGER("INTEGER"),
+    DATE("DATE"),
+    LIST("LIST"),
+    RELATIONSHIP("RELATIONSHIP");
 
     private String value;
 

--- a/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldType.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/config/ImportFieldType.java
@@ -1,0 +1,33 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.config;
+
+public enum ImportFieldType {
+    TEXT("Text"),
+    NUMERICAL("Numerical"),
+    INTEGER("Integer"),
+    DATE("Date"),
+    LIST("List"),
+    RELATIONSHIP("Relationship");
+
+    private String value;
+
+    ImportFieldType(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/config/ImportRelation.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/config/ImportRelation.java
@@ -17,15 +17,12 @@
 
 package org.breedinginsight.model.brapi_import.config;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import lombok.Getter;
+import lombok.Setter;
 
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
-public @interface ImportType {
-    ImportFieldType type();
-    // Indicates class type of list objects
-    Class clazz() default Object.class;
+@Getter
+@Setter
+public class ImportRelation {
+    private String target;
+    private String reference;
 }

--- a/src/main/java/org/breedinginsight/model/brapi_import/config/ImportRelationType.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/config/ImportRelationType.java
@@ -1,0 +1,36 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.config;
+
+import lombok.Getter;
+
+@Getter
+public enum ImportRelationType {
+    DB_LOOKUP("DB_LOOKUP", "Database Lookup", "Specify the lookup value from the list of options, and the column in the file to map to. If the object isn't found, we will throw an error"),
+    FILE_LOOKUP("FILE_LOOKUP", "File Lookup", "Specify a column with a unique id that references a matching id within this file. If the object isn't found we will throw an error.");
+
+    private String id;
+    private String name;
+    private String defaultDescription;
+
+    ImportRelationType(String id, String name, String defaultDescription) {
+        this.id = id;
+        this.name = name;
+        this.defaultDescription = defaultDescription;
+    }
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/config/ImportType.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/config/ImportType.java
@@ -1,0 +1,30 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ImportType {
+    ImportFieldType type();
+    Class clazz() default Object.class;
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/imports/BrAPIImport.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/imports/BrAPIImport.java
@@ -1,0 +1,21 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.imports;
+
+public interface BrAPIImport {
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/imports/GermplasmImport.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/imports/GermplasmImport.java
@@ -17,6 +17,7 @@
 
 package org.breedinginsight.model.brapi_import.imports;
 
+import org.breedinginsight.model.brapi_import.base.Cross;
 import org.breedinginsight.model.brapi_import.base.Germplasm;
 
 
@@ -25,4 +26,5 @@ import org.breedinginsight.model.brapi_import.base.Germplasm;
 public class GermplasmImport implements BrAPIImport {
 
     private Germplasm germplasm;
+    private Cross cross;
 }

--- a/src/main/java/org/breedinginsight/model/brapi_import/imports/GermplasmImport.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/imports/GermplasmImport.java
@@ -1,0 +1,28 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.imports;
+
+import org.breedinginsight.model.brapi_import.base.Germplasm;
+
+
+@ImportMetadata(id="GermplasmImport", name="Germplasm",
+        description = "This import is used to import germplasm and to create crosses to connect germplasm together in order to construct a pedigree.")
+public class GermplasmImport implements BrAPIImport {
+
+    private Germplasm germplasm;
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/imports/ImportMetadata.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/imports/ImportMetadata.java
@@ -1,0 +1,31 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.imports;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ImportMetadata {
+    String id();
+    String name();
+    String description();
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/response/ImportConfig.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/response/ImportConfig.java
@@ -1,0 +1,32 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ImportConfig {
+    private String id;
+    private String name;
+    private String description;
+    private List<ImportObjectConfig> objects;
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/response/ImportFieldConfig.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/response/ImportFieldConfig.java
@@ -1,0 +1,36 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.breedinginsight.model.brapi_import.config.ImportFieldType;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ImportFieldConfig {
+    private String name;
+    private String id;
+    private String description;
+    private ImportFieldType type;
+    private Boolean required;
+    private ImportObjectConfig listObject;
+    private List<ImportRelationOptionConfig> relationOptions;
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/response/ImportObjectConfig.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/response/ImportObjectConfig.java
@@ -1,0 +1,33 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ImportObjectConfig {
+    private String name;
+    private String id;
+    private String description;
+    private Boolean required;
+    private List<ImportFieldConfig> fields;
+}

--- a/src/main/java/org/breedinginsight/model/brapi_import/response/ImportRelationOptionConfig.java
+++ b/src/main/java/org/breedinginsight/model/brapi_import/response/ImportRelationOptionConfig.java
@@ -1,0 +1,30 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model.brapi_import.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class ImportRelationOptionConfig {
+    private String name;
+    private String id;
+    private String description;
+    private String[] importFields;
+}


### PR DESCRIPTION
Endpoint is running as expected. There is another card to configure the germplasm import. We can add more imports as we need them. 

https://breedinginsight.atlassian.net/browse/BI-768

This implementation is driven by some reflection and mainly annotations in order to generate the import configs. The idea is that we can generate all of the base brapi objects like germplasm, cross, in a flattened form (no nesting) so then be used to generate the configs. That way our code is also our config. Each import type will handle the construction and POSTing of brapi objects in a `process()` method (more to come later). 

I am not writing tests yet. I'll do that once I have the whole flow finished (saving mapping, posting to brapi, etc). I'm doing this just so I can see the whole flow implementation, and then decide what needs to be tested. 

I am also going to do api docs later in case the json structure changes. This way I can minimize time restructuring json structure. 

Future Ideas: 
- Tim was going to look into a way that we could run some micronaut code on startup to generate the type config on startup so that we didn't need to do it on every call. 
- Right now I get all the imports using a `Reflections` library and looking for an annotation. There might be a way to do this with micronaut. 