### PR TITLE
[BI-1059] Name vs Full Name

### DIFF
--- a/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
@@ -130,6 +130,26 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
     }
 
     @Override
+    public ValidationError getCharLimitObsVarNameMsg() {
+        return new ValidationError("observationVariableName", "Observation variable name exceeds 12 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Override
+    public ValidationError getCharLimitTraitEntityMsg() {
+        return new ValidationError("entity", "Trait entity exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Override
+    public ValidationError getCharLimitTraitAttributeMsg() {
+        return new ValidationError("attribute", "Trait attribute exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Override
+    public ValidationError getCharLimitMethodDescriptionMsg() {
+        return new ValidationError("method.description", "Method description exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Override
     public ValidationError getDuplicateTraitByNamesMsg() {
         return new ValidationError("Trait name", "Trait name already exists", HttpStatus.CONFLICT);
     }

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
@@ -130,6 +130,26 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
     }
 
     @Override
+    public ValidationError getCharLimitObsVarNameMsg() {
+        return new ValidationError("observationVariableName", "Observation variable name exceeds 12 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Override
+    public ValidationError getCharLimitTraitEntityMsg() {
+        return new ValidationError("entity", "Trait entity exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Override
+    public ValidationError getCharLimitTraitAttributeMsg() {
+        return new ValidationError("attribute", "Trait attribute exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Override
+    public ValidationError getCharLimitMethodDescriptionMsg() {
+        return new ValidationError("method.description", "Method description exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Override
     public ValidationError getDuplicateTraitByNamesMsg() {
         return new ValidationError("traitName", "Trait name already exists", HttpStatus.CONFLICT);
     }

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorErrorInterface.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorErrorInterface.java
@@ -41,6 +41,10 @@ public interface TraitValidatorErrorInterface {
     ValidationError getBlankScaleCategoryLabelMsg();
     ValidationError getBlankScaleCategoryValueMsg();
     ValidationError getMaxLessThenMinError();
+    ValidationError getCharLimitObsVarNameMsg();
+    ValidationError getCharLimitTraitEntityMsg();
+    ValidationError getCharLimitTraitAttributeMsg();
+    ValidationError getCharLimitMethodDescriptionMsg();
     ValidationError getDuplicateTraitByNamesMsg();
     ValidationError getDuplicateTraitByAbbreviationsMsg();
     ValidationError getDuplicateTraitsByNameInFileMsg(List<Integer> matchingRows);

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
@@ -53,10 +53,6 @@ public class TraitValidatorService {
                 ValidationError error = traitValidatorErrors.getMissingMethodMsg();
                 errors.addError(traitValidatorErrors.getRowNumber(i), error);
             } else {
-                if (isBlank(method.getDescription()) || method.getDescription() == null) {
-                    ValidationError error = traitValidatorErrors.getMissingMethodDescriptionMsg();
-                    errors.addError(traitValidatorErrors.getRowNumber(i), error);
-                }
                 if (isBlank(method.getMethodClass()) || method.getMethodClass() == null) {
                     ValidationError error = traitValidatorErrors.getMissingMethodClassMsg();
                     errors.addError(traitValidatorErrors.getRowNumber(i), error);
@@ -163,6 +159,38 @@ public class TraitValidatorService {
             }
         }
 
+        return errors;
+    }
+
+    public ValidationErrors checkTraitFieldsLength(List<Trait> traits, TraitValidatorErrorInterface traitValidatorErrors) {
+
+        ValidationErrors errors = new ValidationErrors();
+
+        for (int i = 0; i < traits.size(); i++) {
+
+            Trait trait = traits.get(i);
+            Method method = trait.getMethod();
+            int shortCharLimit = 12;
+            int longCharLimit = 30;
+
+            if (trait.getObservationVariableName().length() > shortCharLimit) {
+                ValidationError error = traitValidatorErrors.getCharLimitObsVarNameMsg();
+                errors.addError(traitValidatorErrors.getRowNumber(i), error);
+            }
+            if (trait.getEntity().length() > longCharLimit) {
+                ValidationError error = traitValidatorErrors.getCharLimitTraitEntityMsg();
+                errors.addError(traitValidatorErrors.getRowNumber(i), error);
+            }
+            if (trait.getAttribute().length() > longCharLimit) {
+                ValidationError error = traitValidatorErrors.getCharLimitTraitAttributeMsg();
+                errors.addError(traitValidatorErrors.getRowNumber(i), error);
+            }
+            if (method.getDescription().length() > longCharLimit) {
+                ValidationError error = traitValidatorErrors.getCharLimitMethodDescriptionMsg();
+                errors.addError(traitValidatorErrors.getRowNumber(i), error);
+            }
+
+        }
         return errors;
     }
 


### PR DESCRIPTION
Backend changes for Ontology Name and Full Name:

- Add mapping for Name
- Add mapping for Full Name
- Remove required field validations for Method Description
- Add character limit validation for Name, Entity, Attribute, and Method Description
- Add validation that there are at least two filled fields if ordinal scale
- Add validation that there are at least two filled fields if nominal scale

Linked to BI-1127 (which handles front end validation of ordinal and nominal scale)