### PR TITLE
[BI-1487] trait create/update: account for null method description in method name

### DIFF
--- a/src/main/java/org/breedinginsight/daos/TraitDAO.java
+++ b/src/main/java/org/breedinginsight/daos/TraitDAO.java
@@ -36,6 +36,7 @@ import org.breedinginsight.model.*;
 import org.breedinginsight.services.brapi.BrAPIProvider;
 import org.breedinginsight.utilities.BrAPIDAOUtil;
 import org.jooq.*;
+import org.jooq.tools.StringUtils;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -285,7 +286,7 @@ public class TraitDAO extends TraitDao {
                     .referenceID(trait.getMethod().getId().toString())
                     .referenceSource(referenceSource);
             BrAPIMethod brApiMethod = new BrAPIMethod()
-                                                 .methodName(String.format("%s %s [%s]", trait.getMethod().getDescription(), trait.getMethod().getMethodClass(), program.getKey()))
+                                                 .methodName(constructMethodName(trait, program))
                                                  .externalReferences(List.of(methodReference))
                                                  .methodClass(trait.getMethod().getMethodClass())
                                                  .description(trait.getMethod().getDescription())
@@ -405,7 +406,7 @@ public class TraitDAO extends TraitDao {
             BrAPIObservationVariable existingVariable = getBrAPIVariable(variablesAPI, trait.getId());
 
             // Change method
-            existingVariable.getMethod().setMethodName(String.format("%s %s [%s]", trait.getMethod().getDescription(), trait.getMethod().getMethodClass(), program.getKey()));
+            existingVariable.getMethod().setMethodName(constructMethodName(trait, program));
             existingVariable.getMethod().setMethodClass(trait.getMethod().getMethodClass());
             existingVariable.getMethod().setDescription(trait.getMethod().getDescription());
             existingVariable.getMethod().setFormula(trait.getMethod().getFormula());
@@ -451,6 +452,12 @@ public class TraitDAO extends TraitDao {
         }
 
         return updatedTrait;
+    }
+
+    private String constructMethodName(Trait trait, Program program) {
+        return !StringUtils.isBlank(trait.getMethod().getDescription()) ?
+                String.format("%s %s [%s]", trait.getMethod().getDescription(), trait.getMethod().getMethodClass(), program.getKey()) :
+                String.format("%s [%s]", trait.getMethod().getMethodClass(), program.getKey());
     }
 
     private BrAPIObservationVariable getBrAPIVariable(ObservationVariablesApi variablesAPI, UUID traitId) {


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1487

In backend, checked method description and did not add it to the method name if method description was null. 



# Dependencies
biweb: develop

# Testing
In the brapi server and breedbase:
1. Create a trait with no method description
2. Check BrAPI to make sure `null` wasn't put into `methodName`. 
3. Check UI to see that the trait loads and displays properly. 
4. Try editing the trait and adding a method description to make sure it is still save-able. 
5. Try editing the trait and deleting the method description field and make sure `null` is not put in method name. 


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
