### PR TITLE
[BI-1364] View a shared ontology that a program is subscribed to

### DIFF
--- a/src/main/java/org/breedinginsight/api/v1/controller/OntologyController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/OntologyController.java
@@ -201,7 +201,7 @@ public class OntologyController {
      * @param programId -- Program request information
      * @return
      * {
-     *     programId,   -- Program that owns the ontology the request program is subscribed to.
+     *     programId,   -- Program that owns the ontology the request program may subscribe to.
      *     programName,
      *     subscribed,  -- boolean. Whether the requesting program is subscribed to this ontology or not.
      *     editable     -- boolean || null. Indicates whether this program can unsubscribe from this ontology or not. Null if not subscribed to this ontology.

--- a/src/main/java/org/breedinginsight/api/v1/controller/TraitController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/TraitController.java
@@ -37,7 +37,6 @@ import org.breedinginsight.api.model.v1.validators.SearchValid;
 import org.breedinginsight.api.v1.controller.metadata.AddMetadata;
 import org.breedinginsight.model.Editable;
 import org.breedinginsight.model.Program;
-import org.breedinginsight.model.SubscribedProgram;
 import org.breedinginsight.model.Trait;
 import org.breedinginsight.services.OntologyService;
 import org.breedinginsight.services.TraitService;

--- a/src/main/java/org/breedinginsight/services/OntologyService.java
+++ b/src/main/java/org/breedinginsight/services/OntologyService.java
@@ -1,6 +1,8 @@
 package org.breedinginsight.services;
 
 import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.http.multipart.CompletedFileUpload;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import org.brapi.v2.model.core.BrAPIProgram;
 import org.breedinginsight.api.auth.AuthenticatedUser;
@@ -11,13 +13,8 @@ import org.breedinginsight.dao.db.tables.pojos.ProgramSharedOntologyEntity;
 import org.breedinginsight.daos.ProgramDAO;
 import org.breedinginsight.daos.ProgramOntologyDAO;
 import org.breedinginsight.daos.TraitDAO;
-import org.breedinginsight.model.Program;
-import org.breedinginsight.model.SharedOntology;
-import org.breedinginsight.model.SubscribedOntology;
-import org.breedinginsight.model.Trait;
-import org.breedinginsight.services.exceptions.DoesNotExistException;
-import org.breedinginsight.services.exceptions.UnprocessableEntityException;
-import org.breedinginsight.services.exceptions.ValidatorException;
+import org.breedinginsight.model.*;
+import org.breedinginsight.services.exceptions.*;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -32,13 +29,15 @@ public class OntologyService {
     private ProgramOntologyDAO programOntologyDAO;
     private TraitDAO traitDAO;
     private TraitService traitService;
+    private TraitUploadService traitUploadService;
 
     @Inject
-    public OntologyService(ProgramDAO programDAO, ProgramOntologyDAO programOntologyDAO, TraitDAO traitDAO, TraitService traitService) {
+    public OntologyService(ProgramDAO programDAO, ProgramOntologyDAO programOntologyDAO, TraitDAO traitDAO, TraitService traitService, TraitUploadService traitUploadService) {
         this.programDAO = programDAO;
         this.programOntologyDAO = programOntologyDAO;
         this.traitDAO = traitDAO;
         this.traitService = traitService;
+        this.traitUploadService = traitUploadService;
     }
 
     /**
@@ -300,6 +299,67 @@ public class OntologyService {
 
         // Subscribe
         programOntologyDAO.denySharedOntology(sharedOntology);
+    }
+
+    public List<Trait> getTraitsByProgramId(UUID programId, boolean getFullTrait) throws DoesNotExistException {
+        return traitService.getByProgramId(getSubscribedOntologyProgramId(programId), getFullTrait);
+    }
+
+    public List<Trait> updateTraits(UUID programId, List<Trait> traits, AuthenticatedUser actingUser)
+            throws DoesNotExistException, HttpStatusException, ValidatorException, BadRequestException {
+        UUID lookupId = getSubscribedOntologyProgramId(programId);
+        if(lookupId != programId) {
+            throw new BadRequestException("Subscribed ontology terms cannot be updated");
+        }
+
+        return traitService.updateTraits(lookupId, traits, actingUser);
+    }
+
+    public List<Trait> createTraits(UUID programId, List<Trait> traits, AuthenticatedUser actingUser, Boolean throwDuplicateErrors)
+            throws DoesNotExistException, ValidatorException, BadRequestException {
+        UUID lookupId = getSubscribedOntologyProgramId(programId);
+        if(lookupId != programId) {
+            throw new BadRequestException("Subscribed ontology terms cannot be created");
+        }
+
+        return traitService.createTraits(lookupId, traits, actingUser, throwDuplicateErrors);
+    }
+
+    public ProgramUpload updateTraitUpload(UUID programId, CompletedFileUpload file, AuthenticatedUser actingUser)
+            throws DoesNotExistException, UnsupportedTypeException, ValidatorException, AuthorizationException, HttpStatusException, BadRequestException {
+        UUID lookupId = getSubscribedOntologyProgramId(programId);
+        if(lookupId != programId) {
+            throw new BadRequestException("Subscribed ontology terms cannot be imported");
+        }
+
+        return traitUploadService.updateTraitUpload(lookupId, file, actingUser);
+    }
+
+    public void confirmUpload(UUID programId, UUID traitUploadId, AuthenticatedUser actingUser)
+            throws DoesNotExistException, ValidatorException, BadRequestException {
+        UUID lookupId = getSubscribedOntologyProgramId(programId);
+        if(lookupId != programId) {
+            throw new BadRequestException("Subscribed ontology terms cannot be imported");
+        }
+
+        traitUploadService.confirmUpload(lookupId, traitUploadId, actingUser);
+    }
+
+    public UUID getSubscribedOntologyProgramId(UUID programId) throws DoesNotExistException {
+        // get shared ontology programs
+        List<SubscribedProgram> subscriptionOptions = getSubscribeOntologyOptions(programId);
+
+        // check if we are subscribed to one of the programs
+        SubscribedProgram subscribedOntology = null;
+        for (SubscribedProgram sharingProgram : subscriptionOptions) {
+            if (sharingProgram.getSubscribed()) {
+                subscribedOntology = sharingProgram;
+            }
+        }
+
+        UUID lookupId = subscribedOntology == null ? programId : subscribedOntology.getProgramId();
+
+        return lookupId;
     }
 
     public List<SubscribedOntology> getSubscribeOntologyOptions(UUID programId) throws DoesNotExistException {

--- a/src/main/java/org/breedinginsight/services/OntologyService.java
+++ b/src/main/java/org/breedinginsight/services/OntologyService.java
@@ -347,11 +347,11 @@ public class OntologyService {
 
     public UUID getSubscribedOntologyProgramId(UUID programId) throws DoesNotExistException {
         // get shared ontology programs
-        List<SubscribedProgram> subscriptionOptions = getSubscribeOntologyOptions(programId);
+        List<SubscribedOntology> subscriptionOptions = getSubscribeOntologyOptions(programId);
 
         // check if we are subscribed to one of the programs
-        SubscribedProgram subscribedOntology = null;
-        for (SubscribedProgram sharingProgram : subscriptionOptions) {
+        SubscribedOntology subscribedOntology = null;
+        for (SubscribedOntology sharingProgram : subscriptionOptions) {
             if (sharingProgram.getSubscribed()) {
                 subscribedOntology = sharingProgram;
             }

--- a/src/main/java/org/breedinginsight/services/exceptions/BadRequestException.java
+++ b/src/main/java/org/breedinginsight/services/exceptions/BadRequestException.java
@@ -1,0 +1,25 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.services.exceptions;
+
+public class BadRequestException extends Exception {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
# Description
**Story:** [BI-1364 View a shared ontology that a program is subscribed to](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1364)

A new exception class for returning 400 status was created.
OntologyService methods were created that wrap around existing TraitService and TraitUploadService methods which use the program ID for the case of a non-subscriber or sharing program and the sharing program's ID in the case of a subscribed program.
TraitController and TraitUpload controller were updated to return 400 status if a subscribed program requests to create or update traits of a shared ontology.

# Dependencies
bi-web BI-1364 branch

# Testing
See testing procedure for biweb BI-1364.
In addition, manually try to create and update traits for a subscribing program using POST/traits, PUT/traits, PUT/trait-upload, and POST/trait-upload/<trait-ID>.
Verify that a 400 status was returned in all cases.
NOTE: In order to manually test POST/trait-upload/<trait-ID> you will first need to successfully import traits via PUT/trait-upload by making two changes in `TraitUploadController.java`:

1. comment out lines 76-78, and
2. on line 73 replace `ontologyService.updateTraitUpload(programId, file, actingUser);` with `traitUploadService.updateTraitUpload(programId, file, actingUser);`.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_