### PR TITLE
[BI-1223] Add null check for tags field

### DIFF
--- a/src/main/java/org/breedinginsight/daos/TraitDAO.java
+++ b/src/main/java/org/breedinginsight/daos/TraitDAO.java
@@ -554,9 +554,13 @@ public class TraitDAO extends TraitDao {
 
     private void saturateTrait(Trait trait, BrAPIObservationVariable brApiVariable) {
 
-        if (brApiVariable.getAdditionalInfo() != null && brApiVariable.getAdditionalInfo().has(TAGS_KEY)) {
-            List<String> tags = gson.fromJson(brApiVariable.getAdditionalInfo().getAsJsonArray(TAGS_KEY), List.class);
-            trait.setBrAPIProperties(brApiVariable, tags);
+        if (brApiVariable.getAdditionalInfo() != null &&
+                brApiVariable.getAdditionalInfo().has(TAGS_KEY)) {
+            // Prevents BrAPI server from failing the tags load
+            if (!brApiVariable.getAdditionalInfo().get(TAGS_KEY).isJsonNull()) {
+                List<String> tags = gson.fromJson(brApiVariable.getAdditionalInfo().getAsJsonArray(TAGS_KEY), List.class);
+                trait.setBrAPIProperties(brApiVariable, tags);
+            }
         } else {
             trait.setBrAPIProperties(brApiVariable);
         }


### PR DESCRIPTION
The real fix to this was to update the reltest brapi server database. This fix is to make it so that there is a bug that returns something like:

```
additionalInfo: {
  tags: null
}
```

from the brapi-server again, it won't prevent the user from seeing their list of traits. 