### PR TITLE
[BI-1149] Highlighting duplicate germplasm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,6 +370,11 @@
             <artifactId>alphanumeric-comparator</artifactId>
             <version>1.4.1</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.kostaskougios</groupId>
+            <artifactId>cloning</artifactId>
+            <version>1.10.3</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/ProgramCache.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/ProgramCache.java
@@ -62,6 +62,7 @@ public class ProgramCache<R> {
 
     public ProgramCache(FetchFunction fetchMethod) {
         this.fetchMethod = fetchMethod;
+        this.cloner = new Cloner();
     }
 
     public List<R> get(UUID programId) throws ApiException {

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -16,10 +16,6 @@ import org.breedinginsight.services.exceptions.DoesNotExistException;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.brapi.v2.model.germ.request.BrAPIGermplasmSearchRequest;
-import org.breedinginsight.daos.ProgramDAO;
-import org.breedinginsight.services.brapi.BrAPIClientType;
-import org.breedinginsight.services.brapi.BrAPIProvider;
-import org.breedinginsight.utilities.BrAPIDAOUtil;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -29,7 +25,6 @@ import java.util.*;
 @Singleton
 public class BrAPIGermplasmService {
 
-    private ProgramDAO programDAO;
     @Property(name = "brapi.server.reference-source")
     private String referenceSource;
 
@@ -39,16 +34,13 @@ public class BrAPIGermplasmService {
     private BrAPIListDAO brAPIListDAO;
 
     @Inject
-    public BrAPIGermplasmService(BrAPIListDAO brAPIListDAO, ProgramService programService, BrAPIGermplasmDAO germplasmDAO, ProgramDAO programDAO) {
+    public BrAPIGermplasmService(BrAPIListDAO brAPIListDAO, ProgramService programService, BrAPIGermplasmDAO germplasmDAO) {
         this.brAPIListDAO = brAPIListDAO;
         this.programService = programService;
         this.germplasmDAO = germplasmDAO;
-        this.programDAO = programDAO;
     }
     
     public List<BrAPIGermplasm> getGermplasm(UUID programId) {
-
-        GermplasmApi api = new GermplasmApi(programDAO.getCoreClient(programId));
 
         // Set query params and make call
         BrAPIGermplasmSearchRequest germplasmSearch = new BrAPIGermplasmSearchRequest();

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -120,8 +120,8 @@ public class BrAPIGermplasmService {
         return germplasmDAO.importBrAPIGermplasm(brAPIGermplasmList, programId, upload);
     }
 
-    public List<BrAPIGermplasm> getGermplasmByAccessionNumber(ArrayList<String> germplasmAccessionNumbers, UUID programId) throws ApiException {
-        List<BrAPIGermplasm> germplasmList = getGermplasm(programId);
+    public List<BrAPIGermplasm> getRawGermplasmByAccessionNumber(ArrayList<String> germplasmAccessionNumbers, UUID programId) throws ApiException {
+        List<BrAPIGermplasm> germplasmList = germplasmDAO.getGermplasm(programId);
         List<BrAPIGermplasm> resultGermplasm = new ArrayList<>();
         // Search for accession number matches
         for (BrAPIGermplasm germplasm: germplasmList) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -127,7 +127,7 @@ public class GermplasmProcessor implements Processor {
         List<String> missingDbIds = new ArrayList<>(germplasmDBIDs);
         if (germplasmDBIDs.size() > 0) {
             try {
-                existingParentGermplasms = brAPIGermplasmService.getGermplasmByAccessionNumber(new ArrayList<>(germplasmDBIDs), program.getId());
+                existingParentGermplasms = brAPIGermplasmService.getRawGermplasmByAccessionNumber(new ArrayList<>(germplasmDBIDs), program.getId());
                 List<String> existingDbIds = existingParentGermplasms.stream()
                         .map(germplasm -> germplasm.getAccessionNumber())
                         .collect(Collectors.toList());

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
@@ -301,7 +301,6 @@ public class GermplasmTemplateMap extends BrAPITest {
             assertTrue(referenceFound, "Germplasm UUID reference not found");
         }
 
-        // TODO: Reintroduce with 1251 fix
         // Check the germplasm list
         checkGermplasmList(Germplasm.constructGermplasmListName(listName, validProgram), listDescription, germplasmNames);
     }

--- a/src/test/resources/files/germplasm_import/duplicate_db_names.csv
+++ b/src/test/resources/files/germplasm_import/duplicate_db_names.csv
@@ -1,0 +1,7 @@
+Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID
+Full Germplasm 1,ANE,Wild,,,,,,
+Full Germplasm 2,ANE,Wild,,,,,,
+Full Germplasm 3,ANE,Wild,,,,,,
+Unique Germplasm 1,ANE,Wild,,,,,,
+File Germplasm 1,ANE,Wild,,,,,,
+File Germplasm 1,ANE,Wild,,,,,,


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1149

- Uses the import object state (EXISTING) to mark potential duplicates in the germplasm import. 
- Doesn't indicate the reason for the duplicate marking, but since name is our only reason right now that isn't a current issue. 
  - If we need more details in the future we can add a `warnings` field that looks like our multiple error return. 
- Added tests



# Dependencies
bi-web: BI-1149

# Testing
See bi-web branch for testing


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF.
