### PR TITLE
[BI-1251] - Germplasm import: fix to post order construction

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -287,6 +287,11 @@ public class GermplasmProcessor implements Processor {
             List<BrAPIGermplasm> createList = new ArrayList<>();
             for (BrAPIGermplasm germplasm : newGermplasmList) {
 
+                // If we've already planned this germplasm, skip
+                if (created.contains(germplasm.getGermplasmName())) {
+                    continue;
+                }
+
                 // If it has no dependencies, add it
                 if (germplasm.getPedigree() == null) {
                     createList.add(germplasm);


### PR DESCRIPTION
Germplasm were being POSTed twice because of bug in the post order construction. 

See sgn BI-1251 for card details: https://github.com/Breeding-Insight/sgn/pull/48