### PR TITLE
[BI-1315] germplasm import: fix next val germplasm sequence call

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -199,7 +199,7 @@ public class GermplasmProcessor implements Processor {
             log.error(String.format("Program, %s, is missing a value in the germplasm sequence column.", program.getName()));
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Program is not properly configured for germplasm import");
         }
-        Supplier<BigInteger> nextVal = () -> dsl.nextval(program.getGermplasmSequence());
+        Supplier<BigInteger> nextVal = () -> dsl.nextval(germplasmSequenceName.toLowerCase());
 
         // Create new objects
 


### PR DESCRIPTION
# Description

There is a bug with dsl.nextval() that gets our germplasm sequence values where it surrounds program keys that aren't lowercased with quotes, select nextval('"program_sequence"'). This causes a not found error in psql. 





# Dependencies
none

# Testing
Uppercase the program key in one of your germplasm sequences. For example, change bb_germplasm_sequence to BB_germplasm_sequence. 


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF.
