### PR TITLE
[BI-1446] trait error: fix error display on trait form

### DIFF
--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
@@ -37,86 +37,86 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getTraitIdDoesNotExistMsg() {
-        return new ValidationError("Trait Id", "Trait with that id does not exist", HttpStatus.NOT_FOUND);
+        return new ValidationError("traitId", "Trait with that id does not exist", HttpStatus.NOT_FOUND);
     }
 
     @Override
     public ValidationError getMissingMethodMsg() {
-        return new ValidationError("Method", "Missing method", HttpStatus.BAD_REQUEST);
+        return new ValidationError("method", "Missing method", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingMethodClassMsg() {
-        return new ValidationError("Method Class", "Missing method class", HttpStatus.BAD_REQUEST);
+        return new ValidationError("method.methodClass", "Missing method class", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingScaleMsg() {
-        return new ValidationError("Scale", "Missing scale", HttpStatus.BAD_REQUEST);
+        return new ValidationError("scale", "Missing scale", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingScaleNameMsg() {
-        return new ValidationError("Scale Name", "Missing scale name", HttpStatus.BAD_REQUEST);
+        return new ValidationError("scale.scaleName", "Missing scale name", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingScaleDataTypeMsg() {
-        return new ValidationError("Scale Data Type", "Missing scale data type", HttpStatus.BAD_REQUEST);
+        return new ValidationError("scale.dataType", "Missing scale data type", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingObsVarNameMsg() {
-        return new ValidationError("Name", "Missing Name", HttpStatus.BAD_REQUEST);
+        return new ValidationError("observationVariableName", "Missing Name", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingTraitEntityMsg() {
-        return new ValidationError("Entity", "Missing trait entity", HttpStatus.BAD_REQUEST);
+        return new ValidationError("entity", "Missing trait entity", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingTraitAttributeMsg() {
-        return new ValidationError("Attribute", "Missing trait attribute", HttpStatus.BAD_REQUEST);
+        return new ValidationError("attribute", "Missing trait attribute", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingTraitDescriptionMsg() {
-        return new ValidationError("Trait Description", "Missing trait description", HttpStatus.BAD_REQUEST);
+        return new ValidationError("traitDescription", "Missing trait description", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingProgramObservationLevelMsg() {
-        return new ValidationError("Program Observation Level Name", "Missing program observation level", HttpStatus.BAD_REQUEST);
+        return new ValidationError("programObservationLevel.name", "Missing program observation level", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingMethodFormulaMsg() {
-        return new ValidationError("Method Formula", "Missing method formula for Computation method", HttpStatus.BAD_REQUEST);
+        return new ValidationError("method.formula", "Missing method formula for Computation method", HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getMissingScaleCategoriesMsg(DataType dataType) {
-        return new ValidationError("Scale Categories",
+        return new ValidationError("scale.categories",
                 String.format("Missing scale categories for %s scale", WordUtils.capitalize(dataType.getLiteral().toLowerCase())),
                 HttpStatus.BAD_REQUEST);
     }
 
     @Override
     public ValidationError getBadScaleCategory() {
-        return new ValidationError("Scale Categories", "Scale categories contain errors", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("scale.categories", "Scale categories contain errors", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getBlankScaleCategoryLabelMsg() {
-        return new ValidationError("Scale Categories Label",
+        return new ValidationError("scale.categories.label",
                 "Label missing.",
                 HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getBlankScaleCategoryValueMsg() {
-        return new ValidationError("Scale Categories Value",
+        return new ValidationError("scale.categories.value",
                 "Value missing.",
                 HttpStatus.UNPROCESSABLE_ENTITY);
     }
@@ -130,7 +130,7 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getMaxLessThenMinError() {
-        return new ValidationError("Scale Valid Value Max",
+        return new ValidationError("scale.validValueMax",
                 "Scale valid value max must be greater than valid value min.",
                 HttpStatus.UNPROCESSABLE_ENTITY);
     }
@@ -142,39 +142,39 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getInsufficientOrdinalValError() {
-        return new ValidationError("Scale Categories", "Ordinal scales must have at least two categories.", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("scale.categories", "Ordinal scales must have at least two categories.", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getCharLimitObsVarNameMsg() {
-        return new ValidationError("Name", "Name exceeds 12 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("observationVariableName", "Name exceeds 12 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getCharLimitTraitEntityMsg() {
-        return new ValidationError("Entity", "Trait entity exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("entity", "Trait entity exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getCharLimitTraitAttributeMsg() {
-        return new ValidationError("Attribute", "Trait attribute exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("attribute", "Trait attribute exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getCharLimitMethodDescriptionMsg() {
-        return new ValidationError("Method Description", "Method description exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("method.description", "Method description exceeds 30 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override
     public ValidationError getDuplicateTraitByNamesMsg() {
-        return new ValidationError("Trait Name", "Trait name already exists", HttpStatus.CONFLICT);
+        return new ValidationError("traitName", "Trait name already exists", HttpStatus.CONFLICT);
     }
 
 
     @Override
     public ValidationError getDuplicateTraitsByNameInFileMsg(List<Integer> matchingRows) {
         matchingRows = matchingRows.stream().map(rowIndex -> getRowNumber(rowIndex)).collect(Collectors.toList());
-        return new ValidationError("Trait Name",
+        return new ValidationError("traitName",
                 "traitName is a duplicate. Duplicate set of traits are rows " + matchingRows.toString(),
                 HttpStatus.CONFLICT);
     }

--- a/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
@@ -1120,12 +1120,12 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         JsonObject categoryError = categoryErrors.get(0).getAsJsonObject();
         assertEquals(0, categoryError.get("rowIndex").getAsInt(), "wrong error row index returned");
         JsonObject valueError = categoryError.getAsJsonArray("errors").get(0).getAsJsonObject();
-        assertEquals("Scale Categories Value", valueError.get("field").getAsString(), "wrong error returned");
+        assertEquals("scale.categories.value", valueError.get("field").getAsString(), "wrong error returned");
 
         JsonObject secondCategoryError = categoryErrors.get(1).getAsJsonObject();
         assertEquals(2, secondCategoryError.get("rowIndex").getAsInt(), "wrong error row index returned");
         JsonObject labelError = secondCategoryError.getAsJsonArray("errors").get(0).getAsJsonObject();
-        assertEquals("Scale Categories Label", labelError.get("field").getAsString(), "wrong error returned");
+        assertEquals("scale.categories.label", labelError.get("field").getAsString(), "wrong error returned");
     }
 
     @Test
@@ -1365,13 +1365,13 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         JsonArray errors = rowError.getAsJsonArray("errors");
         assertEquals(1, errors.size(), "Not enough errors were returned");
         JsonObject error1 = errors.get(0).getAsJsonObject();
-        assertEquals("Name", error1.get("field").getAsString(), "wrong error returned");
+        assertEquals("observationVariableName", error1.get("field").getAsString(), "wrong error returned");
 
         JsonObject badIdRowError = rowErrors.get(1).getAsJsonObject();
         errors = badIdRowError.getAsJsonArray("errors");
         assertEquals(1, errors.size(), "Not enough errors were returned");
         JsonObject error = errors.get(0).getAsJsonObject();
-        assertEquals("Trait Id", error.get("field").getAsString(), "wrong error returned");
+        assertEquals("traitId", error.get("field").getAsString(), "wrong error returned");
     }
 
     @Test
@@ -1447,7 +1447,7 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         JsonArray errors = rowError.getAsJsonArray("errors");
         assertEquals(1, errors.size(), "Not enough errors were returned");
         JsonObject error = errors.get(0).getAsJsonObject();
-        assertEquals("Trait Id", error.get("field").getAsString(), "wrong error returned");
+        assertEquals("traitId", error.get("field").getAsString(), "wrong error returned");
     }
 
     @Test

--- a/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
@@ -91,7 +91,7 @@ public class TraitValidatorUnitTest {
         RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
         assertEquals(1, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         assertEquals(400, rowValidationErrors.getErrors().get(0).getHttpStatusCode(), "Wrong error code");
-        assertEquals("Method", rowValidationErrors.getErrors().get(0).getField(), "Wrong error column");
+        assertEquals("method", rowValidationErrors.getErrors().get(0).getField(), "Wrong error column");
     }
 
     @Test
@@ -124,7 +124,7 @@ public class TraitValidatorUnitTest {
         RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
         assertEquals(1, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         assertEquals(400, rowValidationErrors.getErrors().get(0).getHttpStatusCode(), "Wrong error code");
-        assertEquals("Scale", rowValidationErrors.getErrors().get(0).getField(), "Wrong error column");
+        assertEquals("scale", rowValidationErrors.getErrors().get(0).getField(), "Wrong error column");
     }
 
     @Test
@@ -143,14 +143,14 @@ public class TraitValidatorUnitTest {
         RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
         assertEquals(6, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         Map<String, Integer> expectedColumns = new HashMap<>();
-        expectedColumns.put("Name", 400);
-        expectedColumns.put("Entity", 400);
-        expectedColumns.put("Attribute", 400);
-        expectedColumns.put("Trait Description", 400);
-        expectedColumns.put("Program Observation Level Name", 400);
-        expectedColumns.put("Method Class", 400);
-        expectedColumns.put("Scale Name", 400);
-        expectedColumns.put("Scale Data Type", 400);
+        expectedColumns.put("observationVariableName", 400);
+        expectedColumns.put("entity", 400);
+        expectedColumns.put("attribute", 400);
+        expectedColumns.put("traitDescription", 400);
+        expectedColumns.put("programObservationLevel.name", 400);
+        expectedColumns.put("method.methodClass", 400);
+        expectedColumns.put("scale.scaleName", 400);
+        expectedColumns.put("scale.dataType", 400);
         List<Boolean> seenTrackList = expectedColumns.keySet().stream().map(column -> false).collect(Collectors.toList());
 
         Boolean unknownColumnReturned = false;
@@ -187,8 +187,8 @@ public class TraitValidatorUnitTest {
         RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
         assertEquals(2, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         Map<String, Integer> expectedColumns = new HashMap<>();
-        expectedColumns.put("Method Formula", 400);
-        expectedColumns.put("Scale Categories", 400);
+        expectedColumns.put("method.formula", 400);
+        expectedColumns.put("scale.categories", 400);
         List<Boolean> seenTrackList = expectedColumns.keySet().stream().map(column -> false).collect(Collectors.toList());
 
         Boolean unknownColumnReturned = false;
@@ -229,8 +229,8 @@ public class TraitValidatorUnitTest {
         RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
         assertEquals(2, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         Map<String, Integer> expectedColumns = new HashMap<>();
-        expectedColumns.put("Method Formula", 400);
-        expectedColumns.put("Scale Categories", 422);
+        expectedColumns.put("method.formula", 400);
+        expectedColumns.put("scale.categories", 422);
         List<Boolean> seenTrackList = expectedColumns.keySet().stream().map(column -> false).collect(Collectors.toList());
 
         Boolean unknownColumnReturned = false;
@@ -328,10 +328,10 @@ public class TraitValidatorUnitTest {
         assertEquals(4, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
 
         Map<String, Integer> expectedColumns = new HashMap<>();
-        expectedColumns.put("Name", 422);
-        expectedColumns.put("Entity", 422);
-        expectedColumns.put("Attribute", 422);
-        expectedColumns.put("Method Description", 422);
+        expectedColumns.put("observationVariableName", 422);
+        expectedColumns.put("entity", 422);
+        expectedColumns.put("attribute", 422);
+        expectedColumns.put("method.description", 422);
         List<Boolean> seenTrackList = expectedColumns.keySet().stream().map(column -> false).collect(Collectors.toList());
 
         Boolean unknownColumnReturned = false;


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1446

The trait errors were accidentally changed when making the trait file import names more consistent. (https://github.com/Breeding-Insight/bi-api/pull/150/files#diff-645879ab06ebc8d8a2f7b0272aaf4c5e897cb743c52798982139924349f1235f)

Reversed those changes for the trait form code, but kept the fixes to the trait file import code. 



# Dependencies
biweb: develop

# Testing
1. Go to the trait list
2. Click on "New Trait"
3. Check that the errors are displayed below the fields. 
4. Try out the Computation, Ordinal, and Nominal fields. 


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/2490243610
