### PR TITLE
[BI-1088] Germplasm Export QA Fix 2

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -124,7 +124,7 @@ public class BrAPIGermplasmService {
                 }
             }
 
-            if (!germplasmEntry.getPedigree().isEmpty()) {
+            if ((germplasmEntry.getPedigree() != null) && (!germplasmEntry.getPedigree().isEmpty())) {
                 Pedigree germPedigree = Pedigree.parsePedigreeString(germplasmEntry.getPedigree());
                 row.put("Female Parent GID", Double.parseDouble(germPedigree.femaleParent));
                 if (!germPedigree.maleParent.isEmpty()) row.put("Male Parent GID", Double.parseDouble(germPedigree.maleParent));

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -124,7 +124,7 @@ public class BrAPIGermplasmService {
                 }
             }
 
-            if (germplasmEntry.getPedigree() != null) {
+            if (!germplasmEntry.getPedigree().isEmpty()) {
                 Pedigree germPedigree = Pedigree.parsePedigreeString(germplasmEntry.getPedigree());
                 row.put("Female Parent GID", Double.parseDouble(germPedigree.femaleParent));
                 if (!germPedigree.maleParent.isEmpty()) row.put("Male Parent GID", Double.parseDouble(germPedigree.maleParent));


### PR DESCRIPTION
# Description
**Story:** [4.3 Germplasm List Export File - FAILED QA](https://breedinginsight.atlassian.net/browse/BI-1088)

- Fixed pedigree logic to check for empty string as well as null

# Dependencies
bi-web/release/0.5

# Testing
See https://github.com/Breeding-Insight/bi-api/pull/162

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [n/a] I have create/modified unit tests to cover this change
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to documentation
- [] I have run TAF: _\<link to TAF run>_