### PR TITLE
[BI-1189] bug - Season dbId is displayed instead of year for the Env Year of existing studies.

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPISeasonDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPISeasonDAO.java
@@ -17,6 +17,7 @@ import org.brapi.v2.model.core.request.BrAPIListSearchRequest;
 import org.brapi.v2.model.core.response.BrAPIListsSingleResponse;
 import org.brapi.v2.model.core.response.BrAPISeasonListResponse;
 import org.brapi.v2.model.core.response.BrAPISeasonListResponseResult;
+import org.brapi.v2.model.core.response.BrAPISeasonSingleResponse;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.daos.ProgramDAO;
@@ -54,6 +55,14 @@ public class BrAPISeasonDAO {
         seasons = result.getData();
 
         return seasons;
+    }
+
+    public BrAPISeason getSeasonById(String id, UUID programId) throws ApiException {
+        SeasonsApi api = new SeasonsApi(programDAO.getCoreClient(programId));
+        ApiResponse<BrAPISeasonSingleResponse> apiResponse = api.seasonsSeasonDbIdGet(id);
+        BrAPISeasonSingleResponse seasonListResponse = apiResponse.getBody();
+        BrAPISeason season = seasonListResponse.getResult();
+        return season;
     }
 
     public BrAPISeason addOneSeason(BrAPISeason season, UUID programId) throws ApiException {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -75,6 +75,8 @@ public class ExperimentProcessor implements Processor {
 
     // used to make the yearsToSeasonDbId() function more efficient
     private Map<String, String > yearToSeasonDbIdCache = new HashMap<>();
+    // used to make the seasonDbIdtoYear() function more efficient
+    private Map<String, String > seasonDbIdToYearCache = new HashMap<>();
 
     //These BrapiData-objects are initially populated by the getExistingBrapiData() method,
     // then updated by the getNewBrapiData() method.
@@ -608,6 +610,9 @@ public class ExperimentProcessor implements Processor {
         try {
             existingStudies = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(experimentIDStr), program);
             existingStudies.forEach(existingStudy -> {
+                //Swap season DbId with year String
+                String seasonId = existingStudy.getSeasons().get(0);
+                existingStudy.setSeasons( List.of( this.seasonDbIdToYear( seasonId, program.getId() ) ) );
 
                 existingStudy.setStudyName(Utilities.removeProgramKeyAndUnknownAdditionalData(existingStudy.getStudyName(), program.getKey()));
                 studyByNameNoScope.put(
@@ -684,7 +689,7 @@ public class ExperimentProcessor implements Processor {
     private String yearsToSeasonDbId(List<String> years, UUID programId) {
         String year = years.get(0);
         String dbID = null;
-        if (this.yearToSeasonDbIdCache.containsKey(year) ){ // get it from cache if possable
+        if (this.yearToSeasonDbIdCache.containsKey(year) ){ // get it from cache if possible
             dbID = this.yearToSeasonDbIdCache.get(year);
         }
         else{
@@ -692,6 +697,18 @@ public class ExperimentProcessor implements Processor {
             this.yearToSeasonDbIdCache.put(year, dbID);
         }
         return dbID;
+    }
+
+    private String seasonDbIdToYear(String seasonDbId, UUID programId) {
+        String year = null;
+        if (this.seasonDbIdToYearCache.containsKey(seasonDbId) ){ // get it from cache if possible
+            year = this.seasonDbIdToYearCache.get(seasonDbId);
+        }
+        else{
+            year = this.seasonDbIdToYearFromDatabase(seasonDbId,programId);
+            this.seasonDbIdToYearCache.put(seasonDbId, year);
+        }
+        return year;
     }
 
     private String yearToSeasonDbIdFromDatabase(String year, UUID programId) {
@@ -718,6 +735,19 @@ public class ExperimentProcessor implements Processor {
 
         String seasonDbId = (targetSeason==null) ? null : targetSeason.getSeasonDbId();
         return seasonDbId;
+    }
+
+    private String seasonDbIdToYearFromDatabase(String seasonDbId, UUID programId) {
+        BrAPISeason targetSeason = null;
+        BrAPISeason season = null;
+        try {
+            season = this.brAPISeasonDAO.getSeasonById (seasonDbId, programId);
+        } catch (ApiException e) {
+            log.error(e.getResponseBody(), e);;
+        }
+        Integer yearInt = (season == null) ? null : season.getYear();;
+        String yearStr = (yearInt==null) ? "" : yearInt.toString();
+        return yearStr;
     }
 
     private boolean isTrialRefSource(BrAPIExternalReference brAPIExternalReference) {


### PR DESCRIPTION
# Description
While testing [BI-1189](https://breedinginsight.atlassian.net/browse/BI-1189), a bug was discovered.  If importing data for an existing study (on an existing experiment), the **Env Year** was displaying incorrectly in the table of the confirmation screen.  It would display the Session DbId instead of the year string.

# Dependencies
bi-web develop-branch

# Testing

1. Import and confirm _Experiments and Observations_ data from a flat file.
2. Import _Experiments and Observations_ data from the _same_ flat file (you should now be on the confirmation page).
 
**Expected results**
The data in the  **Env Year** on the confirmation page's table should match the data from the flat file.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: _\<please include a link to TAF run>_
