### PR TITLE
BI-741 - Create BrAPI v2 Proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.15.1</version>
+            <version>1.15.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/breedinginsight/brapi/v1/controller/BrapiAuthorizeController.java
+++ b/src/main/java/org/breedinginsight/brapi/v1/controller/BrapiAuthorizeController.java
@@ -26,28 +26,35 @@ import io.micronaut.http.uri.UriBuilder;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import lombok.extern.slf4j.Slf4j;
+import org.breedinginsight.daos.ProgramDAO;
 
+import javax.inject.Inject;
 import javax.validation.constraints.NotBlank;
 import java.net.URI;
+import java.util.UUID;
 
 @Slf4j
 @Controller("/${micronaut.bi.api.version}")
 public class BrapiAuthorizeController {
 
+    @Inject
+    private ProgramDAO programDAO;
+
     @Property(name = "web.base-url")
     protected String webBaseUrl;
-
 
     @Get("/programs/{programId}/brapi/authorize")
     @Secured(SecurityRule.IS_ANONYMOUS)
     public HttpResponse authorize(@QueryValue @NotBlank String display_name, @QueryValue @NotBlank String return_url, @PathVariable("programId") String programId) {
+        if(programDAO.existsById(UUID.fromString(programId))) {
+            URI location = UriBuilder.of(String.format("%s/programs/%s/brapi/authorize", webBaseUrl, programId))
+                                     .queryParam("display_name", display_name)
+                                     .queryParam("return_url", return_url)
+                                     .build();
+            return HttpResponse.seeOther(location);
+        }
 
-        URI location = UriBuilder.of(String.format("%s/programs/%s/brapi/authorize", webBaseUrl, programId))
-                .queryParam("display_name", display_name)
-                .queryParam("return_url", return_url)
-                .build();
-        return HttpResponse.seeOther(location);
-
+        return HttpResponse.notFound();
     }
 
 }

--- a/src/main/java/org/breedinginsight/brapi/v1/controller/BrapiAuthorizeController.java
+++ b/src/main/java/org/breedinginsight/brapi/v1/controller/BrapiAuthorizeController.java
@@ -46,15 +46,11 @@ public class BrapiAuthorizeController {
     @Get("/programs/{programId}/brapi/authorize")
     @Secured(SecurityRule.IS_ANONYMOUS)
     public HttpResponse authorize(@QueryValue @NotBlank String display_name, @QueryValue @NotBlank String return_url, @PathVariable("programId") String programId) {
-        if(programDAO.existsById(UUID.fromString(programId))) {
-            URI location = UriBuilder.of(String.format("%s/programs/%s/brapi/authorize", webBaseUrl, programId))
-                                     .queryParam("display_name", display_name)
-                                     .queryParam("return_url", return_url)
-                                     .build();
-            return HttpResponse.seeOther(location);
-        }
-
-        return HttpResponse.notFound();
+        URI location = UriBuilder.of(String.format("%s/programs/%s/brapi/authorize", webBaseUrl, programId))
+                                 .queryParam("display_name", display_name)
+                                 .queryParam("return_url", return_url)
+                                 .build();
+        return HttpResponse.seeOther(location);
     }
 
 }

--- a/src/main/java/org/breedinginsight/brapi/v1/controller/BrapiAuthorizeController.java
+++ b/src/main/java/org/breedinginsight/brapi/v1/controller/BrapiAuthorizeController.java
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.uri.UriBuilder;
 import io.micronaut.security.annotation.Secured;
@@ -30,18 +31,18 @@ import javax.validation.constraints.NotBlank;
 import java.net.URI;
 
 @Slf4j
-@Controller(BrapiVersion.BRAPI_NO_VERSION)
+@Controller("/${micronaut.bi.api.version}")
 public class BrapiAuthorizeController {
 
     @Property(name = "web.base-url")
     protected String webBaseUrl;
 
 
-    @Get("/authorize")
+    @Get("/programs/{programId}/brapi/authorize")
     @Secured(SecurityRule.IS_ANONYMOUS)
-    public HttpResponse authorize(@QueryValue @NotBlank String display_name, @QueryValue @NotBlank String return_url) {
+    public HttpResponse authorize(@QueryValue @NotBlank String display_name, @QueryValue @NotBlank String return_url, @PathVariable("programId") String programId) {
 
-        URI location = UriBuilder.of(webBaseUrl + "/brapi/authorize")
+        URI location = UriBuilder.of(String.format("%s/programs/%s/brapi/authorize", webBaseUrl, programId))
                 .queryParam("display_name", display_name)
                 .queryParam("return_url", return_url)
                 .build();

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIV2Controller.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIV2Controller.java
@@ -1,0 +1,159 @@
+/*
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapi.v2;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.rules.SecurityRule;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+import org.brapi.v2.model.core.BrAPIServerInfo;
+import org.brapi.v2.model.core.response.BrAPIServerInfoResponse;
+import org.breedinginsight.api.auth.AuthenticatedUser;
+import org.breedinginsight.api.auth.SecurityService;
+import org.breedinginsight.brapi.v1.controller.BrapiVersion;
+import org.breedinginsight.model.ProgramBrAPIEndpoints;
+import org.breedinginsight.services.ProgramService;
+import org.breedinginsight.services.exceptions.DoesNotExistException;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+
+@Slf4j
+@Controller(BrapiVersion.BRAPI_V2)
+@Secured(SecurityRule.IS_AUTHENTICATED)
+public class BrAPIV2Controller {
+
+    private final SecurityService securityService;
+    private final ProgramService programService;
+
+    @Inject
+    public BrAPIV2Controller(SecurityService securityService, ProgramService programService) {
+        this.securityService = securityService;
+        this.programService = programService;
+    }
+
+
+    @Get("/serverinfo")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Secured(SecurityRule.IS_ANONYMOUS)
+    public BrAPIServerInfoResponse serverinfo() {
+        BrAPIServerInfo serverInfo = new BrAPIServerInfo();
+        serverInfo.setOrganizationName("Breeding Insight Platform");
+        serverInfo.setServerName("bi-api");
+        serverInfo.setContactEmail("bidevteam@cornell.edu");
+        serverInfo.setOrganizationURL("breedinginsight.org");
+
+        return new BrAPIServerInfoResponse().result(serverInfo);
+    }
+
+    @Get("/{+path}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public HttpResponse<?> getCatchall(@PathVariable String path, HttpRequest<String> request) {
+        return executeRequest(path, request, "GET");
+    }
+
+    @Post("/{+path}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public HttpResponse<String> postCatchall(@PathVariable String path, HttpRequest<String> request) {
+        return executeRequest(path, request, "POST");
+    }
+
+    @Put("/{+path}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public HttpResponse<String> putCatchall(@PathVariable String path, HttpRequest<String> request) {
+        return executeRequest(path, request, "PUT");
+    }
+
+    private HttpResponse<String> executeRequest(String path, HttpRequest<String> request, String method) {
+        AuthenticatedUser actingUser = securityService.getUser();
+        System.out.println(actingUser.getId());
+
+        System.out.println("Params");
+        request.getParameters()
+               .forEach((key, vals) -> System.out.println(key + ": " + vals));
+
+        /*
+        TODO evaluate a few options:
+        1. pass custom "programId" param for each BrAPI request
+        2. embed the programId in the JWT (limited to one program)
+        3. use "programDbId" so it matches BrAPI, but the value will be what's in BI's db, not the BrAPI service
+        4. have brapi requests be per-program -> /programs/{programId}/brapi/v2
+
+        Another question...do we want to swap out all programDbIds with the programId in BI's db?
+         */
+        if (request.getParameters().get("programId") != null) {
+            String programId = request.getParameters().get("programId");
+            ProgramBrAPIEndpoints programBrAPIEndpoints;
+            try {
+                programBrAPIEndpoints = programService.getBrapiEndpoints(UUID.fromString(Objects.requireNonNull(programId)));
+            } catch (DoesNotExistException e) {
+                return HttpResponse.notFound("Program does not exist");
+            }
+
+            OkHttpClient client = new OkHttpClient();
+
+            if(programBrAPIEndpoints.getCoreUrl().isEmpty()) {
+                log.error("Program: " + programId + " is missing BrAPI URL config");
+                throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "");
+            }
+            var programBrAPIBaseUrl = programBrAPIEndpoints.getCoreUrl().get();
+            programBrAPIBaseUrl = programBrAPIBaseUrl.endsWith("/") ? programBrAPIBaseUrl.substring(0, programBrAPIBaseUrl.length() - 1) : programBrAPIBaseUrl;
+            var requestUrl = HttpUrl.parse(programBrAPIBaseUrl + BrapiVersion.BRAPI_V2 + "/" + path)
+                                    .newBuilder();
+
+            request.getParameters()
+                   .asMap()
+                   .entrySet()
+                   .stream()
+                   .filter(param -> !param.getKey()
+                                          .equals("programId"))
+                   .forEach(param -> param.getValue()
+                                          .forEach(val -> requestUrl.addQueryParameter(param.getKey(), val)));
+
+            var brapiRequest = new Request.Builder().url(requestUrl.build())
+//                                                    .addHeader("Authorization", "Bearer " + token) //TODO
+                                                    .method(method, request.getBody().isPresent() ? RequestBody.create(request.getBody().get(), okhttp3.MediaType.get(MediaType.APPLICATION_JSON)) : null)
+                                                    .build();
+
+            try (Response brapiResponse = client.newCall(brapiRequest).execute()) {
+                if(brapiResponse.isSuccessful()) {
+                    try(ResponseBody body = brapiResponse.body()) {
+                        String respBody = body == null ? "" : body.string();
+                        return HttpResponse.ok(respBody);
+                    }
+                } else if(brapiResponse.code() == HttpStatus.NOT_FOUND.getCode()) {
+                    return HttpResponse.notFound();
+                }
+            } catch (IOException e) {
+                log.error("Error calling BrAPI Service", e);
+                throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error calling BrAPI Service");
+            }
+        }
+
+        throw new HttpStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized BrAPI Request");
+    }
+}

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIV2Controller.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIV2Controller.java
@@ -70,14 +70,16 @@ public class BrAPIV2Controller {
         return new BrAPIServerInfoResponse().result(serverInfo);
     }
 
-    @Get("/programs/{programId}" + BrapiVersion.BRAPI_V2 + "/{+path}")
+    //TODO override program serverinfo endpoint to replace some of the data points (contactEmail, organizationName, organizationURL, etc)
+
+    @Get("/${micronaut.bi.api.version}/programs/{programId}" + BrapiVersion.BRAPI_V2 + "/{+path}")
     @Produces(MediaType.APPLICATION_JSON)
     @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
     public HttpResponse<?> getCatchall(@PathVariable("path") String path, @PathVariable("programId") UUID programId, HttpRequest<String> request) {
         return executeRequest(path, programId, request, "GET");
     }
 
-    @Post("/programs/{programId}" + BrapiVersion.BRAPI_V2 + "/{+path}")
+    @Post("/${micronaut.bi.api.version}/programs/{programId}" + BrapiVersion.BRAPI_V2 + "/{+path}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
@@ -85,7 +87,7 @@ public class BrAPIV2Controller {
         return executeRequest(path, programId, request, "POST");
     }
 
-    @Put("/programs/{programId}" + BrapiVersion.BRAPI_V2 + "/{+path}")
+    @Put("/${micronaut.bi.api.version}/programs/{programId}" + BrapiVersion.BRAPI_V2 + "/{+path}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIV2Controller.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIV2Controller.java
@@ -71,8 +71,6 @@ public class BrAPIV2Controller {
         return new BrAPIServerInfoResponse().result(serverInfo);
     }
 
-    //TODO override program serverinfo endpoint to replace some of the data points (contactEmail, organizationName, organizationURL, etc)
-
     @Get("/${micronaut.bi.api.version}/programs/{programId}" + BrapiVersion.BRAPI_V2 + "/{+path}")
     @Produces(MediaType.APPLICATION_JSON)
     @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIV2Controller.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIV2Controller.java
@@ -1,5 +1,6 @@
 /*
- * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +40,8 @@ import org.breedinginsight.services.exceptions.DoesNotExistException;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Controller
@@ -97,11 +98,15 @@ public class BrAPIV2Controller {
 
     private HttpResponse<String> executeRequest(String path, UUID programId, HttpRequest<String> request, String method) {
         AuthenticatedUser actingUser = securityService.getUser();
-        System.out.println(actingUser.getId());
 
-        System.out.println("Params");
-        request.getParameters()
-               .forEach((key, vals) -> System.out.println(key + ": " + vals));
+        log.debug("Params for brapi proxy call: " + String.join("\n",
+                                           request.getParameters()
+                                                  .asMap()
+                                                  .entrySet()
+                                                  .stream()
+                                                  .map(entry -> entry.getKey() + ": " + entry.getValue())
+                                                  .collect(Collectors.joining("\n"))
+        ));
 
         if (programId != null) {
             ProgramBrAPIEndpoints programBrAPIEndpoints;

--- a/src/test/java/org/breedinginsight/BrAPITest.java
+++ b/src/test/java/org/breedinginsight/BrAPITest.java
@@ -30,6 +30,8 @@ import org.testcontainers.images.PullPolicy;
 import javax.annotation.Nonnull;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,7 +46,7 @@ public class BrAPITest extends DatabaseTest {
     public BrAPITest() {
         brapiContainer = new GenericContainer<>("breedinginsight/brapi-java-server")
                 .withNetwork(super.getDbContainer().getNetwork())
-                .withImagePullPolicy(PullPolicy.defaultPolicy())
+                .withImagePullPolicy(PullPolicy.alwaysPull())
                 .withExposedPorts(8080)
                 .withEnv("BRAPI_DB_SERVER",
                         String.format("%s:%s",
@@ -54,7 +56,7 @@ public class BrAPITest extends DatabaseTest {
                 .withEnv("BRAPI_DB_USER", "postgres")
                 .withEnv("BRAPI_DB_PASSWORD", "postgres")
                 .withClasspathResourceMapping("brapi/properties/application.properties", "/home/brapi/properties/application.properties", BindMode.READ_ONLY)
-                .waitingFor(Wait.forListeningPort());
+                .waitingFor(Wait.forHttp("/brapi/v2/serverinfo").forStatusCode(200).withHeader("Accept", "application/json").withStartupTimeout(Duration.of(3, ChronoUnit.MINUTES)));
         brapiContainer.start();
 
         // Get a dsl connection for the brapi db
@@ -72,6 +74,7 @@ public class BrAPITest extends DatabaseTest {
 
         Integer containerPort = brapiContainer.getMappedPort(8080);
         String containerIp = brapiContainer.getContainerIpAddress();
+        properties.put("brapi.server.default-url", String.format("http://%s:%s/", containerIp, containerPort));
         properties.put("brapi.server.core-url", String.format("http://%s:%s/", containerIp, containerPort));
         properties.put("brapi.server.geno-url", String.format("http://%s:%s/", containerIp, containerPort));
         properties.put("brapi.server.pheno-url", String.format("http://%s:%s/", containerIp, containerPort));

--- a/src/test/java/org/breedinginsight/brapi/v1/controller/BrapiAuthorizeControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v1/controller/BrapiAuthorizeControllerIntegrationTest.java
@@ -16,6 +16,7 @@
  */
 package org.breedinginsight.brapi.v1.controller;
 
+import io.kowalski.fannypack.FannyPack;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.RxHttpClient;
@@ -24,7 +25,14 @@ import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.http.netty.cookies.NettyCookie;
 import io.micronaut.test.annotation.MicronautTest;
 import io.reactivex.Flowable;
+import lombok.SneakyThrows;
 import org.breedinginsight.DatabaseTest;
+import org.breedinginsight.api.v1.controller.TestTokenValidator;
+import org.breedinginsight.dao.db.tables.daos.ProgramDao;
+import org.breedinginsight.dao.db.tables.pojos.ProgramEntity;
+import org.breedinginsight.daos.UserDAO;
+import org.breedinginsight.model.User;
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.*;
 
 import javax.inject.Inject;
@@ -38,13 +46,50 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class BrapiAuthorizeControllerIntegrationTest extends DatabaseTest {
 
     @Inject
-    @Client(BrapiVersion.BRAPI_NO_VERSION)
+    @Client("/${micronaut.bi.api.version}")
     RxHttpClient client;
+
+    private FannyPack fp;
+
+    @Inject
+    private DSLContext dsl;
+    @Inject
+    private ProgramDao programDao;
+    @Inject
+    private UserDAO userDAO;
+
+    private ProgramEntity validProgram;
+
+    @BeforeAll
+    @SneakyThrows
+    public void setup() {
+        fp = FannyPack.fill("src/test/resources/sql/BrapiObservationVariablesControllerIntegrationTest.sql");
+        var securityFp = FannyPack.fill("src/test/resources/sql/ProgramSecuredAnnotationRuleIntegrationTest.sql");
+
+        // Insert system roles
+        User testUser = userDAO.getUserByOrcId(TestTokenValidator.TEST_USER_ORCID).get();
+        dsl.execute(securityFp.get("InsertSystemRoleAdmin"), testUser.getId().toString());
+
+        // Insert program
+        dsl.execute(fp.get("InsertProgram"));
+
+        // Insert program observation level
+        dsl.execute(fp.get("InsertProgramObservationLevel"));
+
+        // Insert program ontology sql
+        dsl.execute(fp.get("InsertProgramOntology"));
+        dsl.execute(fp.get("InsertTestProgramUser"));
+
+        // Retrieve our new data
+        validProgram = programDao.findAll().get(0);
+
+        dsl.execute(securityFp.get("InsertProgramRolesBreeder"), testUser.getId().toString(), validProgram.getId().toString());
+    }
 
     @Test
     void redirectMissingRequiredParameters() {
         Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/authorize")
+                GET(String.format("/programs/%s/brapi/authorize", validProgram.getId()))
                         .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
         );
 
@@ -57,7 +102,7 @@ public class BrapiAuthorizeControllerIntegrationTest extends DatabaseTest {
     @Test
     void redirectParameterEmpty() {
         Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/authorize?display_name=&return_url=")
+                GET(String.format("/programs/%s/brapi/authorize?display_name=&return_url=", validProgram.getId()))
                         .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
         );
 

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ControllerIntegrationTest.java
@@ -1,5 +1,6 @@
 /*
- * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ControllerIntegrationTest.java
@@ -145,7 +145,8 @@ public class BrAPIV2ControllerIntegrationTest extends BrAPITest {
     }
 
     @Test
-    public void testPostGetVariablesProxy() throws Exception {
+    @SneakyThrows
+    public void testPostGetVariablesProxy() {
         BrAPIObservationVariable variable = generateVariable();
 
         Flowable<HttpResponse<String>> postCall = biClient.exchange(
@@ -242,7 +243,8 @@ public class BrAPIV2ControllerIntegrationTest extends BrAPITest {
     }
 
     @Test
-    public void testPutVariablesProxy() throws Exception {
+    @SneakyThrows
+    public void testPutVariablesProxy() {
         BrAPIObservationVariable variable = generateVariable();
 
         Flowable<HttpResponse<String>> postCall = biClient.exchange(
@@ -284,7 +286,7 @@ public class BrAPIV2ControllerIntegrationTest extends BrAPITest {
         } catch (Exception e) {
             throw new Exception(e);
         }
-        //check the POST call was successful
+        //check the PUT call was successful
         assertEquals(HttpStatus.OK, putResponse.getStatus());
 
         Flowable<HttpResponse<String>> getCall = biClient.exchange(
@@ -310,7 +312,8 @@ public class BrAPIV2ControllerIntegrationTest extends BrAPITest {
     }
 
     @Test
-    public void testPostGetStudiesProxy() throws Exception {
+    @SneakyThrows
+    public void testPostGetStudiesProxy() {
         BrAPIStudy study = new BrAPIStudy().studyName("test study")
                                            .studyCode("123")
                                            .studyType("Phenotyping Trial")

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ControllerIntegrationTest.java
@@ -1,0 +1,391 @@
+/*
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapi.v2;
+
+import com.google.gson.*;
+import io.kowalski.fannypack.FannyPack;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.client.RxHttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.annotation.MicronautTest;
+import io.reactivex.Flowable;
+import lombok.SneakyThrows;
+import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.core.BrAPIServerInfo;
+import org.brapi.v2.model.core.BrAPIStudy;
+import org.brapi.v2.model.core.response.BrAPIStudyListResponse;
+import org.brapi.v2.model.core.response.BrAPIStudySingleResponse;
+import org.brapi.v2.model.pheno.*;
+import org.brapi.v2.model.pheno.response.BrAPIObservationVariableListResponse;
+import org.brapi.v2.model.pheno.response.BrAPIObservationVariableSingleResponse;
+import org.breedinginsight.BrAPITest;
+import org.breedinginsight.api.v1.controller.TestTokenValidator;
+import org.breedinginsight.dao.db.tables.daos.ProgramDao;
+import org.breedinginsight.dao.db.tables.pojos.ProgramEntity;
+import org.breedinginsight.daos.UserDAO;
+import org.breedinginsight.model.User;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.*;
+
+import javax.inject.Inject;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+
+import static io.micronaut.http.HttpRequest.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class BrAPIV2ControllerIntegrationTest extends BrAPITest {
+
+    @Inject
+    @Client("/")
+    RxHttpClient biClient;
+
+    @Property(name = "micronaut.bi.api.version")
+    String biApiVersion;
+
+    private FannyPack fp;
+
+    private Gson GSON = new GsonBuilder().registerTypeAdapter(OffsetDateTime.class, (JsonDeserializer<OffsetDateTime>)
+            (json, type, context) -> OffsetDateTime.parse(json.getAsString()))
+                                         .create();
+
+    @Inject
+    private DSLContext dsl;
+    @Inject
+    private ProgramDao programDao;
+    @Inject
+    private UserDAO userDAO;
+
+    private ProgramEntity validProgram;
+
+    @BeforeAll
+    @SneakyThrows
+    public void setup() {
+        fp = FannyPack.fill("src/test/resources/sql/BrapiObservationVariablesControllerIntegrationTest.sql");
+        var securityFp = FannyPack.fill("src/test/resources/sql/ProgramSecuredAnnotationRuleIntegrationTest.sql");
+
+        // Insert system roles
+        User testUser = userDAO.getUserByOrcId(TestTokenValidator.TEST_USER_ORCID)
+                               .get();
+        dsl.execute(securityFp.get("InsertSystemRoleAdmin"),
+                    testUser.getId()
+                            .toString());
+
+        // Insert program
+        dsl.execute(fp.get("InsertProgram"));
+
+        // Insert program observation level
+        dsl.execute(fp.get("InsertProgramObservationLevel"));
+
+        // Insert program ontology sql
+        dsl.execute(fp.get("InsertProgramOntology"));
+        dsl.execute(fp.get("InsertTestProgramUser"));
+        dsl.execute(fp.get("InsertOtherTestProgramUser"));
+
+        // Retrieve our new data
+        validProgram = programDao.findAll()
+                                 .stream()
+                                 .filter(programEntity -> programEntity.getName()
+                                                                       .equals("Test Program"))
+                                 .findFirst()
+                                 .get();
+
+        dsl.execute(securityFp.get("InsertProgramRolesBreeder"),
+                    testUser.getId()
+                            .toString(),
+                    validProgram.getId()
+                                .toString());
+
+        var brapiFp = FannyPack.fill("src/test/resources/sql/brapi/species.sql");
+        super.getBrapiDsl()
+             .execute(brapiFp.get("InsertSpecies"));
+    }
+
+    @Test
+    public void testRootServerInfo() {
+        Flowable<HttpResponse<String>> call = biClient.exchange(GET("/brapi/v2/serverinfo"), String.class);
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertNotNull(response.body(), "Response body is empty");
+
+        JsonObject result = JsonParser.parseString(response.body())
+                                      .getAsJsonObject()
+                                      .getAsJsonObject("result");
+        BrAPIServerInfo serverInfo = GSON.fromJson(result, BrAPIServerInfo.class);
+
+        assertEquals("Breeding Insight Platform", serverInfo.getOrganizationName());
+        assertEquals("bi-api", serverInfo.getServerName());
+        assertEquals("bidevteam@cornell.edu", serverInfo.getContactEmail());
+        assertEquals("breedinginsight.org", serverInfo.getOrganizationURL());
+    }
+
+    @Test
+    public void testPostGetVariablesProxy() throws Exception {
+        BrAPIObservationVariable variable = generateVariable();
+
+        Flowable<HttpResponse<String>> postCall = biClient.exchange(
+                POST(String.format("%s/programs/%s/brapi/v2/variables",
+                                   biApiVersion,
+                                   validProgram.getId().toString()), Arrays.asList(variable))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bearerAuth("test-registered-user"), String.class
+        );
+
+        HttpResponse<String> postResponse;
+        try {
+            postResponse = postCall.blockingFirst();
+        } catch (Exception e) {
+            throw new Exception(e);
+        }
+        //check the POST call was successful
+        assertEquals(HttpStatus.OK, postResponse.getStatus());
+
+        BrAPIObservationVariable createdVariable = GSON.fromJson(postResponse.body(), BrAPIObservationVariableListResponse.class)
+                                                       .getResult()
+                                                       .getData()
+                                                       .get(0);
+
+        //and that a variable is returned
+        assertNotNull(createdVariable);
+        //and that the variable has been assigned an ID
+        assertNotNull(createdVariable.getObservationVariableDbId(), "observationVariableDbId is null");
+
+        Flowable<HttpResponse<String>> getCall = biClient.exchange(
+                GET(String.format("%s/programs/%s/brapi/v2/variables/%s",
+                                  biApiVersion,
+                                  validProgram.getId().toString(),
+                                  createdVariable.getObservationVariableDbId()))
+                        .bearerAuth("test-registered-user"), String.class
+        );
+
+        HttpResponse<String> getResponse;
+        try {
+            getResponse = getCall.blockingFirst();
+        } catch (Exception e) {
+            throw new Exception(e);
+        }
+        assertEquals(HttpStatus.OK, getResponse.getStatus());
+        assertNotNull(getResponse.body(), "Response body is empty");
+        BrAPIObservationVariableSingleResponse brAPIObservationVariableSingleResponse = GSON.fromJson(getResponse.body(), BrAPIObservationVariableSingleResponse.class);
+
+        BrAPIObservationVariable fetchedVariable = brAPIObservationVariableSingleResponse.getResult();
+        assertNotNull(fetchedVariable, "Observation Variable was not found");
+        assertEquals(createdVariable.getObservationVariableDbId(), fetchedVariable.getObservationVariableDbId());
+        //make sure the original values sent in the POST were saved correctly
+        assertEquals(variable.getObservationVariableName(), fetchedVariable.getObservationVariableName());
+        assertEquals(variable.getExternalReferences(), fetchedVariable.getExternalReferences());
+        assertEquals(variable.getCommonCropName(), fetchedVariable.getCommonCropName());
+
+        assertNotNull(fetchedVariable.getTrait(), "Trait is null");
+        assertEquals(createdVariable.getTrait().getTraitDbId(), fetchedVariable.getTrait().getTraitDbId());
+        //make sure the original values sent in the POST were saved correctly
+        assertEquals(variable.getTrait().getTraitName(), fetchedVariable.getTrait().getTraitName());
+        assertEquals(variable.getTrait().getTraitClass(), fetchedVariable.getTrait().getTraitClass());
+
+
+        assertNotNull(fetchedVariable.getMethod(), "Method is null");
+        assertEquals(createdVariable.getMethod().getMethodDbId(), fetchedVariable.getMethod().getMethodDbId());
+        //make sure the original values sent in the POST were saved correctly
+        assertEquals(variable.getMethod().getMethodName(), fetchedVariable.getMethod().getMethodName());
+        assertEquals(variable.getMethod().getMethodClass(), fetchedVariable.getMethod().getMethodClass());
+
+        assertNotNull(fetchedVariable.getScale(), "Scale is null");
+        assertEquals(createdVariable.getScale().getScaleDbId(), fetchedVariable.getScale().getScaleDbId());
+        //make sure the original values sent in the POST were saved correctly
+        assertEquals(variable.getScale().getScaleName(), fetchedVariable.getScale().getScaleName());
+
+        Flowable<HttpResponse<String>> getScaleCall = biClient.exchange(
+                GET(String.format("%s/programs/%s/brapi/v2/scales/%s",
+                                  biApiVersion,
+                                  validProgram.getId().toString(),
+                                  createdVariable.getScale().getScaleDbId()))
+                        .bearerAuth("test-registered-user"), String.class
+        );
+
+        HttpResponse<String> getScaleResponse;
+        try {
+            getScaleResponse = getScaleCall.blockingFirst();
+        } catch (Exception e) {
+            throw new Exception(e);
+        }
+        assertEquals(HttpStatus.OK, getScaleResponse.getStatus());
+
+        BrAPIScale scaleResponse = GSON.fromJson(JsonParser.parseString(getScaleResponse.body()).getAsJsonObject().getAsJsonObject("result"), BrAPIScale.class);
+
+        //TODO this is not being returned
+//        assertEquals(variable.getScale().getDataType(), scaleResponse.getDataType());
+    }
+
+    @Test
+    public void testPutVariablesProxy() throws Exception {
+        BrAPIObservationVariable variable = generateVariable();
+
+        Flowable<HttpResponse<String>> postCall = biClient.exchange(
+                POST(String.format("%s/programs/%s/brapi/v2/variables",
+                                   biApiVersion,
+                                   validProgram.getId().toString()), Arrays.asList(variable))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bearerAuth("test-registered-user"), String.class
+        );
+
+        HttpResponse<String> postResponse;
+        try {
+            postResponse = postCall.blockingFirst();
+        } catch (Exception e) {
+            throw new Exception(e);
+        }
+        //check the POST call was successful
+        assertEquals(HttpStatus.OK, postResponse.getStatus());
+
+        BrAPIObservationVariable createdVariable = GSON.fromJson(postResponse.body(), BrAPIObservationVariableListResponse.class)
+                                                       .getResult()
+                                                       .getData()
+                                                       .get(0);
+
+        createdVariable.setObservationVariableName("Updated variable name");
+
+
+        Flowable<HttpResponse<String>> putCall = biClient.exchange(
+                PUT(String.format("%s/programs/%s/brapi/v2/variables/%s",
+                                   biApiVersion,
+                                   validProgram.getId().toString(), createdVariable.getObservationVariableDbId()), variable)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bearerAuth("test-registered-user"), String.class
+        );
+
+        HttpResponse<String> putResponse;
+        try {
+            putResponse = putCall.blockingFirst();
+        } catch (Exception e) {
+            throw new Exception(e);
+        }
+        //check the POST call was successful
+        assertEquals(HttpStatus.OK, putResponse.getStatus());
+
+        Flowable<HttpResponse<String>> getCall = biClient.exchange(
+                GET(String.format("%s/programs/%s/brapi/v2/variables/%s",
+                                  biApiVersion,
+                                  validProgram.getId().toString(),
+                                  createdVariable.getObservationVariableDbId()))
+                        .bearerAuth("test-registered-user"), String.class
+        );
+
+        HttpResponse<String> getResponse;
+        try {
+            getResponse = getCall.blockingFirst();
+        } catch (Exception e) {
+            throw new Exception(e);
+        }
+        assertEquals(HttpStatus.OK, getResponse.getStatus());
+        BrAPIObservationVariableSingleResponse brAPIObservationVariableSingleResponse = GSON.fromJson(getResponse.body(), BrAPIObservationVariableSingleResponse.class);
+
+        BrAPIObservationVariable fetchedVariable = brAPIObservationVariableSingleResponse.getResult();
+        //make sure the updated value persisted
+        assertEquals(variable.getObservationVariableName(), fetchedVariable.getObservationVariableName());
+    }
+
+    @Test
+    public void testPostGetStudiesProxy() throws Exception {
+        BrAPIStudy study = new BrAPIStudy().studyName("test study")
+                                           .studyCode("123")
+                                           .studyType("Phenotyping Trial")
+                                           .studyDescription("Test study description")
+                .active(true)
+                .startDate(OffsetDateTime.of(2021, 1, 5, 0, 0, 0, 0, ZoneOffset.UTC))
+                                           .endDate(OffsetDateTime.of(2021, 2, 5, 0, 0, 0, 0, ZoneOffset.UTC));
+
+        Flowable<HttpResponse<String>> postCall = biClient.exchange(
+                POST(String.format("%s/programs/%s/brapi/v2/studies",
+                                   biApiVersion,
+                                   validProgram.getId().toString()), Arrays.asList(study))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bearerAuth("test-registered-user"), String.class
+        );
+
+        HttpResponse<String> postResponse;
+        try {
+            postResponse = postCall.blockingFirst();
+        } catch (Exception e) {
+            throw new Exception(e);
+        }
+        //check the POST call was successful
+        assertEquals(HttpStatus.OK, postResponse.getStatus());
+
+        BrAPIStudy createdStudy = GSON.fromJson(postResponse.body(), BrAPIStudyListResponse.class)
+                                                       .getResult()
+                                                       .getData()
+                                                       .get(0);
+
+        //and that a study is returned
+        assertNotNull(createdStudy);
+        //and that the study has been assigned an ID
+        assertNotNull(createdStudy.getStudyDbId(), "studyDbId is null");
+
+        Flowable<HttpResponse<String>> getCall = biClient.exchange(
+                GET(String.format("%s/programs/%s/brapi/v2/studies/%s",
+                                  biApiVersion,
+                                  validProgram.getId().toString(),
+                                  createdStudy.getStudyDbId()))
+                        .bearerAuth("test-registered-user"), String.class
+        );
+
+        HttpResponse<String> getResponse;
+        try {
+            getResponse = getCall.blockingFirst();
+        } catch (Exception e) {
+            throw new Exception(e);
+        }
+        assertEquals(HttpStatus.OK, getResponse.getStatus());
+        assertNotNull(getResponse.body(), "Response body is empty");
+
+        BrAPIStudy fetchedStudy = GSON.fromJson(getResponse.body(), BrAPIStudySingleResponse.class).getResult();
+
+        assertEquals(study.getStudyName(), fetchedStudy.getStudyName());
+        assertEquals(study.getStudyCode(), fetchedStudy.getStudyCode());
+        assertEquals(study.getStudyType(), fetchedStudy.getStudyType());
+        assertEquals(study.getStudyDescription(), fetchedStudy.getStudyDescription());
+        assertEquals(study.isActive(), fetchedStudy.isActive());
+        assertEquals(study.getStartDate(), fetchedStudy.getStartDate());
+        assertEquals(study.getEndDate(), fetchedStudy.getEndDate());
+    }
+
+    private BrAPIObservationVariable generateVariable() {
+        var random = UUID.randomUUID()
+                         .toString();
+        return new BrAPIObservationVariable().observationVariableName("test" + random)
+                                             .commonCropName("Grape")
+                                             .externalReferences(Collections.singletonList(new BrAPIExternalReference().referenceID("abc123")
+                                                                                                                       .referenceSource("breedinginsight.org")))
+                                             .trait(new BrAPITrait().traitClass("Agronomic")
+                                                                    .traitName("test trait" + random))
+                                             .method(new BrAPIMethod().methodName("test method" + random)
+                                                                      .methodClass("Measurement"))
+                                             .scale(new BrAPIScale().scaleName("test scale" + random)
+                                                                    .dataType(BrAPITraitDataType.NUMERICAL));
+    }
+}


### PR DESCRIPTION
Created a BrAPI v2 controller that has catchall methods to intercept GET, PUT, and POST requests to BrAPI endpoints, scoped within a program.  BrAPI endpoints are of the form `/v1/programs/{programId}/brapi/v2/<BrAPI endpoint>`.

There is a `serverinfo` endpoint that is at the root of bi-api (`/brapi/v2/serverinfo`), with basic server information.