### PR TITLE
[BI-1074 ] Add multiple error display and breeding method errors for germplasm import

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/model/ImportProgress.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/ImportProgress.java
@@ -26,8 +26,11 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
 import org.breedinginsight.dao.db.tables.pojos.ImporterProgressEntity;
 import org.jooq.Record;
+
+import java.util.ArrayList;
 import java.util.Map;
 
 import static org.breedinginsight.dao.db.tables.ImporterProgressTable.IMPORTER_PROGRESS;
@@ -39,6 +42,7 @@ import static org.breedinginsight.dao.db.tables.ImporterProgressTable.IMPORTER_P
 @ToString
 @SuperBuilder
 @NoArgsConstructor
+@Slf4j
 public class ImportProgress extends ImporterProgressEntity {
 
     public static ImportProgress parseSQLRecord(Record record) {
@@ -54,13 +58,17 @@ public class ImportProgress extends ImporterProgressEntity {
                 .build();
     }
 
-    @JsonProperty("errors")
-    public Map<String, Object> getErrors() throws JsonProcessingException {
+    @JsonProperty("rowErrors")
+    public ArrayList<Object> getRowErrors() throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
-        if(super.getBody() == null){
+        if (super.getBody() == null) {
             return null;
         }
-        return objectMapper.readValue(super.getBody().data(), Map.class);
+        return (ArrayList<Object>) (objectMapper.readValue(super.getBody().data(), Map.class)).get("rowErrors");
     }
 
 }
+
+
+
+

--- a/src/main/java/org/breedinginsight/brapps/importer/model/ImportProgress.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/ImportProgress.java
@@ -17,6 +17,9 @@
 
 package org.breedinginsight.brapps.importer.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -25,6 +28,7 @@ import lombok.experimental.Accessors;
 import lombok.experimental.SuperBuilder;
 import org.breedinginsight.dao.db.tables.pojos.ImporterProgressEntity;
 import org.jooq.Record;
+import java.util.Map;
 
 import static org.breedinginsight.dao.db.tables.ImporterProgressTable.IMPORTER_PROGRESS;
 
@@ -46,6 +50,17 @@ public class ImportProgress extends ImporterProgressEntity {
                 .total(record.getValue(IMPORTER_PROGRESS.TOTAL))
                 .finished(record.getValue(IMPORTER_PROGRESS.FINISHED))
                 .inProgress(record.getValue(IMPORTER_PROGRESS.IN_PROGRESS))
+                .body(record.getValue(IMPORTER_PROGRESS.BODY))
                 .build();
     }
+
+    @JsonProperty("errors")
+    public Map<String, Object> getErrors() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        if(super.getBody() == null){
+            return null;
+        }
+        return objectMapper.readValue(super.getBody().data(), Map.class);
+    }
+
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
@@ -23,6 +23,7 @@ import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
 import org.breedinginsight.services.exceptions.DoesNotExistException;
 import org.breedinginsight.services.exceptions.UnprocessableEntityException;
+import org.breedinginsight.services.exceptions.ValidatorException;
 import tech.tablesaw.api.Table;
 
 import java.util.List;
@@ -31,5 +32,5 @@ public abstract class BrAPIImportService {
     public String getImportTypeId() {return null;}
     public BrAPIImport getImportClass() {return null;}
     public ImportPreviewResponse process(List<BrAPIImport> brAPIImports, Table data, Program program, ImportUpload upload, User user, Boolean commit)
-            throws UnprocessableEntityException, DoesNotExistException {return null;}
+            throws UnprocessableEntityException, DoesNotExistException, ValidatorException {return null;}
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/germplasm/GermplasmImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/germplasm/GermplasmImportService.java
@@ -64,15 +64,11 @@ public class GermplasmImportService extends BrAPIImportService {
 
     @Override
     public ImportPreviewResponse process(List<BrAPIImport> brAPIImports, Table data, Program program, ImportUpload upload, User user, Boolean commit)
-            throws UnprocessableEntityException, DoesNotExistException {
+            throws UnprocessableEntityException, DoesNotExistException, ValidatorException {
 
         ImportPreviewResponse response = null;
         List<Processor> processors = List.of(germplasmProcessorProvider.get());
-        try {
-            response = processorManagerProvider.get().process(brAPIImports, processors, program, upload, user, commit);
-        } catch (ValidatorException e) {
-            log.error(e.getMessage());
-        }
+        response = processorManagerProvider.get().process(brAPIImports, processors, program, upload, user, commit);
         return response;
     }
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -249,7 +249,7 @@ public class GermplasmProcessor implements Processor {
                             breedingMethod = breedingMethods.get(germplasm.getBreedingMethod());
                         } else {
                             ValidationError ve = new ValidationError("Breeding Method", badBreedMethodsMsg, HttpStatus.UNPROCESSABLE_ENTITY);
-                            validationErrors.addError(i+1, ve );
+                            validationErrors.addError(i+2, ve );  // +2 instead of +1 to account for the column header row.
                             badBreedingMethods.add(germplasm.getBreedingMethod());
                             breedingMethod = null;
                         }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -29,6 +29,7 @@ import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapi.v2.services.BrAPIGermplasmService;
+
 import org.breedinginsight.brapps.importer.daos.BrAPIListDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.base.Germplasm;
@@ -201,7 +202,7 @@ public class GermplasmProcessor implements Processor {
 
     @Override
     public Map<String, ImportPreviewStatistics> process(List<BrAPIImport> importRows,
-                        Map<Integer, PendingImport> mappedBrAPIImport, Program program, User user, boolean commit) {
+                        Map<Integer, PendingImport> mappedBrAPIImport, Program program, User user, boolean commit) throws ValidatorException {
 
         // Method for generating accession number
         String germplasmSequenceName = program.getGermplasmSequence();
@@ -226,6 +227,7 @@ public class GermplasmProcessor implements Processor {
         List<String> badBreedingMethods = new ArrayList<>();
         Map<String, Integer> entryNumberCounts = new HashMap<>();
         List<String> userProvidedEntryNumbers = new ArrayList<>();
+        ValidationErrors validationErrors = new ValidationErrors();
         for (int i = 0; i < importRows.size(); i++) {
             BrAPIImport brapiImport = importRows.get(i);
             PendingImport mappedImportRow = mappedBrAPIImport.getOrDefault(i, new PendingImport());
@@ -246,6 +248,8 @@ public class GermplasmProcessor implements Processor {
                             breedingMethods.put(germplasm.getBreedingMethod(), breedingMethodResults.get(0));
                             breedingMethod = breedingMethods.get(germplasm.getBreedingMethod());
                         } else {
+                            ValidationError ve = new ValidationError("breeding_method",String.format(badBreedMethodsMsg, germplasm.getBreedingMethod()),HttpStatus.UNPROCESSABLE_ENTITY);
+                            validationErrors.addError(i+1, ve );
                             badBreedingMethods.add(germplasm.getBreedingMethod());
                             breedingMethod = null;
                         }
@@ -276,6 +280,9 @@ public class GermplasmProcessor implements Processor {
                 mappedImportRow.setGermplasm(null);
             }
             mappedBrAPIImport.put(i, mappedImportRow);
+        }
+        if (validationErrors.hasErrors() ){
+            throw new ValidatorException(validationErrors);
         }
 
         // Check for bad breeding methods

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -27,6 +27,8 @@ import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.core.BrAPIListSummary;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
+import org.breedinginsight.api.model.v1.response.ValidationError;
+import org.breedinginsight.api.model.v1.response.ValidationErrors;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapi.v2.services.BrAPIGermplasmService;
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -77,7 +77,7 @@ public class GermplasmProcessor implements Processor {
 
     public static String missingParentalDbIdsMsg = "The following parental GIDs were not found in the database: %s.";
     public static String missingParentalEntryNoMsg = "The following parental entry numbers were not found in the database: %s.";
-    public static String badBreedMethodsMsg = "Breeding methods not found: %s";
+    public static String badBreedMethodsMsg = "Invalid breeding method";
     public static String missingEntryNumbersMsg = "Either all or none of the germplasm must have entry numbers.";
     public static String duplicateEntryNoMsg = "Entry numbers must be unique. Duplicated entry numbers found: %s";
     public static String circularDependency = "Circular dependency in the pedigree tree";
@@ -248,7 +248,7 @@ public class GermplasmProcessor implements Processor {
                             breedingMethods.put(germplasm.getBreedingMethod(), breedingMethodResults.get(0));
                             breedingMethod = breedingMethods.get(germplasm.getBreedingMethod());
                         } else {
-                            ValidationError ve = new ValidationError("breeding_method",String.format(badBreedMethodsMsg, germplasm.getBreedingMethod()),HttpStatus.UNPROCESSABLE_ENTITY);
+                            ValidationError ve = new ValidationError("Breeding Method", badBreedMethodsMsg, HttpStatus.UNPROCESSABLE_ENTITY);
                             validationErrors.addError(i+1, ve );
                             badBreedingMethods.add(germplasm.getBreedingMethod());
                             breedingMethod = null;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
@@ -51,7 +51,6 @@ public class ProcessorManager {
     }
 
     public ImportPreviewResponse process(List<BrAPIImport> importRows, List<Processor> processors, Program program, ImportUpload upload, User user, boolean commit) throws ValidatorException {
-
         this.processors = processors;
         statusService.setUpload(upload);
 

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
@@ -469,7 +469,6 @@ public class GermplasmTemplateMap extends BrAPITest {
 
         JsonArray errorList = result
                 .getAsJsonObject("progress")
-                .getAsJsonObject("errors")
                 .getAsJsonArray("rowErrors");
         assertEquals(2, errorList.size());
 

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
@@ -466,10 +466,18 @@ public class GermplasmTemplateMap extends BrAPITest {
         HttpResponse<String> upload = getUploadedFile(importId);
         JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
         assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt());
-        List<String> badBreedingMethods = List.of("BAD", "BAD1");
-        assertEquals(String.format(GermplasmProcessor.badBreedMethodsMsg, GermplasmProcessor.arrayOfStringFormatter.apply(badBreedingMethods)),
-                result.getAsJsonObject("progress").get("message").getAsString());
 
+        JsonArray errorList = result
+                .getAsJsonObject("progress")
+                .getAsJsonObject("errors")
+                .getAsJsonArray("rowErrors");
+        assertEquals(2, errorList.size());
+
+        JsonObject firstError = errorList
+                .get(0).getAsJsonObject()
+                .getAsJsonArray("errors").get(0).getAsJsonObject();
+        assertEquals("Invalid breeding method", firstError.get("errorMessage").getAsString());
+        assertEquals("Breeding Method",         firstError.get("field").getAsString());
     }
 
     @Test


### PR DESCRIPTION
# Description
**Story:**  [Story: BI-1074 - 1.4 Germplasm Import - Validate Breeding Methods](https://breedinginsight.atlassian.net/browse/BI-1074)

When Importing Germplasms, validate the breading methods against the breeding_method table.



# Dependencies
Must be run with bi-web branch feature/BI-1074.

# Checklist:

- [ x] I have performed a self-review of my own code
- x[ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF.
