### PR TITLE
[BI-1281] refactor obsVarName error messages to use Name

### DIFF
--- a/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
@@ -37,22 +37,22 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getTraitIdDoesNotExistMsg() {
-        return new ValidationError("traitId", "Missing trait id", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Trait Id", "Missing trait id", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getMissingMethodMsg() {
-        return new ValidationError("method", "Missing method", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Method", "Missing method", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getMissingMethodClassMsg() {
-        return new ValidationError("Method class", "Missing method class", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Method Class", "Missing method class", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getMissingScaleMsg() {
-        return new ValidationError("scale", "Missing scale class", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Scale", "Missing scale class", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getMissingScaleDataTypeMsg() {
-        return new ValidationError("Scale class", "Missing scale class", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Scale Class", "Missing scale class", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
@@ -72,39 +72,39 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getMissingTraitEntityMsg() {
-        return new ValidationError("Trait entity", "Missing trait entity", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Trait Entity", "Missing trait entity", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getMissingTraitAttributeMsg() {
-        return new ValidationError("Trait attribute", "Missing trait attribute", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Trait Attribute", "Missing trait attribute", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getMissingTraitDescriptionMsg() {
-        return new ValidationError("Trait description", "Missing trait description", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Trait Description", "Missing trait description", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getMissingProgramObservationLevelMsg() {
-        return new ValidationError("Trait level", "Missing trait level", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Trait Level", "Missing trait level", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getMissingMethodFormulaMsg() {
-        return new ValidationError("Method formula", "Missing method formula for Computation method", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Method Formula", "Missing method formula for Computation method", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getMissingScaleCategoriesMsg(DataType dataType) {
-        return new ValidationError("Scale categories",
+        return new ValidationError("Scale Categories",
                 String.format("Missing scale categories for %s scale", WordUtils.capitalize(dataType.getLiteral().toLowerCase())),
                 HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getBadScaleCategory() {
-        return new ValidationError("Scale categories", "Scale categories contain errors", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Scale Categories", "Scale categories contain errors", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
@@ -145,12 +145,12 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getCharLimitTraitEntityMsg() {
-        return new ValidationError("entity", "Trait entity exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Entity", "Trait entity exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getCharLimitTraitAttributeMsg() {
-        return new ValidationError("attribute", "Trait attribute exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Attribute", "Trait attribute exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
@@ -160,13 +160,13 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getDuplicateTraitByNamesMsg() {
-        return new ValidationError("Trait name", "Trait name already exists", HttpStatus.CONFLICT);
+        return new ValidationError("Trait Name", "Trait name already exists", HttpStatus.CONFLICT);
     }
     
     @Override
     public ValidationError getDuplicateTraitsByNameInFileMsg(List<Integer> matchingRows) {
         matchingRows = matchingRows.stream().map(rowIndex -> getRowNumber(rowIndex)).collect(Collectors.toList());
-        return new ValidationError("Trait name",
+        return new ValidationError("Trait Name",
                 "Trait name duplicated in file. Duplicate set of traits are rows " + matchingRows.toString(),
                 HttpStatus.CONFLICT);
     }

--- a/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
@@ -130,12 +130,12 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getInsufficientNominalValError() {
-        return new ValidationError("scale.categories", "Nominal scales must have at least one category.", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Scale Categories", "Nominal scales must have at least one category.", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getInsufficientOrdinalValError() {
-        return new ValidationError("scale.categories", "Ordinal scales must have at least two categories.", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Scale Categories", "Ordinal scales must have at least two categories.", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
@@ -155,7 +155,7 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getCharLimitMethodDescriptionMsg() {
-        return new ValidationError("method.description", "Method description exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Method Description", "Method description exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override

--- a/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
@@ -67,7 +67,7 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getMissingObsVarNameMsg() {
-        return new ValidationError("Observation variable name", "Missing observation variable name", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Name", "Missing name", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
@@ -140,7 +140,7 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getCharLimitObsVarNameMsg() {
-        return new ValidationError("observationVariableName", "Observation variable name exceeds 12 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Name", "Name exceeds 12 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
@@ -67,7 +67,7 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getMissingObsVarNameMsg() {
-        return new ValidationError("observationVariableName", "Missing observation variable name", HttpStatus.BAD_REQUEST);
+        return new ValidationError("name", "Missing Name", HttpStatus.BAD_REQUEST);
     }
 
     @Override
@@ -140,7 +140,7 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getCharLimitObsVarNameMsg() {
-        return new ValidationError("observationVariableName", "Observation variable name exceeds 12 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("name", "Name exceeds 12 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
@@ -37,62 +37,62 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getTraitIdDoesNotExistMsg() {
-        return new ValidationError("traitId", "Trait with that id does not exist", HttpStatus.NOT_FOUND);
+        return new ValidationError("Trait Id", "Trait with that id does not exist", HttpStatus.NOT_FOUND);
     }
 
     @Override
     public ValidationError getMissingMethodMsg() {
-        return new ValidationError("method", "Missing method", HttpStatus.BAD_REQUEST);
+        return new ValidationError("Method", "Missing method", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingMethodClassMsg() {
-        return new ValidationError("method.methodClass", "Missing method class", HttpStatus.BAD_REQUEST);
+        return new ValidationError("Method Class", "Missing method class", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingScaleMsg() {
-        return new ValidationError("scale", "Missing scale", HttpStatus.BAD_REQUEST);
+        return new ValidationError("Scale", "Missing scale", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingScaleNameMsg() {
-        return new ValidationError("scale.scaleName", "Missing scale name", HttpStatus.BAD_REQUEST);
+        return new ValidationError("Scale Name", "Missing scale name", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingScaleDataTypeMsg() {
-        return new ValidationError("scale.dataType", "Missing scale data type", HttpStatus.BAD_REQUEST);
+        return new ValidationError("Scale Data Type", "Missing scale data type", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingObsVarNameMsg() {
-        return new ValidationError("name", "Missing Name", HttpStatus.BAD_REQUEST);
+        return new ValidationError("Name", "Missing Name", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingTraitEntityMsg() {
-        return new ValidationError("entity", "Missing trait entity", HttpStatus.BAD_REQUEST);
+        return new ValidationError("Entity", "Missing trait entity", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingTraitAttributeMsg() {
-        return new ValidationError("attribute", "Missing trait attribute", HttpStatus.BAD_REQUEST);
+        return new ValidationError("Attribute", "Missing trait attribute", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingTraitDescriptionMsg() {
-        return new ValidationError("traitDescription", "Missing trait description", HttpStatus.BAD_REQUEST);
+        return new ValidationError("Trait Description", "Missing trait description", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingProgramObservationLevelMsg() {
-        return new ValidationError("programObservationLevel.name", "Missing program observation level", HttpStatus.BAD_REQUEST);
+        return new ValidationError("Program Observation Level Name", "Missing program observation level", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingMethodFormulaMsg() {
-        return new ValidationError("method.formula", "Missing method formula for Computation method", HttpStatus.BAD_REQUEST);
+        return new ValidationError("Method Formula", "Missing method formula for Computation method", HttpStatus.BAD_REQUEST);
     }
 
     @Override
@@ -123,7 +123,7 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getMaxLessThenMinError() {
-        return new ValidationError("scale.validValueMax",
+        return new ValidationError("Scale Valid Value Max",
                 "Scale valid value max must be greater than valid value min.",
                 HttpStatus.UNPROCESSABLE_ENTITY);
     }
@@ -140,17 +140,17 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getCharLimitObsVarNameMsg() {
-        return new ValidationError("name", "Name exceeds 12 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Name", "Name exceeds 12 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getCharLimitTraitEntityMsg() {
-        return new ValidationError("entity", "Trait entity exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Entity", "Trait entity exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getCharLimitTraitAttributeMsg() {
-        return new ValidationError("attribute", "Trait attribute exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Attribute", "Trait attribute exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
@@ -160,14 +160,14 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getDuplicateTraitByNamesMsg() {
-        return new ValidationError("traitName", "Trait name already exists", HttpStatus.CONFLICT);
+        return new ValidationError("Trait Name", "Trait name already exists", HttpStatus.CONFLICT);
     }
 
 
     @Override
     public ValidationError getDuplicateTraitsByNameInFileMsg(List<Integer> matchingRows) {
         matchingRows = matchingRows.stream().map(rowIndex -> getRowNumber(rowIndex)).collect(Collectors.toList());
-        return new ValidationError("traitName",
+        return new ValidationError("Trait Name",
                 "traitName is a duplicate. Duplicate set of traits are rows " + matchingRows.toString(),
                 HttpStatus.CONFLICT);
     }

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
@@ -97,26 +97,26 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getMissingScaleCategoriesMsg(DataType dataType) {
-        return new ValidationError("scale.categories",
+        return new ValidationError("Scale Categories",
                 String.format("Missing scale categories for %s scale", WordUtils.capitalize(dataType.getLiteral().toLowerCase())),
                 HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getBadScaleCategory() {
-        return new ValidationError("scale.categories", "Scale categories contain errors", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Scale Categories", "Scale categories contain errors", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getBlankScaleCategoryLabelMsg() {
-        return new ValidationError("scale.categories.label",
+        return new ValidationError("Scale Categories Label",
                 "Label missing.",
                 HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getBlankScaleCategoryValueMsg() {
-        return new ValidationError("scale.categories.value",
+        return new ValidationError("Scale Categories Value",
                 "Value missing.",
                 HttpStatus.UNPROCESSABLE_ENTITY);
     }
@@ -130,12 +130,12 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getInsufficientNominalValError() {
-        return new ValidationError("scale.categories", "Nominal scales must have at least one category.", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Scale Categories", "Nominal scales must have at least one category.", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getInsufficientOrdinalValError() {
-        return new ValidationError("scale.categories", "Ordinal scales must have at least two categories.", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Scale Categories", "Ordinal scales must have at least two categories.", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
@@ -155,7 +155,7 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getCharLimitMethodDescriptionMsg() {
-        return new ValidationError("method.description", "Method description exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Method Description", "Method description exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override

--- a/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
@@ -1227,7 +1227,7 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         JsonArray errors = rowError.getAsJsonArray("errors");
         assertEquals(1, errors.size(), "Not enough errors were returned");
         JsonObject error1 = errors.get(0).getAsJsonObject();
-        assertEquals("observationVariableName", error1.get("field").getAsString(), "wrong error returned");
+        assertEquals("name", error1.get("field").getAsString(), "wrong error returned");
 
         JsonObject badIdRowError = rowErrors.get(1).getAsJsonObject();
         errors = badIdRowError.getAsJsonArray("errors");

--- a/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
@@ -1004,12 +1004,12 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         JsonObject categoryError = categoryErrors.get(0).getAsJsonObject();
         assertEquals(0, categoryError.get("rowIndex").getAsInt(), "wrong error row index returned");
         JsonObject valueError = categoryError.getAsJsonArray("errors").get(0).getAsJsonObject();
-        assertEquals("scale.categories.value", valueError.get("field").getAsString(), "wrong error returned");
+        assertEquals("Scale Categories Value", valueError.get("field").getAsString(), "wrong error returned");
 
         JsonObject secondCategoryError = categoryErrors.get(1).getAsJsonObject();
         assertEquals(2, secondCategoryError.get("rowIndex").getAsInt(), "wrong error row index returned");
         JsonObject labelError = secondCategoryError.getAsJsonArray("errors").get(0).getAsJsonObject();
-        assertEquals("scale.categories.label", labelError.get("field").getAsString(), "wrong error returned");
+        assertEquals("Scale Categories Label", labelError.get("field").getAsString(), "wrong error returned");
     }
 
     @Test

--- a/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
@@ -1227,13 +1227,13 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         JsonArray errors = rowError.getAsJsonArray("errors");
         assertEquals(1, errors.size(), "Not enough errors were returned");
         JsonObject error1 = errors.get(0).getAsJsonObject();
-        assertEquals("name", error1.get("field").getAsString(), "wrong error returned");
+        assertEquals("Name", error1.get("field").getAsString(), "wrong error returned");
 
         JsonObject badIdRowError = rowErrors.get(1).getAsJsonObject();
         errors = badIdRowError.getAsJsonArray("errors");
         assertEquals(1, errors.size(), "Not enough errors were returned");
         JsonObject error = errors.get(0).getAsJsonObject();
-        assertEquals("traitId", error.get("field").getAsString(), "wrong error returned");
+        assertEquals("Trait Id", error.get("field").getAsString(), "wrong error returned");
     }
 
     @Test
@@ -1309,7 +1309,7 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         JsonArray errors = rowError.getAsJsonArray("errors");
         assertEquals(1, errors.size(), "Not enough errors were returned");
         JsonObject error = errors.get(0).getAsJsonObject();
-        assertEquals("traitId", error.get("field").getAsString(), "wrong error returned");
+        assertEquals("Trait Id", error.get("field").getAsString(), "wrong error returned");
     }
 
     @Test

--- a/src/test/java/org/breedinginsight/api/v1/controller/TraitUploadControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/TraitUploadControllerIntegrationTest.java
@@ -427,8 +427,8 @@ public class TraitUploadControllerIntegrationTest extends BrAPITest {
         JsonArray rowValidationErrors = rowErrors.get(0).getAsJsonObject().get("errors").getAsJsonArray();
         assertEquals(1, rowValidationErrors.size(), "Wrong number of errors for row");
         JsonObject error = rowValidationErrors.get(0).getAsJsonObject();
-        assertTrue(error.get("field").getAsString().contains("Trait entity"), "Wrong field returned");
-        assertFalse(error.get("field").getAsString().contains("Trait level"), "Wrong field returned");
+        assertTrue(error.get("field").getAsString().contains("Trait Entity"), "Wrong field returned");
+        assertFalse(error.get("field").getAsString().contains("Trait Level"), "Wrong field returned");
     }
 
     @Test
@@ -445,7 +445,7 @@ public class TraitUploadControllerIntegrationTest extends BrAPITest {
       JsonArray rowValidationErrors = rowErrors.get(0).getAsJsonObject().get("errors").getAsJsonArray();
       assertEquals(1, rowValidationErrors.size(), "Wrong number of errors for row");
       JsonObject error = rowValidationErrors.get(0).getAsJsonObject();
-      assertTrue(error.get("field").getAsString().contains("Scale class"), "Wrong field returned");
+      assertTrue(error.get("field").getAsString().contains("Scale Class"), "Wrong field returned");
       assertFalse(error.get("field").getAsString().contains("Unit"), "Wrong field returned");
     }
 

--- a/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
@@ -143,7 +143,7 @@ public class TraitValidatorUnitTest {
         RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
         assertEquals(6, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         Map<String, Integer> expectedColumns = new HashMap<>();
-        expectedColumns.put("observationVariableName", 400);
+        expectedColumns.put("name", 400);
         expectedColumns.put("entity", 400);
         expectedColumns.put("attribute", 400);
         expectedColumns.put("traitDescription", 400);
@@ -328,7 +328,7 @@ public class TraitValidatorUnitTest {
         assertEquals(4, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
 
         Map<String, Integer> expectedColumns = new HashMap<>();
-        expectedColumns.put("observationVariableName", 422);
+        expectedColumns.put("name", 422);
         expectedColumns.put("entity", 422);
         expectedColumns.put("attribute", 422);
         expectedColumns.put("method.description", 422);

--- a/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
@@ -188,7 +188,7 @@ public class TraitValidatorUnitTest {
         assertEquals(2, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         Map<String, Integer> expectedColumns = new HashMap<>();
         expectedColumns.put("method.formula", 400);
-        expectedColumns.put("scale.categories", 400);
+        expectedColumns.put("Scale Categories", 400);
         List<Boolean> seenTrackList = expectedColumns.keySet().stream().map(column -> false).collect(Collectors.toList());
 
         Boolean unknownColumnReturned = false;
@@ -230,7 +230,7 @@ public class TraitValidatorUnitTest {
         assertEquals(2, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         Map<String, Integer> expectedColumns = new HashMap<>();
         expectedColumns.put("method.formula", 400);
-        expectedColumns.put("scale.categories", 422);
+        expectedColumns.put("Scale Categories", 422);
         List<Boolean> seenTrackList = expectedColumns.keySet().stream().map(column -> false).collect(Collectors.toList());
 
         Boolean unknownColumnReturned = false;

--- a/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
@@ -331,7 +331,7 @@ public class TraitValidatorUnitTest {
         expectedColumns.put("name", 422);
         expectedColumns.put("entity", 422);
         expectedColumns.put("attribute", 422);
-        expectedColumns.put("method.description", 422);
+        expectedColumns.put("Method Description", 422);
         List<Boolean> seenTrackList = expectedColumns.keySet().stream().map(column -> false).collect(Collectors.toList());
 
         Boolean unknownColumnReturned = false;

--- a/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
@@ -91,7 +91,7 @@ public class TraitValidatorUnitTest {
         RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
         assertEquals(1, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         assertEquals(400, rowValidationErrors.getErrors().get(0).getHttpStatusCode(), "Wrong error code");
-        assertEquals("method", rowValidationErrors.getErrors().get(0).getField(), "Wrong error column");
+        assertEquals("Method", rowValidationErrors.getErrors().get(0).getField(), "Wrong error column");
     }
 
     @Test
@@ -124,7 +124,7 @@ public class TraitValidatorUnitTest {
         RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
         assertEquals(1, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         assertEquals(400, rowValidationErrors.getErrors().get(0).getHttpStatusCode(), "Wrong error code");
-        assertEquals("scale", rowValidationErrors.getErrors().get(0).getField(), "Wrong error column");
+        assertEquals("Scale", rowValidationErrors.getErrors().get(0).getField(), "Wrong error column");
     }
 
     @Test
@@ -143,14 +143,14 @@ public class TraitValidatorUnitTest {
         RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
         assertEquals(6, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         Map<String, Integer> expectedColumns = new HashMap<>();
-        expectedColumns.put("name", 400);
-        expectedColumns.put("entity", 400);
-        expectedColumns.put("attribute", 400);
-        expectedColumns.put("traitDescription", 400);
-        expectedColumns.put("programObservationLevel.name", 400);
-        expectedColumns.put("method.methodClass", 400);
-        expectedColumns.put("scale.scaleName", 400);
-        expectedColumns.put("scale.dataType", 400);
+        expectedColumns.put("Name", 400);
+        expectedColumns.put("Entity", 400);
+        expectedColumns.put("Attribute", 400);
+        expectedColumns.put("Trait Description", 400);
+        expectedColumns.put("Program Observation Level Name", 400);
+        expectedColumns.put("Method Class", 400);
+        expectedColumns.put("Scale Name", 400);
+        expectedColumns.put("Scale Data Type", 400);
         List<Boolean> seenTrackList = expectedColumns.keySet().stream().map(column -> false).collect(Collectors.toList());
 
         Boolean unknownColumnReturned = false;
@@ -187,7 +187,7 @@ public class TraitValidatorUnitTest {
         RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
         assertEquals(2, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         Map<String, Integer> expectedColumns = new HashMap<>();
-        expectedColumns.put("method.formula", 400);
+        expectedColumns.put("Method Formula", 400);
         expectedColumns.put("Scale Categories", 400);
         List<Boolean> seenTrackList = expectedColumns.keySet().stream().map(column -> false).collect(Collectors.toList());
 
@@ -229,7 +229,7 @@ public class TraitValidatorUnitTest {
         RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
         assertEquals(2, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         Map<String, Integer> expectedColumns = new HashMap<>();
-        expectedColumns.put("method.formula", 400);
+        expectedColumns.put("Method Formula", 400);
         expectedColumns.put("Scale Categories", 422);
         List<Boolean> seenTrackList = expectedColumns.keySet().stream().map(column -> false).collect(Collectors.toList());
 
@@ -328,9 +328,9 @@ public class TraitValidatorUnitTest {
         assertEquals(4, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
 
         Map<String, Integer> expectedColumns = new HashMap<>();
-        expectedColumns.put("name", 422);
-        expectedColumns.put("entity", 422);
-        expectedColumns.put("attribute", 422);
+        expectedColumns.put("Name", 422);
+        expectedColumns.put("Entity", 422);
+        expectedColumns.put("Attribute", 422);
         expectedColumns.put("Method Description", 422);
         List<Boolean> seenTrackList = expectedColumns.keySet().stream().map(column -> false).collect(Collectors.toList());
 


### PR DESCRIPTION
# Description
**Story:** [BI-1281](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1281)

trait import validation error messages for observation variable names were changed to refer instead to "name"



# Dependencies
bi-web `develop`

# Testing
try importing a trait with a name that exceeds the 12 char limit.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
