### PR TITLE
[BI-1445] - Trait Entity/Attribute/Method capitalization

### DIFF
--- a/src/main/java/org/breedinginsight/daos/TraitDAO.java
+++ b/src/main/java/org/breedinginsight/daos/TraitDAO.java
@@ -316,7 +316,7 @@ public class TraitDAO extends TraitDao {
                     .traitDescription(trait.getTraitDescription())
                     .synonyms(trait.getSynonyms())
                     .status("active")
-                    .entity(trait.getEntity())
+                    .entity(trait.getProgramObservationLevel().getName())
                     .mainAbbreviation(trait.getMainAbbreviation())
                     .traitClass(trait.getTraitClass())
                     .externalReferences(List.of(traitReference))

--- a/src/main/java/org/breedinginsight/services/TraitService.java
+++ b/src/main/java/org/breedinginsight/services/TraitService.java
@@ -17,12 +17,12 @@
 
 package org.breedinginsight.services;
 
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.http.server.exceptions.HttpServerException;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.text.WordUtils;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.breedinginsight.api.auth.AuthenticatedUser;
 import org.breedinginsight.api.model.v1.response.ValidationErrors;
@@ -242,11 +242,11 @@ public class TraitService {
                 if (matchingLevels.size() == 0) {
                     // If doesn't exist, save it without an id. We will create it later
                     ProgramObservationLevel programObservationLevel = new ProgramObservationLevel();
-                    programObservationLevel.setName(StringUtils.capitalize(trait.getProgramObservationLevel().getName().toLowerCase()));
+                    programObservationLevel.setName(WordUtils.capitalize(trait.getProgramObservationLevel().getName().toLowerCase()));
                     trait.setProgramObservationLevel(programObservationLevel);
                 } else {
                     ProgramObservationLevel dbLevel = matchingLevels.get(0);
-                    trait.getProgramObservationLevel().setName(StringUtils.capitalize(trait.getProgramObservationLevel().getName().toLowerCase()));
+                    trait.getProgramObservationLevel().setName(dbLevel.getName());
                     trait.getProgramObservationLevel().setId(dbLevel.getId());
                 }
             }

--- a/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
@@ -1284,7 +1284,7 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         updateTrait.setTraitDescription("Updated description");
         updateTrait.setEntity("Updated entity");
         updateTrait.setObservationVariableName("Updated name");
-        updateTrait.setProgramObservationLevel(ProgramObservationLevel.builder().name("Updated level").build());
+        updateTrait.setProgramObservationLevel(ProgramObservationLevel.builder().name("Updated Level").build());
         updateTrait.getScale().setScaleName("Updated Scale");
         updateTrait.getScale().setDataType(DataType.DATE);
         updateTrait.getMethod().setDescription("A method");
@@ -1418,7 +1418,7 @@ public class TraitControllerIntegrationTest extends BrAPITest {
 
         updateTrait.setId(UUID.randomUUID());
         updateTrait.setObservationVariableName("Update Name");
-        updateTrait.setProgramObservationLevel(ProgramObservationLevel.builder().name("Updated level").build());
+        updateTrait.setProgramObservationLevel(ProgramObservationLevel.builder().name("Updated Level").build());
         updateTrait.getScale().setScaleName("Updated Scale");
         updateTrait.getScale().setDataType(DataType.DATE);
         updateTrait.getMethod().setDescription("A method");


### PR DESCRIPTION
# Description
**Story:** [BI-1445 - Trait Column value not the same as entered in the the Term creation](https://breedinginsight.atlassian.net/browse/BI-1445)

Implemented changes to make capitalization of trait entity, trait attribute, and method description more consistent in table and sidepanel display.

- On ontology term creation, set brapi trait entity to program observation level name to be consistent with ontology term update
- Modified saving of program observation level (and by extension trait entity) to capitalize each word rather than only the first letter

# Dependencies
[bi-web/BI-1445](https://github.com/Breeding-Insight/bi-web/pull/240)

# Testing
see bi-web for testing

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have tested that my code works with both the brapi-java-server and BreedBase
- [X] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<please include a link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/2471799460)