### PR TITLE
[BI-1202] Add sort fields to GET germplasm

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -51,8 +51,6 @@ public class GermplasmController {
             @QueryValue @QueryValid(using = GermplasmQueryMapper.class) @Valid BrapiQuery queryParams) {
         try {
             List<BrAPIGermplasm> germplasm = germplasmService.getGermplasm(programId);
-            queryParams.setSortField(germplasmQueryMapper.getDefaultSortField());
-            queryParams.setSortOrder(germplasmQueryMapper.getDefaultSortOrder());
             return ResponseUtils.getBrapiQueryResponse(germplasm, germplasmQueryMapper, queryParams);}
         catch (ApiException e) {
             log.info(e.getMessage());

--- a/src/main/java/org/breedinginsight/brapi/v2/model/response/mappers/GermplasmQueryMapper.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/model/response/mappers/GermplasmQueryMapper.java
@@ -1,5 +1,6 @@
 package org.breedinginsight.brapi.v2.model.response.mappers;
 
+import com.google.gson.JsonObject;
 import lombok.Getter;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.breedinginsight.api.v1.controller.metadata.SortOrder;
@@ -21,7 +22,27 @@ public class GermplasmQueryMapper extends AbstractQueryMapper {
 
     public GermplasmQueryMapper() {
         fields = Map.ofEntries(
-                Map.entry("accessionNumber", BrAPIGermplasm::getAccessionNumber)
+                Map.entry("accessionNumber", BrAPIGermplasm::getAccessionNumber),
+                Map.entry("defaultDisplayName", BrAPIGermplasm::getDefaultDisplayName),
+                Map.entry("additionalInfo.breedingMethod", (germplasm) ->
+                        germplasm.getAdditionalInfo() != null && germplasm.getAdditionalInfo().get("breedingMethod") != null ?
+                                germplasm.getAdditionalInfo().get("breedingMethod").getAsString() : null),
+                Map.entry("seedSource", BrAPIGermplasm::getSeedSource),
+                Map.entry("femaleParent", (germplasm) ->
+                        germplasm.getPedigree() != null ? germplasm.getPedigree().split("/")[0] : null),
+                Map.entry("maleParent", (germplasm) ->
+                        germplasm.getPedigree() != null && germplasm.getPedigree().split("/").length > 1 ? germplasm.getPedigree().split("/")[1] : null),
+                Map.entry("additionalInfo.createdDate", (germplasm) ->
+                        germplasm.getAdditionalInfo() != null && germplasm.getAdditionalInfo().get("createdDate") != null ?
+                                germplasm.getAdditionalInfo().get("createdDate").getAsString() : null),
+                Map.entry("additionalInfo.createdBy.userName", (germplasm) -> {
+                            JsonObject additionalInfo = germplasm.getAdditionalInfo();
+                            if (additionalInfo == null) { return null;}
+                            if (!additionalInfo.has("createdBy")) { return null;}
+                            JsonObject createdBy = additionalInfo.getAsJsonObject("createdBy");
+                            if (!createdBy.has("userName")) { return null; }
+                            return createdBy.get("userName").getAsString();
+                        })
         );
     }
 

--- a/src/test/java/org/breedinginsight/brapi/v2/GermplasmControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/GermplasmControllerIntegrationTest.java
@@ -153,7 +153,7 @@ public class GermplasmControllerIntegrationTest extends BrAPITest {
         // TODO: Parents are updated
         // Breeding method is assigned
         Flowable<HttpResponse<String>> call = client.exchange(
-                GET(String.format("/programs/%s/brapi/v2/germplasm",validProgram.getId().toString()))
+                GET(String.format("/programs/%s/brapi/v2/germplasm?sortField=defaultDisplayName&sortOrder=ASC",validProgram.getId().toString()))
                         .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
         );
         HttpResponse<String> response = call.blockingFirst();
@@ -164,7 +164,9 @@ public class GermplasmControllerIntegrationTest extends BrAPITest {
         JsonArray data = result.getAsJsonArray("data");
 
         assertEquals(6, data.size(), "Wrong number of germplasm were returned");
-        for (JsonElement jsonGermplasm: data) {
+        List<String> correctOrder = List.of("Full Germplasm 1", "Full Germplasm 2", "Full Germplasm 3", "Germplasm 1", "Germplasm 2", "Germplasm 3");
+        for (int i = 0; i < data.size(); i++) {
+            JsonElement jsonGermplasm = data.get(i);
             JsonObject exampleGermplasm = jsonGermplasm.getAsJsonObject();
             assertEquals(exampleGermplasm.get("defaultDisplayName").getAsString(), exampleGermplasm.get("germplasmName").getAsString(), "Germplasm name was not set to display name");
             if (exampleGermplasm.get("additionalInfo").getAsJsonObject().has("breedingMethodId")){
@@ -178,6 +180,8 @@ public class GermplasmControllerIntegrationTest extends BrAPITest {
                 }
             }
 
+            // Check the correct sort order
+            assertEquals(correctOrder.get(i), exampleGermplasm.get("defaultDisplayName").getAsString(), "Wrong sort order");
         }
     }
 


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1202

Added sort fields to GET germplasm endpoint. Added a test. 



# Dependencies
biweb: BI-1202

# Testing
You can use these files in create some germplasm in your system. Test the sorting on the germplasm table. 

[BI-1202-germplasm-1.xls](https://github.com/Breeding-Insight/bi-api/files/8155918/BI-1202-germplasm-1.xls)
[BI-1202-germplasm-2.xls](https://github.com/Breeding-Insight/bi-api/files/8155919/BI-1202-germplasm-2.xls)



# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
