### PR TITLE
[BI-1574] Exp Block # not displayed

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -224,7 +224,7 @@ public class ExperimentObservation implements BrAPIImport {
         // Block number
         if( getExpBlockNo() != null ) {
             BrAPIObservationUnitLevelRelationship repLvl = new BrAPIObservationUnitLevelRelationship();
-            repLvl.setLevelName( BrAPIConstants.REPLICATE.getValue() );
+            repLvl.setLevelName( BrAPIConstants.BLOCK.getValue() );
             repLvl.setLevelCode(getExpBlockNo());
             levelRelationships.add(repLvl);
         }

--- a/src/main/java/org/breedinginsight/model/BrAPIConstants.java
+++ b/src/main/java/org/breedinginsight/model/BrAPIConstants.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum BrAPIConstants {
     SYSTEM_DEFAULT("System Default"),
     REPLICATE( "replicate"),
-    BLOCK( "bolck");
+    BLOCK( "block");
 
     private String value;
 


### PR DESCRIPTION
# Description
**Story:** [BI-1574](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1574)

A typo was fixed in the BrAPIConstants class.
A REPLICATE enum in the ExperimentObservation class was replaced where BLOCK was needed, instead.


# Dependencies
bi-web develop branch

# Testing
import an experiment and check that the "Exp Block #" column in the preview table is the same as in the excel file. 


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
