### PR TITLE
Bug/bi 1387

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -73,7 +73,7 @@ public class GermplasmController {
             return germplasmListExport;
         }
         catch (Exception e) {
-            log.info(e.toString());
+            log.info(e.getMessage(), e);
             e.printStackTrace();
             HttpResponse response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, downloadErrorMessage).contentType(MediaType.TEXT_PLAIN).body(downloadErrorMessage);
             return response;

--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -72,16 +72,9 @@ public class GermplasmController {
             HttpResponse<StreamedFile> germplasmListExport = HttpResponse.ok(germplasmListFile.getStreamedFile()).header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename="+germplasmListFile.getFileName()+".xlsx");
             return germplasmListExport;
         }
-        catch (ApiException e){
-            log.info(e.getMessage());
-            HttpResponse response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, downloadErrorMessage).contentType(MediaType.TEXT_PLAIN).body(downloadErrorMessage);
-            return response;
-        } catch (IOException e){
-            log.info(e.getMessage());
-            HttpResponse response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, downloadErrorMessage).contentType(MediaType.TEXT_PLAIN).body(downloadErrorMessage);
-            return response;
-        } catch (Exception e) {
-            log.info(e.getMessage());
+        catch (Exception e) {
+            log.info(e.toString());
+            e.printStackTrace();
             HttpResponse response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, downloadErrorMessage).contentType(MediaType.TEXT_PLAIN).body(downloadErrorMessage);
             return response;
         }


### PR DESCRIPTION
# Description
[BI-1387](https://breedinginsight.atlassian.net/browse/BI-1387) Download germplasm list error 

When downloading a germplasm-list, the user receives the error "An error occurred while generating the download file. Contact the development team at bidevteam@cornell.edu."

BreedBase is not returning a create_date.  The create_date is used in the filename of the downloaded file. The null value for create_date is causing an error.

Now, if no create_date is given, then the system will use the current date/time for the file name.  
(also, I tried to make the exception handling produce more valuable information to the log.)


# Dependencies
BI-web branch release/0.5

# Testing
**1. select a program that has an instance of BreedBase as its custom program data storage location.** 
2. import germplasm and save list
3. navigate to germplasm lists table
4. Select download


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: \  [BI-1387 TAF](https://github.com/Breeding-Insight/taf/actions/runs/1935867236) has same errors as [release.05 TAF](https://github.com/Breeding-Insight/taf/actions/runs/1936127239)
