### PR TITLE
[BI-1435] Allow for null observation dates

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Observation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Observation.java
@@ -77,7 +77,6 @@ public class Observation implements BrAPIObject {
     private String value;
 
     @ImportFieldType(type= ImportFieldTypeEnum.DATE)
-    @ImportMappingRequired
     @ImportFieldMetadata(id="observationDate", name="Observation Date", description = "Date that the observation was taken.")
     private String observationDate;
 
@@ -102,10 +101,12 @@ public class Observation implements BrAPIObject {
         }
 
         // TODO: use common time format, using discrete analyzer format for now 16/12/2020 16:16:49
-        LocalDateTime datetime = LocalDateTime.parse(getObservationDate(), formatter);
-        ZonedDateTime zoned = datetime.atZone(ZoneId.of("UTC"));
-        OffsetDateTime timestamp = zoned.toOffsetDateTime();
-        observation.setObservationTimeStamp(timestamp);
+        if (getObservationDate() != null) {
+            LocalDateTime datetime = LocalDateTime.parse(getObservationDate(), formatter);
+            ZonedDateTime zoned = datetime.atZone(ZoneId.of("UTC"));
+            OffsetDateTime timestamp = zoned.toOffsetDateTime();
+            observation.setObservationTimeStamp(timestamp);
+        }
 
         if (additionalInfos != null) {
             additionalInfos.stream()

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ObservationProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ObservationProcessor.java
@@ -239,15 +239,26 @@ public class ObservationProcessor implements Processor {
     }
 
     private static String getBrapiObservationHash(BrAPIObservation observation) {
-        return getObservationHash(observation.getObservationUnitName(),
-               observation.getObservationVariableName(),
-               observation.getObservationTimeStamp().withOffsetSameInstant(ZoneOffset.UTC).format(Observation.formatter));
+        if (observation.getObservationTimeStamp() != null) {
+            return getObservationHash(observation.getObservationUnitName(),
+                    observation.getObservationVariableName(),
+                    observation.getObservationTimeStamp().withOffsetSameInstant(ZoneOffset.UTC).format(Observation.formatter));
+        } else {
+            return getObservationHash(observation.getObservationUnitName(),
+                    observation.getObservationVariableName());
+        }
     }
 
     private static String getImportObservationHash(Observation observation) {
-        return getObservationHash(observation.getObservationUnit().getReferenceValue(),
-                observation.getTrait().getReferenceValue(),
-                observation.getObservationDate());
+        if (observation.getObservationDate() != null) {
+            return getObservationHash(observation.getObservationUnit().getReferenceValue(),
+                    observation.getTrait().getReferenceValue(),
+                    observation.getObservationDate());
+        } else {
+            return getObservationHash(observation.getObservationUnit().getReferenceValue(),
+                    observation.getTrait().getReferenceValue());
+        }
+
     }
 
     private static String getObservationHash(String observationUnitName, String variableName, String observationDate) {
@@ -255,6 +266,13 @@ public class ObservationProcessor implements Processor {
         String concat = DigestUtils.sha256Hex(observationUnitName) +
                         DigestUtils.sha256Hex(variableName) +
                         DigestUtils.sha256Hex(observationDate);
+        return DigestUtils.sha256Hex(concat);
+    }
+
+    private static String getObservationHash(String observationUnitName, String variableName) {
+
+        String concat = DigestUtils.sha256Hex(observationUnitName) +
+                DigestUtils.sha256Hex(variableName);
         return DigestUtils.sha256Hex(concat);
     }
 


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-1435

Changed the observation hashing in the importer to allow for null observation dates. Made observation date optional. 



# Dependencies
sgn: BI-1435
biweb: release/0.5

# Testing
1. Create an import with observation dates for the file below. 
2. Import that file, see that the observations are labeled NEW
3. Import that file again, they should now be EXISTING.
4. Create an import with no observation date mapped. 
5. Import the same file, see that observations are labeled as NEW
6. Import the file again, see that the observations are label as EXISTING. 


[phenotypic_importer_demo.xlsx](https://github.com/Breeding-Insight/bi-api/files/8289362/phenotypic_importer_demo.xlsx)


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
