### PR TITLE
[BI-1219] Update Germplasm Import Parent DBID to GID

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -71,7 +71,7 @@ public class GermplasmProcessor implements Processor {
     List<List<BrAPIGermplasm>> postOrder = new ArrayList<>();
     BrAPIListNewRequest importList = new BrAPIListNewRequest();
 
-    public static String missingParentalDbIdsMsg = "The following parental db ids were not found in the database: %s.";
+    public static String missingParentalDbIdsMsg = "The following parental GIDs were not found in the database: %s.";
     public static String missingParentalEntryNoMsg = "The following parental entry numbers were not found in the database: %s.";
     public static String badBreedMethodsMsg = "Breeding methods not found: %s";
     public static String missingEntryNumbersMsg = "Either all or none of the germplasm must have entry numbers.";

--- a/src/main/resources/db/migration/V0.5.32__germplasm_import_change_dbid_to_gid.sql
+++ b/src/main/resources/db/migration/V0.5.32__germplasm_import_change_dbid_to_gid.sql
@@ -1,0 +1,21 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+update importer_mapping
+    set mapping = '[{"id": "f8d43c7e-a618-4c16-8829-3085f7202a67", "mapping": [{"id": "f384837e-ad8d-4dbe-b54e-87b57070bed1", "value": {"fileFieldName": "Name"}, "objectId": "germplasmName"}, {"id": "39628d14-458b-429b-8e66-bb48e0445a83", "value": {"fileFieldName": "Breeding Method"}, "objectId": "breedingMethod"}, {"id": "f1ba63e1-f5e4-433f-a53e-1c2f3e2fa71f", "value": {"fileFieldName": "Source"}, "objectId": "germplasmSource"}, {"id": "f5892565-f888-4596-be82-ab8eeabf37ce", "value": {"fileFieldName": "External UID"}, "objectId": "externalUID"}, {"id": "65507e5d-2d66-4595-8763-e772fe25c870", "value": {"fileFieldName": "Entry No"}, "objectId": "entryNo"}, {"id": "3eae24c1-ca4a-48a2-96d0-3cf4630acd3a", "value": {"fileFieldName": "Female Parent GID"}, "objectId": "femaleParentDBID"}, {"id": "2dbd7262-93a1-44b0-86b7-f5fca290b965", "value": {"fileFieldName": "Male Parent GID"}, "objectId": "maleParentDBID"}, {"id": "6f7f1539-6e8f-4ede-b7d3-3423cc63abec", "value": {"fileFieldName": "Female Parent Entry No"}, "objectId": "femaleParentEntryNo"}, {"id": "25fe9954-bca7-42f1-818a-5f71e242fa1f", "value": {"fileFieldName": "Male Parent Entry No"}, "objectId": "maleParentEntryNo"}, {"id": "15836d5f-8194-40a8-a771-114eaae31eb4", "objectId": "germplasmPUI"}, {"id": "675b6af8-5a17-4146-a503-2e4e1a65d5fa", "objectId": "acquisitionDate"}, {"id": "69a3bd3c-cebc-435c-acdd-0be62dda25ed", "objectId": "countryOfOrigin"}, {"id": "8ab25267-20f2-450e-89ca-21634ff8fadb", "objectId": "collection"}, {"id": "ce1701e2-2f61-4250-8595-9536e3f5ddcf", "objectId": "AdditionalInfo"}, {"id": "3470e9df-a028-45b7-943f-198bc62b6dbe", "objectId": "ExternalReference"}], "objectId": "Germplasm"}]',
+    file = '[{"Name": "BITest Pinot Noir", "Source": "Unknown", "Entry No": "1", "External UID": "", "Breeding Method": "UMM", "Male Parent GID": "", "Female Parent GID": "", "Male Parent Entry No": "", "Female Parent Entry No": ""}, {"Name": "BITest Pixie", "Source": "Winters Nursery", "Entry No": "2", "External UID": "", "Breeding Method": "CFV", "Male Parent GID": "", "Female Parent GID": "", "Male Parent Entry No": "", "Female Parent Entry No": "1"}, {"Name": "BITest BI002", "Source": "Ithaca Nursery", "Entry No": "7", "External UID": "12231321", "Breeding Method": "Biparental cross", "Male Parent GID": "", "Female Parent GID": "", "Male Parent Entry No": "", "Female Parent Entry No": "2"}, {"Name": "BITest BI003", "Source": "Ithaca Nursery", "Entry No": "8", "External UID": "", "Breeding Method": "BPC", "Male Parent GID": "", "Female Parent GID": "", "Male Parent Entry No": "7", "Female Parent Entry No": "2"}, {"Name": "BITest Pinot Noir", "Source": "Unknown", "Entry No": "3", "External UID": "", "Breeding Method": "UMM", "Male Parent GID": "", "Female Parent GID": "5fb01ea5-c212-4cfa-84e4-6d190379341f", "Male Parent Entry No": "", "Female Parent Entry No": ""}, {"Name": "BITest Pixie", "Source": "Winters Nursery", "Entry No": "4", "External UID": "", "Breeding Method": "CFV", "Male Parent GID": "640e8b58-1b1c-44a6-91a6-85b2b773376b", "Female Parent GID": "5fb01ea5-c212-4cfa-84e4-6d190379341f", "Male Parent Entry No": "", "Female Parent Entry No": ""}, {"Name": "BITest BI002", "Source": "Ithaca Nursery", "Entry No": "5", "External UID": "12231321", "Breeding Method": "Biparental cross", "Male Parent GID": "", "Female Parent GID": "5fb01ea5-c212-4cfa-84e4-6d190379341f", "Male Parent Entry No": "", "Female Parent Entry No": "2"}]'
+    where name = 'GermplasmTemplateMap';

--- a/src/test/resources/files/germplasm_import/bad_breeding_methods.csv
+++ b/src/test/resources/files/germplasm_import/bad_breeding_methods.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,ANE,Wild,,,,,,
 Germplasm 2,BAD,Wild,,,,,,
 Germplasm 3,BAD1,Wild,,,,,,

--- a/src/test/resources/files/germplasm_import/circular_parent_dependencies.csv
+++ b/src/test/resources/files/germplasm_import/circular_parent_dependencies.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,Wild,,,1,2,3,1234
 Germplasm 2,,Wild,,,2,1,2,5678
 Germplasm 3,,Wild,,,3,2,3,9123

--- a/src/test/resources/files/germplasm_import/duplicate_entry_numbers.csv
+++ b/src/test/resources/files/germplasm_import/duplicate_entry_numbers.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,Wild,,,1,,,
 Germplasm 2,,Wild,,,1,,,
 Germplasm 3,,Wild,,,3,,,

--- a/src/test/resources/files/germplasm_import/empty_required_fields.csv
+++ b/src/test/resources/files/germplasm_import/empty_required_fields.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,ANE,Wild,,,,,,
 ,ANE,Wild,,,,,,
 Germplasm 3,ANE,,,,,,,

--- a/src/test/resources/files/germplasm_import/empty_values_required_fields.csv
+++ b/src/test/resources/files/germplasm_import/empty_values_required_fields.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,Wild,,,,,,
 ,,Wild,,,,,,
 Germplasm 3,,,,,,,,

--- a/src/test/resources/files/germplasm_import/female_dbid_not_exist.csv
+++ b/src/test/resources/files/germplasm_import/female_dbid_not_exist.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,Wild,1000,,,,,
 Germplasm 2,,Cultivated,1001,,,,,
 Germplasm 3,,Kinda Wild,1002,,,,,

--- a/src/test/resources/files/germplasm_import/female_entry_number_not_exist.csv
+++ b/src/test/resources/files/germplasm_import/female_entry_number_not_exist.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,Wild,,,,1,,
 Germplasm 2,,Cultivated,,,,2,,
 Germplasm 3,,Kinda Wild,,,,3,,

--- a/src/test/resources/files/germplasm_import/full_import.csv
+++ b/src/test/resources/files/germplasm_import/full_import.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Full Germplasm 1,ANE,Wild,1,2,2,,,1234
 Full Germplasm 2,ANE,Wild,2,,3,,,5678
 Full Germplasm 3,ANE,Wild,,,4,2,3,9123

--- a/src/test/resources/files/germplasm_import/male_dbid_no_female_success.csv
+++ b/src/test/resources/files/germplasm_import/male_dbid_no_female_success.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,Wild,,100,,,,
 Germplasm 2,,Cultivated,,101,,,,
 Germplasm 3,,Kinda Wild,,102,,,,

--- a/src/test/resources/files/germplasm_import/male_dbid_not_exist.csv
+++ b/src/test/resources/files/germplasm_import/male_dbid_not_exist.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,Wild,,100,,,,
 Germplasm 2,,Cultivated,,101,,,,
 Germplasm 3,,Kinda Wild,,102,,,,

--- a/src/test/resources/files/germplasm_import/male_entry_number_not_exist.csv
+++ b/src/test/resources/files/germplasm_import/male_entry_number_not_exist.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,Wild,,,,,1,
 Germplasm 2,,Cultivated,,,,,2,
 Germplasm 3,,Kinda Wild,,,,,3,

--- a/src/test/resources/files/germplasm_import/minimal_germplasm_import.csv
+++ b/src/test/resources/files/germplasm_import/minimal_germplasm_import.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,Wild,,,,,,
 Germplasm 2,,Cultivated,,,,,,
 Germplasm 3,,Kinda Wild,,,,,,

--- a/src/test/resources/files/germplasm_import/missing_optional_header.csv
+++ b/src/test/resources/files/germplasm_import/missing_optional_header.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,ANE,Wild,,,,,
 Germplasm 2,ANE,Wild,,,,,
 Germplasm 3,ANE,Wild,,,,,

--- a/src/test/resources/files/germplasm_import/missing_required_header.csv
+++ b/src/test/resources/files/germplasm_import/missing_required_header.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,,,,,,
 Germplasm 2,,,,,,,
 Germplasm 3,,,,,,,

--- a/src/test/resources/files/germplasm_import/no_female_parent_blank_pedigree.csv
+++ b/src/test/resources/files/germplasm_import/no_female_parent_blank_pedigree.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,Wild,,2,,,,1234
 Germplasm 2,,Wild,,3,,,,5678
 Germplasm 3,,Wild,,3,,,,9123

--- a/src/test/resources/files/germplasm_import/nonnumerical_entry_numbers.csv
+++ b/src/test/resources/files/germplasm_import/nonnumerical_entry_numbers.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,Wild,,,a,,,
 Germplasm 2,,Wild,,,b,,,
 Germplasm 3,,Wild,,,3,,,

--- a/src/test/resources/files/germplasm_import/self_ref_parent_dependencies.csv
+++ b/src/test/resources/files/germplasm_import/self_ref_parent_dependencies.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,Wild,,,1,1,1,1234
 Germplasm 2,,Wild,,,2,2,2,5678
 Germplasm 3,,Wild,,,3,3,3,9123

--- a/src/test/resources/files/germplasm_import/some_entry_numbers.csv
+++ b/src/test/resources/files/germplasm_import/some_entry_numbers.csv
@@ -1,4 +1,4 @@
-﻿Name,Breeding Method,Source,Female Parent DBID,Male Parent DBID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
 Germplasm 1,,Wild,,,1,,,
 Germplasm 2,,Wild,,,,,,
 Germplasm 3,,Wild,,,3,,,


### PR DESCRIPTION
# Description
**Story:** (https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1219)

Updated the germplasm system import to accept "Parent GID" for column instead of "Parent DB ID". The BrAPI Importer was already updated so that did not needed any changes. 

I also needed to update the Germplasm Import test files to reflect the column header change.

# Dependencies
biweb: BI-1219 (https://github.com/Breeding-Insight/bi-web/pull/166)

# Testing
See biweb: BI-1219 for testing details. 


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF.
