### PR TITLE
[BI-1227] Add 'Program Key' to Existing Programs

### DIFF
--- a/src/main/resources/db/migration/V0_5_29__add_program_keys.sql
+++ b/src/main/resources/db/migration/V0_5_29__add_program_keys.sql
@@ -1,0 +1,30 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+UPDATE program SET key = 'STPALF' WHERE name = 'StPaul-Alfalfa';
+UPDATE program SET key = 'PROALF' WHERE name = 'Prosser-Alfalfa';
+UPDATE program SET key = 'POPBLU' WHERE name = 'Poplarville-Blueberry';
+UPDATE program SET key = 'FTPCIT' WHERE name = 'FortPierce-Citrus';
+UPDATE program SET key = 'UAUSWP' WHERE name = 'USDA-ARS-USVL-Sweetpotato';
+UPDATE program SET key = 'CPTSGR' WHERE name = 'CanalPoint-Sugarcane';
+UPDATE program SET key = 'HOUSGR' WHERE name = 'Houma-Sugarcane';
+UPDATE program SET key = 'GRAPE' WHERE name = 'Grape';
+UPDATE program SET key = 'SALMO' WHERE name = 'Salmon';
+UPDATE program SET key = 'SUGAR' WHERE name = 'Sugarcane';
+UPDATE program SET key = 'SMOKE' WHERE name = 'Smoke Test';
+
+

--- a/src/main/resources/db/migration/V0_5_29__add_program_keys.sql
+++ b/src/main/resources/db/migration/V0_5_29__add_program_keys.sql
@@ -22,9 +22,9 @@ UPDATE program SET key = 'FTPCIT' WHERE name = 'FortPierce-Citrus';
 UPDATE program SET key = 'UAUSWP' WHERE name = 'USDA-ARS-USVL-Sweetpotato';
 UPDATE program SET key = 'CPTSGR' WHERE name = 'CanalPoint-Sugarcane';
 UPDATE program SET key = 'HOUSGR' WHERE name = 'Houma-Sugarcane';
-UPDATE program SET key = 'GRAPE' WHERE name = 'Grape';
-UPDATE program SET key = 'SALMO' WHERE name = 'Salmon';
-UPDATE program SET key = 'SUGAR' WHERE name = 'Sugarcane';
+UPDATE program SET key = 'GRP' WHERE name = 'Grape';
+UPDATE program SET key = 'SLM' WHERE name = 'Salmon';
+UPDATE program SET key = 'SGR' WHERE name = 'Sugarcane';
 UPDATE program SET key = 'SMOKE' WHERE name = 'Smoke Test';
 
 


### PR DESCRIPTION
Due to the new required program Key field, a migration is needed to add keys to existing programs.

NOTE: This migration just adds a value for the key column in the bidb programs table. Once this migration is run, the programs will need to be saved on the BI UI to have the keys associated with the name in the brapi database.