### PR TITLE
BI-1291 - Import Germplasm Preview Columns Incorrect

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -143,6 +143,10 @@ public class Germplasm implements BrAPIObject {
         germplasm.setGermplasmPUI(getGermplasmPUI());
         germplasm.setCollection(getCollection());
         germplasm.putAdditionalInfoItem("importEntryNumber", entryNo);
+        germplasm.putAdditionalInfoItem("femaleParentGid", getFemaleParentDBID());
+        germplasm.putAdditionalInfoItem("maleParentGid", getMaleParentDBID());
+        germplasm.putAdditionalInfoItem("femaleParentEntryNo", getFemaleParentEntryNo());
+        germplasm.putAdditionalInfoItem("maleParentEntryNo", getMaleParentEntryNo());
         Map<String, String> createdBy = new HashMap<>();
         createdBy.put("userId", user.getId().toString());
         createdBy.put("userName", user.getName());


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1291?atlOrigin=eyJpIjoiMjg3MTc1YWQzMjA3NDQyMTgyMzliNGFmNjJhYmM4ZWUiLCJwIjoiaiJ9

- Added parental gids and entry numbers to additionalInfo to facilitate display on front end

# Dependencies
- BI-1291 on bi-web

# Testing
- Import germplasm file with parents specified as both gids and entry numbers and verify they are displayed correctly on the bi-web germplasm import preview page. Also verify that the External UID works.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
