### PR TITLE
[BI-1370] ontology search: add trait description sorting

### DIFF
--- a/src/main/java/org/breedinginsight/utilities/response/mappers/TraitQueryMapper.java
+++ b/src/main/java/org/breedinginsight/utilities/response/mappers/TraitQueryMapper.java
@@ -35,6 +35,7 @@ public class TraitQueryMapper extends AbstractQueryMapper {
 
         fields = Map.ofEntries(
                 Map.entry("name", Trait::getObservationVariableName),
+                Map.entry("traitDescription", Trait::getTraitDescription),
                 Map.entry("mainAbbreviation", Trait::getMainAbbreviation),
                 Map.entry("synonyms", Trait::getSynonyms),
                 Map.entry("level",

--- a/src/test/java/org/breedinginsight/TestUtils.java
+++ b/src/test/java/org/breedinginsight/TestUtils.java
@@ -38,13 +38,16 @@ import java.util.UUID;
 
 import static io.micronaut.http.HttpRequest.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestUtils {
 
     public static void checkStringSorting(JsonArray data, String field, SortOrder sortOrder) {
 
+        Integer missedFields = 0;
         for (int i = 0; i < data.size() - 1; i++){
             if (!data.get(i).getAsJsonObject().has(field) || !data.get(i + 1).getAsJsonObject().has(field)) {
+                missedFields += 1;
                 continue;
             }
             String firstValue = data.get(i).getAsJsonObject().get(field).getAsString();
@@ -63,6 +66,7 @@ public class TestUtils {
 
         }
 
+        assertTrue(missedFields < data.size() -1, "No fields by the name " + field + "were found.");
     }
 
     public static void checkNumericSorting(JsonArray data, String field, SortOrder sortOrder) {

--- a/src/test/java/org/breedinginsight/TestUtils.java
+++ b/src/test/java/org/breedinginsight/TestUtils.java
@@ -66,7 +66,7 @@ public class TestUtils {
 
         }
 
-        assertTrue(missedFields < data.size() -1, "No fields by the name " + field + "were found.");
+        assertTrue(missedFields < data.size() -1 || data.size() == 1, "No fields by the name " + field + "were found.");
     }
 
     public static void checkNumericSorting(JsonArray data, String field, SortOrder sortOrder) {

--- a/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
@@ -1088,6 +1088,28 @@ public class TraitControllerIntegrationTest extends BrAPITest {
     }
 
     @Test
+    @Order(12)
+    public void searchTraitsByDescription() {
+
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.setFilters(new ArrayList<>());
+        searchRequest.getFilters().add(new FilterRequest("name", "trait1"));
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/" + validProgram.getId() + "/traits/search?page=1&pageSize=20&sortField=traitDescription&sortOrder=ASC", searchRequest).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        JsonObject result = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result");
+        JsonArray data = result.get("data").getAsJsonArray();
+
+        assertEquals(11, data.size(), "Wrong page size");
+        TestUtils.checkStringSorting(data, "traitDescription", SortOrder.ASC);
+    }
+
+    @Test
     @Order(13)
     public void postTraitComputation() {
 


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1370

Add traitDescription to the trait controller sort/filtering. 



# Dependencies
bi-web: BI-1370

# Testing
You can use this file to load some traits into your system if you need them. 

[BI_1373_good_traits.xls](https://github.com/Breeding-Insight/bi-api/files/8089829/BI_1373_good_traits.xls)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
