### PR TITLE
BI-1365 - Scope ontology terms to be within a program when saved over BrAPI

### DIFF
--- a/src/main/java/org/breedinginsight/daos/TraitDAO.java
+++ b/src/main/java/org/breedinginsight/daos/TraitDAO.java
@@ -264,7 +264,7 @@ public class TraitDAO extends TraitDao {
                     .referenceID(trait.getMethod().getId().toString())
                     .referenceSource(referenceSource);
             BrAPIMethod brApiMethod = new BrAPIMethod()
-                                                 .methodName(String.format("%s %s", trait.getMethod().getDescription(), trait.getMethod().getMethodClass()))
+                                                 .methodName(String.format("%s %s [%s]", trait.getMethod().getDescription(), trait.getMethod().getMethodClass(), program.getKey()))
                                                  .externalReferences(List.of(methodReference))
                                                  .methodClass(trait.getMethod().getMethodClass())
                                                  .description(trait.getMethod().getDescription())
@@ -280,7 +280,7 @@ public class TraitDAO extends TraitDao {
                                                                                .max(trait.getScale().getValidValueMax())
                                                                                .min(trait.getScale().getValidValueMin());
             BrAPIScale brApiScale = new BrAPIScale()
-                    .scaleName(trait.getScale().getScaleName())
+                    .scaleName(String.format("%s [%s]", trait.getScale().getScaleName(), program.getKey()))
                     .externalReferences(List.of(scaleReference))
                     .dataType(brApiTraitDataType)
                     .decimalPlaces(trait.getScale().getDecimalPlaces())
@@ -291,7 +291,7 @@ public class TraitDAO extends TraitDao {
                     .referenceID(trait.getId().toString())
                     .referenceSource(referenceSource);
             BrAPITrait brApiTrait = new BrAPITrait()
-                    .traitName(String.format("%s %s", trait.getEntity(), trait.getAttribute()))
+                    .traitName(String.format("%s %s [%s]", trait.getEntity(), trait.getAttribute(), program.getKey()))
                     .traitDescription(trait.getTraitDescription())
                     .synonyms(trait.getSynonyms())
                     .status("active")
@@ -309,7 +309,7 @@ public class TraitDAO extends TraitDao {
                     .scale(brApiScale)
                     .trait(brApiTrait)
                     .externalReferences(List.of(variableReference))
-                    .observationVariableName(trait.getObservationVariableName())
+                    .observationVariableName(String.format("%s [%s]", trait.getObservationVariableName(), program.getKey()))
                     .status("active")
                     .language("english")
                     .scientist(actingUser.getName())

--- a/src/main/java/org/breedinginsight/daos/TraitDAO.java
+++ b/src/main/java/org/breedinginsight/daos/TraitDAO.java
@@ -384,14 +384,14 @@ public class TraitDAO extends TraitDao {
             BrAPIObservationVariable existingVariable = getBrAPIVariable(variablesAPI, trait.getId());
 
             // Change method
-            existingVariable.getMethod().setMethodName(String.format("%s %s", trait.getMethod().getDescription(), trait.getMethod().getMethodClass()));
+            existingVariable.getMethod().setMethodName(String.format("%s %s [%s]", trait.getMethod().getDescription(), trait.getMethod().getMethodClass(), program.getKey()));
             existingVariable.getMethod().setMethodClass(trait.getMethod().getMethodClass());
             existingVariable.getMethod().setDescription(trait.getMethod().getDescription());
             existingVariable.getMethod().setFormula(trait.getMethod().getFormula());
 
             // Change scale
             BrAPITraitDataType brApiTraitDataType = BrAPITraitDataType.valueOf(trait.getScale().getDataType().toString());
-            existingVariable.getScale().setScaleName(trait.getScale().getScaleName());
+            existingVariable.getScale().setScaleName(String.format("%s [%s]", trait.getScale().getScaleName(), program.getKey()));
             existingVariable.getScale().setDataType(brApiTraitDataType);
             existingVariable.getScale().setDecimalPlaces(trait.getScale().getDecimalPlaces());
             BrAPIScaleValidValues brApiScaleValidValues = new BrAPIScaleValidValues()
@@ -401,7 +401,7 @@ public class TraitDAO extends TraitDao {
             existingVariable.getScale().setValidValues(brApiScaleValidValues);
 
             // Change trait
-            existingVariable.getTrait().setTraitName(String.format("%s %s", trait.getEntity(), trait.getAttribute()));
+            existingVariable.getTrait().setTraitName(String.format("%s %s [%s]", trait.getEntity(), trait.getAttribute(), program.getKey()));
             existingVariable.getTrait().setTraitDescription(trait.getTraitDescription());
             existingVariable.getTrait().setSynonyms(trait.getSynonyms());
             existingVariable.getTrait().setEntity(trait.getProgramObservationLevel().getName());
@@ -410,7 +410,7 @@ public class TraitDAO extends TraitDao {
             existingVariable.getTrait().setAttribute(trait.getAttribute());
 
             // Change variable
-            existingVariable.setObservationVariableName(trait.getObservationVariableName());
+            existingVariable.setObservationVariableName(String.format("%s [%s]", trait.getObservationVariableName(), program.getKey()));
             existingVariable.setDefaultValue(trait.getDefaultValue());
             existingVariable.setSynonyms(trait.getSynonyms());
             if (trait.getActive() == null || trait.getActive()){

--- a/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
@@ -32,6 +32,7 @@ import junit.framework.AssertionFailedError;
 import lombok.SneakyThrows;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.BrAPIClient;
+import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.model.queryParams.phenotype.VariableQueryParams;
 import org.brapi.client.v2.modules.phenotype.ObservationVariablesApi;
 import org.brapi.client.v2.modules.phenotype.ObservationsApi;
@@ -41,6 +42,7 @@ import org.brapi.v2.model.pheno.BrAPIScaleValidValuesCategories;
 import org.brapi.v2.model.pheno.response.BrAPIObservationLevelListResponse;
 import org.brapi.v2.model.pheno.response.BrAPIObservationListResponse;
 import org.brapi.v2.model.pheno.response.BrAPIObservationVariableListResponse;
+import org.brapi.v2.model.pheno.response.BrAPIObservationVariableListResponseResult;
 import org.breedinginsight.BrAPITest;
 import org.breedinginsight.TestUtils;
 import org.breedinginsight.api.model.v1.request.ProgramRequest;
@@ -358,6 +360,116 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         }
 
         validTraits = traits;
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(4)
+    public void checkBrapiValues() {
+
+        Trait trait1 = new Trait();
+        trait1.setTraitDescription("trait 1 description");
+        trait1.setEntity("entity1");
+        trait1.setObservationVariableName("Test Brapi");
+        trait1.setProgramObservationLevel(ProgramObservationLevel.builder().name("Plant").build());
+        Scale scale1 = new Scale();
+        scale1.setScaleName("Test Scale");
+        scale1.setDataType(DataType.TEXT);
+        Method method1 = new Method();
+        trait1.setScale(scale1);
+        trait1.setMethod(method1);
+
+        // Set the brapi properties
+        setBrAPIProperties(trait1);
+
+        // set the synonyms
+        trait1.setSynonyms(List.of("Test Trait", "test1", "test2"));
+
+        // Set the tags
+        trait1.setTags(List.of("leaf trait"));
+
+        List<Trait> traits = List.of(trait1);
+
+        // Call endpoint
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST("/programs/" + validProgram.getId() + "/traits", traits)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> res = call.blockingFirst();
+        assertEquals(HttpStatus.OK, res.getStatus());
+
+        JsonObject result = JsonParser.parseString(res.getBody().get()).getAsJsonObject().getAsJsonObject("result");
+        JsonArray data = result.getAsJsonArray("data");
+
+        for (JsonElement traitJson: data) {
+            JsonObject trait = (JsonObject) traitJson;
+            String traitName = trait.get("observationVariableName").getAsString();
+            if (traitName.equals(trait1.getObservationVariableName())) {
+                trait1.setId(UUID.fromString(trait.get("id").getAsString()));
+            }
+        }
+
+        String validProgramKey = validProgram.getKey();
+        BrAPIObservationVariable variable = getBrapiVariable(trait1.getObservationVariableName(), "Test Program");
+
+        assertEquals(String.format("%s [%s]", trait1.getObservationVariableName(), validProgramKey),
+                variable.getObservationVariableName(), "Unexpected observation variable name");
+        String methodName = String.format("%s %s", trait1.getMethod().getDescription(), trait1.getMethod().getMethodClass());
+        assertEquals(String.format("%s [%s]", methodName, validProgramKey),
+                variable.getMethod().getMethodName(), "Unexpected method name");
+        assertEquals(String.format("%s [%s]", trait1.getScale().getScaleName(), validProgramKey),
+                variable.getScale().getScaleName(), "Unexpected scale name");
+        String traitName = String.format("%s %s", trait1.getEntity(), trait1.getAttribute());
+        assertEquals(String.format("%s [%s]", traitName, validProgramKey),
+                variable.getTrait().getTraitName(), "Unexpected trait name");
+
+        // update
+        trait1.getMethod().setMethodClass("Observation");
+        trait1.getMethod().setDescription("Updated description");
+        trait1.setEntity("Updated entity");
+        trait1.setAttribute("Updated attribute");
+        trait1.setObservationVariableName("Updated name");
+        trait1.getScale().setScaleName("Updated Scale");
+
+        Flowable<HttpResponse<String>> call2 = client.exchange(
+                PUT("/programs/" + validProgram.getId() + "/traits", traits)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> response2 = call2.blockingFirst();
+        assertEquals(HttpStatus.OK, response2.getStatus());
+
+        variable = getBrapiVariable(trait1.getObservationVariableName(), "Test Program");
+
+        assertEquals(String.format("%s [%s]", trait1.getObservationVariableName(), validProgramKey),
+                variable.getObservationVariableName(), "Unexpected observation variable name");
+        methodName = String.format("%s %s", trait1.getMethod().getDescription(), trait1.getMethod().getMethodClass());
+        assertEquals(String.format("%s [%s]", methodName, validProgramKey),
+                variable.getMethod().getMethodName(), "Unexpected method name");
+        assertEquals(String.format("%s [%s]", trait1.getScale().getScaleName(), validProgramKey),
+                variable.getScale().getScaleName(), "Unexpected scale name");
+        traitName = String.format("%s %s", trait1.getEntity(), trait1.getAttribute());
+        assertEquals(String.format("%s [%s]", traitName, validProgramKey),
+                variable.getTrait().getTraitName(), "Unexpected trait name");
+        
+    }
+
+    private BrAPIObservationVariable getBrapiVariable(String variableName, String programName) throws ApiException {
+        BrAPIClient client2 = new BrAPIClient(getProperties().get("brapi.server.pheno-url"));
+        ObservationVariablesApi variablesApi = new ObservationVariablesApi(client2);
+        VariableQueryParams queryParams = new VariableQueryParams();
+        ApiResponse<BrAPIObservationVariableListResponse> response = variablesApi.variablesGet(queryParams);
+
+        BrAPIObservationVariableListResponse variableResponse = response.getBody();
+        BrAPIObservationVariableListResponseResult result = variableResponse.getResult();
+        List<BrAPIObservationVariable> variables = result.getData();
+
+        Optional<BrAPIObservationVariable> searchResult = variables.stream().filter(
+                variable -> variable.getObservationVariableName().contains(variableName)
+                        && variable.getInstitution().equals(programName)).findFirst();
+
+        return searchResult.orElseThrow();
     }
 
     @Test


### PR DESCRIPTION
# Description
**Story:** [BI-1365](https://breedinginsight.atlassian.net/browse/BI-1365?atlOrigin=eyJpIjoiNzk2ZWNjZmM2OGM2NDU4YThkN2M4NmI2NzdhZjUzNzkiLCJwIjoiaiJ9)

- Added program key to scope ontology terms

# Dependencies
None

# Testing
- Create and update ontology terms. Verify that the observationVariableName, traitName, scaleName, and methodName values are scoped with the program key in the underlying brapi service and that these fields all appear normal without the program key in the BI interface.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
