### PR TITLE
[BI-1494] Improve Pedigree View Display

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v1/model/request/query/GermplasmQuery.java
+++ b/src/main/java/org/breedinginsight/brapi/v1/model/request/query/GermplasmQuery.java
@@ -1,0 +1,26 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.breedinginsight.brapi.v1.model.request.query;
+
+import io.micronaut.core.annotation.Introspected;
+import lombok.Getter;
+
+@Getter
+@Introspected
+public class GermplasmQuery extends BrapiQuery {
+    private String accessionNumber;
+}


### PR DESCRIPTION
# Description
**Story:** [BI-1494 - Improve Pedigree View Display](https://breedinginsight.atlassian.net/browse/BI-1494)

To enable pedigree tree nodes (which only have name and accessionNumber information) to be germplasm links, added a GermplasmQuery class that enables filtering on accessionNumber and updated GermplasmController to utilize it.

# Dependencies
[bi-web: feature/BI-1494](https://github.com/Breeding-Insight/bi-web/pull/248)
[BrAPI-Pedigree-Viewer: feature/BI-1494](https://github.com/Breeding-Insight/BrAPI-Pedigree-Viewer/pull/3)

# Testing
see bi-web

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
