### PR TITLE
BI-1408 - ISSUE - All Germplasm Table stuck loading when connected with Breedbase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,8 +278,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>3.2.4</version>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -50,6 +50,7 @@ public class GermplasmController {
             @PathVariable("programId") UUID programId,
             @QueryValue @QueryValid(using = GermplasmQueryMapper.class) @Valid BrapiQuery queryParams) {
         try {
+            log.debug("fetching germ for program: " + programId);
             List<BrAPIGermplasm> germplasm = germplasmService.getGermplasm(programId);
             queryParams.setSortField(germplasmQueryMapper.getDefaultSortField());
             queryParams.setSortOrder(germplasmQueryMapper.getDefaultSortOrder());

--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -34,8 +34,8 @@ import java.util.UUID;
 @Secured(SecurityRule.IS_AUTHENTICATED)
 public class GermplasmController {
 
-    private BrAPIGermplasmService germplasmService;
-    private GermplasmQueryMapper germplasmQueryMapper;
+    private final BrAPIGermplasmService germplasmService;
+    private final GermplasmQueryMapper germplasmQueryMapper;
 
     @Inject
     public GermplasmController(BrAPIGermplasmService germplasmService, GermplasmQueryMapper germplasmQueryMapper) {
@@ -53,11 +53,10 @@ public class GermplasmController {
             List<BrAPIGermplasm> germplasm = germplasmService.getGermplasm(programId);
             queryParams.setSortField(germplasmQueryMapper.getDefaultSortField());
             queryParams.setSortOrder(germplasmQueryMapper.getDefaultSortOrder());
-            return ResponseUtils.getBrapiQueryResponse(germplasm, germplasmQueryMapper, queryParams);}
-        catch (ApiException e) {
-            log.info(e.getMessage());
-            HttpResponse response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, "Error retrieving germplasm");
-            return response;
+            return ResponseUtils.getBrapiQueryResponse(germplasm, germplasmQueryMapper, queryParams);
+        } catch (ApiException e) {
+            log.info(e.getMessage(), e);
+            return HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, "Error retrieving germplasm");
         }
     }
 

--- a/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
@@ -1,0 +1,22 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapi.v2.constants;
+
+public final class BrAPIAdditionalInfoFields {
+    public static final String GERMPLASM_RAW_PEDIGREE = "rawPedigree";
+}

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -17,6 +17,7 @@
 
 package org.breedinginsight.brapi.v2.dao;
 
+import com.google.gson.JsonObject;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.http.server.exceptions.InternalServerException;
@@ -34,9 +35,7 @@ import org.breedinginsight.utilities.BrAPIDAOUtil;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
@@ -45,8 +44,10 @@ import java.util.stream.Collectors;
 @Context
 public class BrAPIGermplasmDAO {
 
-    private ProgramDAO programDAO;
-    private ImportDAO importDAO;
+    private final String BREEDING_METHOD_ID_KEY = "breedingMethodId";
+
+    private final ProgramDAO programDAO;
+    private final ImportDAO importDAO;
 
     @Property(name = "brapi.server.reference-source")
     private String referenceSource;
@@ -63,7 +64,7 @@ public class BrAPIGermplasmDAO {
     private void setup() {
         // Populate germplasm cache for all programs on startup
         List<UUID> programs = programDAO.getAll().stream().map(Program::getId).collect(Collectors.toList());
-        programGermplasmCache = new ProgramCache<>((programId) -> fetchProgramGermplasm((UUID) programId), programs);
+        programGermplasmCache = new ProgramCache<>(this::fetchProgramGermplasm, programs);
     }
 
     public List<BrAPIGermplasm> getGermplasm(UUID programId) throws ApiException {
@@ -75,21 +76,59 @@ public class BrAPIGermplasmDAO {
 
         // Set query params and make call
         BrAPIGermplasmSearchRequest germplasmSearch = new BrAPIGermplasmSearchRequest();
-        germplasmSearch.externalReferenceIDs(Arrays.asList(programId.toString()));
-        germplasmSearch.externalReferenceSources(Arrays.asList(String.format("%s/programs", referenceSource)));
-        return BrAPIDAOUtil.search(
+        germplasmSearch.externalReferenceIDs(List.of(programId.toString()));
+        germplasmSearch.externalReferenceSources(List.of(String.format("%s/programs", referenceSource)));
+        return processGermplasmForDisplay(BrAPIDAOUtil.search(
                 api::searchGermplasmPost,
                 api::searchGermplasmSearchResultsDbIdGet,
                 germplasmSearch
-        );
+        ));
+    }
+
+    private List<BrAPIGermplasm> processGermplasmForDisplay(List<BrAPIGermplasm> programGermplasm) {
+        // Process the germplasm
+        Map<String, BrAPIGermplasm> programGermplasmByFullName = new HashMap<>();
+        for (BrAPIGermplasm germplasm: programGermplasm) {
+            programGermplasmByFullName.put(germplasm.getGermplasmName(), germplasm);
+
+            JsonObject additionalInfo = germplasm.getAdditionalInfo();
+            if (additionalInfo != null && additionalInfo.has(BREEDING_METHOD_ID_KEY)) {
+                germplasm.setBreedingMethodDbId(additionalInfo.get(BREEDING_METHOD_ID_KEY).getAsString());
+            }
+
+            if (germplasm.getDefaultDisplayName() != null) {
+                germplasm.setGermplasmName(germplasm.getDefaultDisplayName());
+            }
+        }
+
+        // Update pedigree string
+        for (BrAPIGermplasm germplasm: programGermplasm) {
+            if (germplasm.getPedigree() != null) {
+                String newPedigreeString = germplasm.getPedigree();
+                List<String> parents = Arrays.asList(germplasm.getPedigree().split("/"));
+                if (parents.size() >= 1) {
+                    if (programGermplasmByFullName.containsKey(parents.get(0))) {
+                        //problem, if parent not in germplasmbyfullname, not replaced by accession number, assumption that parents are also in file
+                        newPedigreeString = programGermplasmByFullName.get(parents.get(0)).getAccessionNumber();
+                    }
+                }
+                if (parents.size() == 2) {
+                    if (programGermplasmByFullName.containsKey(parents.get(1))) {
+                        newPedigreeString += "/" + programGermplasmByFullName.get(parents.get(1)).getAccessionNumber();
+                    }
+                }
+                germplasm.setPedigree(newPedigreeString);
+            }
+        }
+
+        return programGermplasm;
     }
 
     public List<BrAPIGermplasm> importBrAPIGermplasm(List<BrAPIGermplasm> brAPIGermplasmList, UUID programId, ImportUpload upload) throws ApiException {
         GermplasmApi api = new GermplasmApi(programDAO.getCoreClient(programId));
         try {
             Callable<List<BrAPIGermplasm>> postFunction = () -> BrAPIDAOUtil.post(brAPIGermplasmList, upload, api::germplasmPost, importDAO::update);
-            List<BrAPIGermplasm> newGermplasm = programGermplasmCache.post(programId, postFunction);
-            return newGermplasm;
+            return programGermplasmCache.post(programId, postFunction);
         } catch (ApiException e) {
             throw e;
         } catch (Exception e) {
@@ -98,13 +137,9 @@ public class BrAPIGermplasmDAO {
     }
 
     public List<BrAPIGermplasm> getGermplasmByName(List<String> germplasmNames, UUID programId) throws ApiException {
-        BrAPIGermplasmSearchRequest germplasmSearch = new BrAPIGermplasmSearchRequest();
-        germplasmSearch.germplasmNames(germplasmNames);
-        GermplasmApi api = new GermplasmApi(programDAO.getCoreClient(programId));
-        return BrAPIDAOUtil.search(
-                api::searchGermplasmPost,
-                api::searchGermplasmSearchResultsDbIdGet,
-                germplasmSearch
-        );
+        return programGermplasmCache.get(programId)
+                                    .stream()
+                                    .filter(brAPIGermplasm -> germplasmNames.contains(brAPIGermplasm.getGermplasmName()))
+                                    .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/ProgramCache.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/ProgramCache.java
@@ -24,6 +24,7 @@ import com.rits.cloning.Cloner;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import lombok.extern.slf4j.Slf4j;
 import org.brapi.client.v2.model.exceptions.ApiException;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -32,26 +33,28 @@ import java.util.stream.Collectors;
 @Slf4j
 public class ProgramCache<R> {
 
-    private FetchFunction<UUID, List<R>> fetchMethod;
-    private Map<UUID, Semaphore> programSemaphore = new HashMap<>();
-    private Cloner cloner;
+    private final FetchFunction<UUID, List<R>> fetchMethod;
+    private final Map<UUID, Semaphore> programSemaphore = new HashMap<>();
+    private final Cloner cloner;
 
-    final Executor executor = Executors.newCachedThreadPool();
-    private LoadingCache<UUID, List<R>> cache = CacheBuilder.newBuilder()
+    private final Executor executor = Executors.newCachedThreadPool();
+    private final LoadingCache<UUID, List<R>> cache = CacheBuilder.newBuilder()
             .build(new CacheLoader<>() {
                 @Override
-                public List<R> load(UUID programId) throws Exception {
+                public List<R> load(@NotNull UUID programId) throws Exception {
                     try {
-                        return fetchMethod.apply(programId);
+                        List<R> values = fetchMethod.apply(programId);
+                        log.debug("cache loading complete.\nprogramId: " + programId);
+                        return values;
                     } catch (Exception e) {
-                        log.error(e.getMessage());
+                        log.error(e.getMessage(), e);
                         cache.invalidate(programId);
                         throw e;
                     }
                 }
             });
 
-    public ProgramCache(FetchFunction fetchMethod, List<UUID> keys) {
+    public ProgramCache(FetchFunction<UUID, List<R>> fetchMethod, List<UUID> keys) {
         this.fetchMethod = fetchMethod;
         this.cloner = new Cloner();
         // Populate cache on start up
@@ -60,7 +63,7 @@ public class ProgramCache<R> {
         }
     }
 
-    public ProgramCache(FetchFunction fetchMethod) {
+    public ProgramCache(FetchFunction<UUID, List<R>> fetchMethod) {
         this.fetchMethod = fetchMethod;
         this.cloner = new Cloner();
     }
@@ -71,18 +74,20 @@ public class ProgramCache<R> {
             // TODO: Do we want to wait for a refresh method if it is running? Returns current data right now, even if old
             if (!programSemaphore.containsKey(programId) || cache.getIfPresent(programId) == null) {
                 // If the cache is missing, refresh and get
+                log.trace("cache miss, fetching from source.\nprogramId: " + programId);
                 updateCache(programId);
                 List<R> result = new ArrayList<>(cache.get(programId));
-                result = result.stream().map(obj -> cloner.deepClone(obj)).collect(Collectors.toList());
+                result = result.stream().map(cloner::deepClone).collect(Collectors.toList());
                 return result;
             } else {
+                log.trace("cache contains records for the program.\nprogramId: " + programId);
                 // Most cases where the cache is populated
                 List<R> result = new ArrayList<>(cache.get(programId));
-                result = result.stream().map(obj -> cloner.deepClone(obj)).collect(Collectors.toList());
+                result = result.stream().map(cloner::deepClone).collect(Collectors.toList());
                 return result;
             }
         } catch (ExecutionException e) {
-            log.error(e.getMessage());
+            log.error(e.getMessage(), e);
             return fetchMethod.apply(programId);
         }
     }
@@ -99,7 +104,7 @@ public class ProgramCache<R> {
             programSemaphore.put(programId, new Semaphore(1));
         }
 
-        if (!programSemaphore.get(programId).hasQueuedThreads()) {
+        if (!programSemaphore.get(programId).hasQueuedThreads()) { // if false, an update is already queued, skip this one
             // Start a refresh process asynchronously
             executor.execute(() -> {
                 // Synchronous
@@ -112,9 +117,6 @@ public class ProgramCache<R> {
                     programSemaphore.get(programId).release();
                 }
             });
-        } else {
-            // An update is already queued, skip this one
-            return;
         }
     }
 

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -151,7 +151,7 @@ public class BrAPIGermplasmService {
     }
 
     public List<BrAPIGermplasm> getRawGermplasmByAccessionNumber(ArrayList<String> germplasmAccessionNumbers, UUID programId) throws ApiException {
-        List<BrAPIGermplasm> germplasmList = germplasmDAO.getGermplasm(programId);
+        List<BrAPIGermplasm> germplasmList = germplasmDAO.getRawGermplasm(programId);
         List<BrAPIGermplasm> resultGermplasm = new ArrayList<>();
         // Search for accession number matches
         for (BrAPIGermplasm germplasm: germplasmList) {

--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -28,6 +28,7 @@ import org.breedinginsight.brapps.importer.model.config.*;
 import org.breedinginsight.dao.db.tables.pojos.BreedingMethodEntity;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
+import org.breedinginsight.utilities.Utilities;
 
 import java.math.BigInteger;
 import java.time.LocalDateTime;
@@ -203,7 +204,7 @@ public class Germplasm implements BrAPIObject {
         germplasm.setAccessionNumber(nextVal.get().toString());
 
         // Set germplasm name to <Name> [<program key>-<accessionNumber>]
-        germplasm.setGermplasmName(String.format("%s [%s-%s]", germplasm.getDefaultDisplayName(), programKey, germplasm.getAccessionNumber()));
+        germplasm.setGermplasmName(Utilities.appendProgramKey(germplasm.getDefaultDisplayName(), programKey, germplasm.getAccessionNumber()));
 
         // Set createdDate field
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");

--- a/src/main/java/org/breedinginsight/utilities/Utilities.java
+++ b/src/main/java/org/breedinginsight/utilities/Utilities.java
@@ -17,6 +17,8 @@
 
 package org.breedinginsight.utilities;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -41,5 +43,23 @@ public class Utilities {
      */
     public static boolean containsCaseInsensitive(String target, List<String> list){
         return list.stream().anyMatch(x -> x.equalsIgnoreCase(target));
+    }
+
+    /**
+     * Formats a string to: <code>&lt;original&gt; [&lt;programKey&gt;]</code>.<br><br>
+     *
+     * If <code>additionalKeyData</code> is populated, then returns: <code>&lt;original&gt; [&lt;programKey&gt;-&lt;additionalKeyData&gt;]</code>
+     *
+     * @param original
+     * @param programKey
+     * @param additionalKeyData
+     * @return the formatted string
+     */
+    public static String appendProgramKey(String original, String programKey, String additionalKeyData) {
+        if(StringUtils.isNotEmpty(additionalKeyData)) {
+            return String.format("%s [%s-%s]", original, programKey, additionalKeyData);
+        } else {
+            return String.format("%s [%s]", original, programKey);
+        }
     }
 }

--- a/src/test/java/org/breedinginsight/brapi/v2/ProgramCacheUnitTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/ProgramCacheUnitTest.java
@@ -78,10 +78,10 @@ public class ProgramCacheUnitTest {
     @SneakyThrows
     public void populatedRefreshQueueSkipsRefresh() {
         // Make a lot of post calls and just how many times the fetch method is called
-        ProgramCache<BrAPIGermplasm> cache = new ProgramCache<>((Object id) -> mockFetch((UUID) id, waitTime));
+        ProgramCache<BrAPIGermplasm> cache = new ProgramCache<>((UUID id) -> mockFetch(id, waitTime));
         UUID programId = UUID.randomUUID();
-        Integer numPost = 10;
-        Integer currPost = 0;
+        int numPost = 10;
+        int currPost = 0;
         while (currPost < numPost) {
             List<BrAPIGermplasm> newList = new ArrayList<>();
             newList.add(new BrAPIGermplasm());
@@ -99,9 +99,9 @@ public class ProgramCacheUnitTest {
     @SneakyThrows
     public void programRefreshesSeparated() {
         // Make a lot of post calls on different programs to check that they don't wait for each other
-        ProgramCache<BrAPIGermplasm> cache = new ProgramCache<>((Object id) -> mockFetch((UUID) id, waitTime));
-        Integer numPost = 10;
-        Integer currPost = 0;
+        ProgramCache<BrAPIGermplasm> cache = new ProgramCache<>((UUID id) -> mockFetch(id, waitTime));
+        int numPost = 10;
+        int currPost = 0;
         while (currPost < numPost) {
             UUID id = UUID.randomUUID();
             List<BrAPIGermplasm> newList = new ArrayList<>();
@@ -124,7 +124,7 @@ public class ProgramCacheUnitTest {
     public void initialGetMethodWaitsForLoad() {
         // Test that the get method waits for an ongoing refresh to finish when there isn't any day
         UUID programId = UUID.randomUUID();
-        ProgramCache<BrAPIGermplasm> cache = new ProgramCache<>((Object id) -> mockFetch((UUID) id, waitTime), List.of(programId));
+        ProgramCache<BrAPIGermplasm> cache = new ProgramCache<>((UUID id) -> mockFetch(id, waitTime), List.of(programId));
         cache.get(programId);
         // Our fetch method should have only been called once for the initial loading
         assertEquals(1, fetchCount, "Fetch method was called on get");
@@ -138,7 +138,7 @@ public class ProgramCacheUnitTest {
         List<BrAPIGermplasm> newList = new ArrayList<>();
         newList.add(new BrAPIGermplasm());
         mockBrAPI.put(programId, new ArrayList<>(newList));
-        ProgramCache<BrAPIGermplasm> cache = new ProgramCache<>((Object id) -> mockFetch((UUID) id, waitTime), List.of(programId));
+        ProgramCache<BrAPIGermplasm> cache = new ProgramCache<>((UUID id) -> mockFetch(id, waitTime), List.of(programId));
         Callable<List<BrAPIGermplasm>> postFunction = () -> mockPost(programId, new ArrayList<>(newList));
 
         // Get waits for initial fetch
@@ -173,7 +173,7 @@ public class ProgramCacheUnitTest {
         ProgramCacheUnitTest mockTest = spy(this);
 
         // Start cache
-        ProgramCache<BrAPIGermplasm> cache = new ProgramCache<>((Object id) -> mockTest.mockFetch(programId, waitTime), List.of(programId));
+        ProgramCache<BrAPIGermplasm> cache = new ProgramCache<>((UUID id) -> mockTest.mockFetch(programId, waitTime), List.of(programId));
 
         // Get waits for initial fetch
         List<BrAPIGermplasm> cachedGermplasm = cache.get(programId);

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -22,11 +22,13 @@
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+            <pattern>%cyan(%d{yyyy-MM-dd HH:mm:ss.SSSZ}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <root level="info">
+    <logger name="org.breedinginsight" level="DEBUG"/>
+
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
# Description
https://breedinginsight.atlassian.net/browse/BI-1408

Refactored the germplasm cache to store the processed germplasm that bi-api will return instead of the raw germplasm that came from the BrAPI service storing the program's data.



# Dependencies
bi-web - release/0.5

# Testing
_Please include any details needed for reviewers to test this code_


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
