### PR TITLE
[BI-1230] Truly Unknown Germplasm

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -1,6 +1,5 @@
 package org.breedinginsight.brapi.v2;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -41,7 +40,6 @@ import org.breedinginsight.utilities.response.ResponseUtils;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -230,8 +228,7 @@ public class GermplasmController {
     @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
     public HttpResponse<BrAPIGermplasmProgenyResponse> getGermplasmProgenyInfo(
             @PathVariable("programId") UUID programId,
-            @PathVariable("germplasmId") String germplasmId,
-            @QueryValue(defaultValue = "0") String page) {
+            @PathVariable("germplasmId") String germplasmId) {
         try {
             log.debug("fetching progeny for germ id:" +  germplasmId +" for program: " + programId);
             BrAPIProgenyNode returnNode;
@@ -246,7 +243,7 @@ public class GermplasmController {
                 ArrayList<BrAPIProgenyNodeProgeny> progeny = new ArrayList<>();
                 BrAPIProgenyNodeProgeny singleProgeny = new BrAPIProgenyNodeProgeny();
                 singleProgeny.setGermplasmDbId(germplasmId.split("-")[0]);
-                singleProgeny.setGermplasmName("todo"); //todo, see if necessary, preferable to avoid longer id string/making more endpoint calls
+                singleProgeny.setGermplasmName("Name"); //does not seem necessary, preferable to avoid longer id string/making more endpoint calls
                 if (germplasmId.endsWith("F-Unknown")) {
                     singleProgeny.setParentType(BrAPIParentType.FEMALE);
                 } else {
@@ -272,9 +269,8 @@ public class GermplasmController {
             } else {
                 //Forward the progeny call to the backing BrAPI system of the program passing the germplasmDbId that came in the request
                 GermplasmApi api = new GermplasmApi(programDAO.getCoreClient(programId));
-                //need new method to make api call?
-                ApiResponse<BrAPIGermplasmProgenyResponse> progenyResponse = germplasmDAO.getGermplasmProgenyByDBID(programId, germplasmId, page);
-                //ApiResponse<BrAPIGermplasmProgenyResponse> progenyResponse = api.germplasmGermplasmDbIdProgenyGet(germplasmId);
+                ApiResponse<BrAPIGermplasmProgenyResponse> progenyResponse = api.germplasmGermplasmDbIdProgenyGet(germplasmId);
+
                 //If no progeny, need to add empty progeny for display to work
                 if (progenyResponse.getBody().getResult().getProgeny().isEmpty()) {
                     BrAPIProgenyNodeProgeny emptyProgeny = new BrAPIProgenyNodeProgeny();

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -18,21 +18,16 @@
 package org.breedinginsight.brapi.v2.dao;
 
 import com.google.gson.JsonObject;
-import com.google.gson.reflect.TypeToken;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.*;
-import org.brapi.client.v2.ApiResponse;
-import org.brapi.client.v2.BrAPIClient;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.germplasm.GermplasmApi;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.germ.BrAPIGermplasmSynonyms;
 import org.brapi.v2.model.germ.request.BrAPIGermplasmSearchRequest;
-import org.brapi.v2.model.germ.response.BrAPIGermplasmProgenyResponse;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapps.importer.daos.ImportDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
@@ -45,7 +40,6 @@ import org.breedinginsight.utilities.Utilities;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.lang.reflect.Type;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
@@ -167,7 +161,6 @@ public class BrAPIGermplasmDAO {
         }
 
         // Update pedigree string
-        //TODO update namepedigreeString
         for (BrAPIGermplasm germplasm: programGermplasm) {
             if (germplasm.getPedigree() != null) {
                 JsonObject additionalInfo = germplasm.getAdditionalInfo();
@@ -268,36 +261,4 @@ public class BrAPIGermplasmDAO {
         }
         return germplasm;
     }
-
-    public ApiResponse<BrAPIGermplasmProgenyResponse> getGermplasmProgenyByDBID(UUID programId, String germplasmDbId, String page) throws ApiException {
-        BrAPIClient apiClient = programDAO.getCoreClient(programId);
-
-        if (germplasmDbId == null) {
-            throw new IllegalArgumentException("germplasmDbId cannot be null");
-        } else {
-            Object localVarPostBody = null;
-            String localVarPath = "/germplasm/{germplasmDbId}/progeny".replaceAll("\\{germplasmDbId\\}", germplasmDbId);
-            Map<String, String> localVarQueryParams = new HashMap();
-            Map<String, String> localVarCollectionQueryParams = new HashMap();
-            Map<String, String> localVarHeaderParams = new HashMap();
-            Map<String, Object> localVarFormParams = new HashMap();
-            apiClient.prepQueryParameter(localVarQueryParams, "page", page);
-
-            String[] localVarAccepts = new String[]{"application/json"};
-            String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts); //todo next
-            if (localVarAccept != null) {
-                localVarHeaderParams.put("Accept", localVarAccept);
-            }
-
-            String[] localVarContentTypes = new String[0];
-            String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-            localVarHeaderParams.put("Content-Type", localVarContentType);
-            String[] localVarAuthNames = new String[]{"AuthorizationToken"};
-            Call call = apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames);
-            Type localVarReturnType = (new TypeToken<BrAPIGermplasmProgenyResponse>() {
-            }).getType();
-            return apiClient.execute(call, localVarReturnType);//verify, grab body, etc
-        }
-    }
-
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -161,6 +161,7 @@ public class BrAPIGermplasmDAO {
         }
 
         // Update pedigree string
+        //TODO update namepedigreeString
         for (BrAPIGermplasm germplasm: programGermplasm) {
             if (germplasm.getPedigree() != null) {
                 JsonObject additionalInfo = germplasm.getAdditionalInfo();
@@ -194,6 +195,13 @@ public class BrAPIGermplasmDAO {
                                 map(ref -> ref.getReferenceID()).findFirst().orElse("");
                         additionalInfo.addProperty(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID, maleParentAccessionNumber);
                     }
+                }
+                //Add Unknown germplasm for display
+                if (germplasm.getAdditionalInfo().has("femaleParentUnknown") && germplasm.getAdditionalInfo().get("femaleParentUnknown").getAsBoolean()) {
+                    namePedigreeString = "Unknown";
+                }
+                if (germplasm.getAdditionalInfo().has("maleParentUnknown") && germplasm.getAdditionalInfo().get("maleParentUnknown").getAsBoolean()) {
+                    namePedigreeString += "/Unknown";
                 }
                 //For use in individual germplasm display
                 additionalInfo.addProperty(BrAPIAdditionalInfoFields.GERMPLASM_PEDIGREE_BY_NAME, namePedigreeString);
@@ -238,6 +246,19 @@ public class BrAPIGermplasmDAO {
         }
         if (germplasm == null) {
             throw new DoesNotExistException("UUID for this germplasm does not exist");
+        }
+        return germplasm;
+    }
+
+    public BrAPIGermplasm getGermplasmByDBID(String germplasmDbId, UUID programId) throws ApiException, DoesNotExistException {
+        Map<String, BrAPIGermplasm> cache = programGermplasmCache.get(programId);
+        //key is UUID, want to filter by DBID
+        BrAPIGermplasm germplasm = null;
+        if (cache != null) {
+            germplasm = cache.values().stream().filter(x -> x.getGermplasmDbId().equals(germplasmDbId)).collect(Collectors.toList()).get(0);
+        }
+        if (germplasm == null) {
+            throw new DoesNotExistException("DBID for this germplasm does not exist");
         }
         return germplasm;
     }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -18,16 +18,21 @@
 package org.breedinginsight.brapi.v2.dao;
 
 import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+import org.brapi.client.v2.ApiResponse;
+import org.brapi.client.v2.BrAPIClient;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.germplasm.GermplasmApi;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.germ.BrAPIGermplasmSynonyms;
 import org.brapi.v2.model.germ.request.BrAPIGermplasmSearchRequest;
+import org.brapi.v2.model.germ.response.BrAPIGermplasmProgenyResponse;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapps.importer.daos.ImportDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
@@ -40,6 +45,7 @@ import org.breedinginsight.utilities.Utilities;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.lang.reflect.Type;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
@@ -261,6 +267,37 @@ public class BrAPIGermplasmDAO {
             throw new DoesNotExistException("DBID for this germplasm does not exist");
         }
         return germplasm;
+    }
+
+    public ApiResponse<BrAPIGermplasmProgenyResponse> getGermplasmProgenyByDBID(UUID programId, String germplasmDbId, String page) throws ApiException {
+        BrAPIClient apiClient = programDAO.getCoreClient(programId);
+
+        if (germplasmDbId == null) {
+            throw new IllegalArgumentException("germplasmDbId cannot be null");
+        } else {
+            Object localVarPostBody = null;
+            String localVarPath = "/germplasm/{germplasmDbId}/progeny".replaceAll("\\{germplasmDbId\\}", germplasmDbId);
+            Map<String, String> localVarQueryParams = new HashMap();
+            Map<String, String> localVarCollectionQueryParams = new HashMap();
+            Map<String, String> localVarHeaderParams = new HashMap();
+            Map<String, Object> localVarFormParams = new HashMap();
+            apiClient.prepQueryParameter(localVarQueryParams, "page", page);
+
+            String[] localVarAccepts = new String[]{"application/json"};
+            String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts); //todo next
+            if (localVarAccept != null) {
+                localVarHeaderParams.put("Accept", localVarAccept);
+            }
+
+            String[] localVarContentTypes = new String[0];
+            String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+            String[] localVarAuthNames = new String[]{"AuthorizationToken"};
+            Call call = apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames);
+            Type localVarReturnType = (new TypeToken<BrAPIGermplasmProgenyResponse>() {
+            }).getType();
+            return apiClient.execute(call, localVarReturnType);//verify, grab body, etc
+        }
     }
 
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -64,13 +64,6 @@ public class BrAPIGermplasmService {
 
     public BrAPIGermplasm getGermplasmByUUID(UUID programId, String germplasmId) throws DoesNotExistException {
         try {
-            if (germplasmId.equals(0)){
-                //Unknown germplasm todo check if this necessary
-                BrAPIGermplasm unknownGermplasm = new BrAPIGermplasm();
-                unknownGermplasm.setGermplasmName("Unknown");
-                unknownGermplasm.setGermplasmDbId("0");
-                return unknownGermplasm;
-            }
             return germplasmDAO.getGermplasmByUUID(germplasmId, programId);
         } catch (ApiException e) {
             throw new InternalServerException(e.getMessage(), e);

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -64,6 +64,13 @@ public class BrAPIGermplasmService {
 
     public BrAPIGermplasm getGermplasmByUUID(UUID programId, String germplasmId) throws DoesNotExistException {
         try {
+            if (germplasmId.equals(0)){
+                //Unknown germplasm todo check if this necessary
+                BrAPIGermplasm unknownGermplasm = new BrAPIGermplasm();
+                unknownGermplasm.setGermplasmName("Unknown");
+                unknownGermplasm.setGermplasmDbId("0");
+                return unknownGermplasm;
+            }
             return germplasmDAO.getGermplasmByUUID(germplasmId, programId);
         } catch (ApiException e) {
             throw new InternalServerException(e.getMessage(), e);

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -70,6 +70,14 @@ public class BrAPIGermplasmService {
         }
     }
 
+    public BrAPIGermplasm getGermplasmByDBID(UUID programId, String germplasmId) throws DoesNotExistException {
+        try {
+            return germplasmDAO.getGermplasmByDBID(germplasmId, programId);
+        } catch (ApiException e) {
+            throw new InternalServerException(e.getMessage(), e);
+        }
+    }
+
     public List<BrAPIListSummary> getGermplasmListsByProgramId(UUID programId, HttpRequest<String> request) throws DoesNotExistException, ApiException {
 
         if (!programService.exists(programId)) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -61,9 +61,9 @@ public class GermplasmProcessor implements Processor {
     private String BRAPI_REFERENCE_SOURCE;
 
     private BrAPIGermplasmService brAPIGermplasmService;
-    private BreedingMethodDAO breedingMethodDAO;
-    private BrAPIListDAO brAPIListDAO;
-    private DSLContext dsl;
+    private final BreedingMethodDAO breedingMethodDAO;
+    private final BrAPIListDAO brAPIListDAO;
+    private final DSLContext dsl;
 
     Map<String, PendingImportObject<BrAPIGermplasm>> germplasmByAccessionNumber = new HashMap<>();
     Map<String, Integer> fileGermplasmByName = new HashMap<>();
@@ -128,6 +128,8 @@ public class GermplasmProcessor implements Processor {
         List<String> missingDbIds = new ArrayList<>(germplasmDBIDs);
         if (germplasmDBIDs.size() > 0) {
             try {
+                //Remove germplasm DBID of 0 todo may move this
+                germplasmDBIDs.remove("0");
                 existingParentGermplasms = brAPIGermplasmService.getRawGermplasmByAccessionNumber(new ArrayList<>(germplasmDBIDs), program.getId());
                 List<String> existingDbIds = existingParentGermplasms.stream()
                         .map(germplasm -> germplasm.getAccessionNumber())
@@ -149,6 +151,7 @@ public class GermplasmProcessor implements Processor {
         List<BrAPIGermplasm> dbGermplasm = brAPIGermplasmService.getGermplasmByDisplayName(new ArrayList<>(fileGermplasmByName.keySet()), program.getId());
         dbGermplasm.stream().forEach(germplasm -> dbGermplasmByName.put(germplasm.getDefaultDisplayName(), germplasm));
 
+        /*
         // Check for existing germplasm lists
         Boolean listNameDup = false;
         if (importRows.size() > 0 && importRows.get(0).getGermplasm().getListName() != null) {
@@ -164,7 +167,7 @@ public class GermplasmProcessor implements Processor {
             } catch (ApiException e) {
                 throw new InternalServerException(e.toString(), e);
             }
-        }
+        }*/
 
         // Parent reference checks
         if (missingDbIds.size() > 0) {
@@ -178,13 +181,13 @@ public class GermplasmProcessor implements Processor {
             Germplasm germplasm = importRow.getGermplasm();
             // Check Female Parent
             if (germplasm.getFemaleParentEntryNo() != null) {
-                if (!germplasmIndexByEntryNo.containsKey(germplasm.getFemaleParentEntryNo())) {
+                if ((!germplasmIndexByEntryNo.containsKey(germplasm.getFemaleParentEntryNo())) && !(germplasm.getFemaleParentEntryNo().equals("0"))) {
                     missingEntryNumbers.add(germplasm.getFemaleParentEntryNo());
                 }
             }
             // Check Male Parent
             if (germplasm.getMaleParentEntryNo() != null) {
-                if (!germplasmIndexByEntryNo.containsKey(germplasm.getMaleParentEntryNo())) {
+                if ((!germplasmIndexByEntryNo.containsKey(germplasm.getMaleParentEntryNo())) && !(germplasm.getMaleParentEntryNo().equals("0"))) {
                     missingEntryNumbers.add(germplasm.getMaleParentEntryNo());
                 }
             }
@@ -195,9 +198,10 @@ public class GermplasmProcessor implements Processor {
                             arrayOfStringFormatter.apply(missingEntryNumbers)));
         }
 
+        /*
         if (listNameDup) {
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, listNameAlreadyExists);
-        }
+        }*/
     }
 
     @Override
@@ -352,8 +356,8 @@ public class GermplasmProcessor implements Processor {
                 List<String> pedigreeArray = List.of(germplasm.getPedigree().split("/"));
                 String femaleParent = pedigreeArray.get(0);
                 String maleParent = pedigreeArray.size() > 1 ? pedigreeArray.get(1) : null;
-                if (created.contains(femaleParent)) {
-                    if (maleParent == null || created.contains(maleParent)) {
+                if (created.contains(femaleParent) || germplasm.getAdditionalInfo().get("femaleParentUnknown").getAsBoolean()) {
+                    if (maleParent == null || created.contains(maleParent) || germplasm.getAdditionalInfo().get("maleParentUnknown").getAsBoolean()) {
                         createList.add(germplasm);
                     }
                 }
@@ -434,16 +438,24 @@ public class GermplasmProcessor implements Processor {
             String femaleParentFile = germplasm.getFemaleParentEntryNo();
             String maleParentFile = germplasm.getMaleParentEntryNo();
 
+            boolean femaleParentUnknown = false;
+            boolean maleParentUnknown = false;
+
             boolean femaleParentFound = false;
             String pedigreeString = null;
             if (femaleParentDB != null) {
-                if (germplasmByAccessionNumber.containsKey(femaleParentDB)) {
+                if (femaleParentDB.equals("0")) {
+                    femaleParentUnknown = true;
+                } else if (germplasmByAccessionNumber.containsKey(femaleParentDB)) {
                     BrAPIGermplasm femaleParent = germplasmByAccessionNumber.get(femaleParentDB).getBrAPIObject();
                     pedigreeString = commit ? femaleParent.getGermplasmName() : femaleParent.getDefaultDisplayName();
                     femaleParentFound = true;
                 }
             } else if (femaleParentFile != null) {
-                if (germplasmIndexByEntryNo.containsKey(germplasm.getFemaleParentEntryNo())) {
+                if (femaleParentFile.equals("0")){
+                    femaleParentUnknown = true;
+                }
+                else if (germplasmIndexByEntryNo.containsKey(germplasm.getFemaleParentEntryNo())) {
                     Integer femaleParentInd = germplasmIndexByEntryNo.get(femaleParentFile);
                     BrAPIGermplasm femaleParent = mappedBrAPIImport.get(femaleParentInd).getGermplasm().getBrAPIObject();
                     pedigreeString = commit ? femaleParent.getGermplasmName() : femaleParent.getDefaultDisplayName();
@@ -451,21 +463,33 @@ public class GermplasmProcessor implements Processor {
                 }
             }
 
-            if(femaleParentFound) {
+            if(femaleParentFound || femaleParentUnknown) {
                 if (maleParentDB != null) {
+                    if (maleParentDB.equals("0")) {
+                        maleParentUnknown = true;
+                    }
                     if ((germplasmByAccessionNumber.containsKey(germplasm.getMaleParentDBID()))) {
                         BrAPIGermplasm maleParent = germplasmByAccessionNumber.get(maleParentDB).getBrAPIObject();
-                        pedigreeString += String.format("/%s", commit ? maleParent.getGermplasmName() : maleParent.getDefaultDisplayName());
+                        //todo name for display retrieved here, irksome
+                        if (!femaleParentUnknown) pedigreeString += String.format("/%s", commit ? maleParent.getGermplasmName() : maleParent.getDefaultDisplayName());
                     }
                 } else if (maleParentFile != null){
+                    if (maleParentFile.equals("0")) {
+                        maleParentUnknown = true;
+                    }
                     if (germplasmIndexByEntryNo.containsKey(germplasm.getMaleParentEntryNo())) {
                         Integer maleParentInd = germplasmIndexByEntryNo.get(maleParentFile);
                         BrAPIGermplasm maleParent = mappedBrAPIImport.get(maleParentInd).getGermplasm().getBrAPIObject();
-                        pedigreeString += String.format("/%s", commit ? maleParent.getGermplasmName() : maleParent.getDefaultDisplayName());
+                        if (!femaleParentUnknown) pedigreeString += String.format("/%s", commit ? maleParent.getGermplasmName() : maleParent.getDefaultDisplayName());
                     }
                 }
             }
             mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().setPedigree(pedigreeString);
+            //only set if unknown, or simpler to just always add boolean, todo, consider that previous imported values won't have that value
+            mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem("femaleParentUnknown", femaleParentUnknown);
+            mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem("maleParentUnknown", maleParentUnknown);
+            //Temporary measure until breedbase permits unknown female, knowm male pedigrees, but honestly messy  todo
+            //mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem("maleParentUnknown", maleParentUnknown);
         }
     }
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -469,7 +469,6 @@ public class GermplasmProcessor implements Processor {
                     }
                     if ((germplasmByAccessionNumber.containsKey(germplasm.getMaleParentDBID()))) {
                         BrAPIGermplasm maleParent = germplasmByAccessionNumber.get(maleParentDB).getBrAPIObject();
-                        //todo name for display retrieved here, irksome
                         if (!femaleParentUnknown) pedigreeString += String.format("/%s", commit ? maleParent.getGermplasmName() : maleParent.getDefaultDisplayName());
                     }
                 } else if (maleParentFile != null){
@@ -484,11 +483,9 @@ public class GermplasmProcessor implements Processor {
                 }
             }
             mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().setPedigree(pedigreeString);
-            //only set if unknown, or simpler to just always add boolean, todo, consider that previous imported values won't have that value
+            //Simpler to just always add boolean, but consider for logic that previous imported values won't have that additional info value
             mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem("femaleParentUnknown", femaleParentUnknown);
             mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem("maleParentUnknown", maleParentUnknown);
-            //Temporary measure until breedbase permits unknown female, knowm male pedigrees, but honestly messy  todo
-            //mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem("maleParentUnknown", maleParentUnknown);
         }
     }
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -128,8 +128,6 @@ public class GermplasmProcessor implements Processor {
         List<String> missingDbIds = new ArrayList<>(germplasmDBIDs);
         if (germplasmDBIDs.size() > 0) {
             try {
-                //Remove germplasm DBID of 0 todo may move this
-                germplasmDBIDs.remove("0");
                 existingParentGermplasms = brAPIGermplasmService.getRawGermplasmByAccessionNumber(new ArrayList<>(germplasmDBIDs), program.getId());
                 List<String> existingDbIds = existingParentGermplasms.stream()
                         .map(germplasm -> germplasm.getAccessionNumber())
@@ -151,13 +149,12 @@ public class GermplasmProcessor implements Processor {
         List<BrAPIGermplasm> dbGermplasm = brAPIGermplasmService.getGermplasmByDisplayName(new ArrayList<>(fileGermplasmByName.keySet()), program.getId());
         dbGermplasm.stream().forEach(germplasm -> dbGermplasmByName.put(germplasm.getDefaultDisplayName(), germplasm));
 
-        /*
         // Check for existing germplasm lists
         Boolean listNameDup = false;
         if (importRows.size() > 0 && importRows.get(0).getGermplasm().getListName() != null) {
             try {
                 Germplasm row = importRows.get(0).getGermplasm();
-                String listName = row.constructGermplasmListName(row.getListName(), program);
+                String listName = Germplasm.constructGermplasmListName(row.getListName(), program);
                 List<BrAPIListSummary> existingLists = brAPIListDAO.getListByName(List.of(listName), program.getId());
                 for (BrAPIListSummary existingList: existingLists) {
                     if (existingList.getListName().equals(listName)) {
@@ -167,7 +164,10 @@ public class GermplasmProcessor implements Processor {
             } catch (ApiException e) {
                 throw new InternalServerException(e.toString(), e);
             }
-        }*/
+        }
+
+        //Remove id indicating unknown parent
+        missingDbIds.remove("0");
 
         // Parent reference checks
         if (missingDbIds.size() > 0) {
@@ -198,10 +198,9 @@ public class GermplasmProcessor implements Processor {
                             arrayOfStringFormatter.apply(missingEntryNumbers)));
         }
 
-        /*
         if (listNameDup) {
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, listNameAlreadyExists);
-        }*/
+        }
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -159,7 +159,7 @@ brapi:
     geno-url: ${brapi.server.default-url}
     reference-source: ${BRAPI_REFERENCE_SOURCE:breedinginsight.org}
   read-timeout: 10m
-  page-size: 5000
+  page-size: 1000
   search:
     wait-time: 1000
   post-group-size: 100

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -159,7 +159,7 @@ brapi:
     geno-url: ${brapi.server.default-url}
     reference-source: ${BRAPI_REFERENCE_SOURCE:breedinginsight.org}
   read-timeout: 10m
-  page-size: 1000
+  page-size: 5000
   search:
     wait-time: 1000
   post-group-size: 100


### PR DESCRIPTION
# Description
**Story:** [BI-1230 - Truly Unknown Germplasm](https://breedinginsight.atlassian.net/browse/BI-1230)

Updates to support importing germplasm with truly unknown parents without using a dummy parent. This development also ensures that unrelated germplasm with unknown parents are not falsely attributed as siblings in the pedigree view display.

This included adding GET endpoint calls to /pedigree and /progeny in GermplasmController and adding additionalInfo items of femaleParentUnknown and maleParentUnknown on import. For import and display, the GID of an Unknown Parent is 0, but the backend endpoint retrieval labels an unknown parent GID as <child GID>-F-Unknown or <child GID>-M-Unknown, which is needed for maintaining information of pedigree connections for constructing the pedigree tree.

To import a file with unknown parents, a GID or entry number of 0 must be used. Presently only both parents unknown or female parent known and male parent unknown are supported.

Unknown parents will be displayed as "Unknown" in the parent GID columns in the All Germplasm table and in the pedigree in Germplasm Details page.

Due to Breedbase limitations, parents with more than 10 progeny will cause the pedigree viewer to error (to be fixed in [BI-1579](https://breedinginsight.atlassian.net/browse/BI-1579).


# Dependencies
[bi-web/BI-1230](https://github.com/Breeding-Insight/bi-web/pull/260)

# Testing
see bi-web

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: [_\<please include a link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/3009574983)
