### PR TITLE
[BI-1224] - Show list creator in Germplasm lists table

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -85,16 +85,12 @@ public class BrAPIGermplasmService {
                 germplasmList.setListName(newListName);
 
                 //Retrieve germplasm details to get list owner name
+                //Due to listOwnerName not being stored in breedbase
                 BrAPIListDetails listData = brAPIListDAO.getListById(germplasmList.getListDbId(), programId).getResult();
                 List<String> germplasmNames = listData.getData().subList(0,1);
                 List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
                 String createdBy = germplasm.get(0).getAdditionalInfo().getAsJsonObject("createdBy").get("userName").getAsString();
                 germplasmList.setListOwnerName(createdBy);
-
-                //germplasmList.getListType(); value germplasm name GERMPLASM
-                //germplasmList.getAdditionalInfo(); todo utilize this instead if possible
-                //logic based on listType to know what BrAPI endpoint to call after fetching the first record in the list
-                //in order to fetch the full object
             }
 
             return germplasmLists;

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -83,6 +83,18 @@ public class BrAPIGermplasmService {
                 String listName = germplasmList.getListName();
                 String newListName = removeAppendedKey(listName, program.getKey());
                 germplasmList.setListName(newListName);
+
+                //Retrieve germplasm details to get list owner name
+                BrAPIListDetails listData = brAPIListDAO.getListById(germplasmList.getListDbId(), programId).getResult();
+                List<String> germplasmNames = listData.getData().subList(0,1);
+                List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
+                String createdBy = germplasm.get(0).getAdditionalInfo().getAsJsonObject("createdBy").get("userName").getAsString();
+                germplasmList.setListOwnerName(createdBy);
+
+                //germplasmList.getListType(); value germplasm name GERMPLASM
+                //germplasmList.getAdditionalInfo(); todo utilize this instead if possible
+                //logic based on listType to know what BrAPI endpoint to call after fetching the first record in the list
+                //in order to fetch the full object
             }
 
             return germplasmLists;


### PR DESCRIPTION
# Description
**Story:** [BI-1224 - Show list creator in Germplasm lists table](https://breedinginsight.atlassian.net/browse/BI-1224)

Retrieves list creator and displays for germplasm lists.

As the brapi listOwnerName is not stored in breedbase, the list creator is retrieved from the first germplasm in the list, which requires multiple calls to retrieve alas. Trying to store listOwnerName in additionalInfo on list create does not work alas as additionalInfo for lists is also not saved on breedbase.

# Dependencies
[bi-web/BI-1224](https://github.com/Breeding-Insight/bi-web/pull/244)

# Testing
see bi-web

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have tested that my code works with both the brapi-java-server and BreedBase
- [X] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<please include a link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/2572017460)