### PR TITLE
[BI-1478] - Add Pedigree to All Germplasm Table

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/model/request/query/GermplasmQuery.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/model/request/query/GermplasmQuery.java
@@ -17,6 +17,7 @@ public class GermplasmQuery extends BrapiQuery {
     private String defaultDisplayName;
     private String breedingMethod;
     private String seedSource;
+    private String pedigree;
     private String femaleParentGID;
     private String maleParentGID;
     private String createdDate;
@@ -36,6 +37,9 @@ public class GermplasmQuery extends BrapiQuery {
         }
         if (!StringUtils.isBlank(getSeedSource())) {
             filters.add(constructFilterRequest("seedSource", getSeedSource()));
+        }
+        if (!StringUtils.isBlank(getPedigree())) {
+            filters.add(constructFilterRequest("pedigree", getPedigree()));
         }
         if (!StringUtils.isBlank(getFemaleParentGID())) {
             filters.add(constructFilterRequest("femaleParentGID", getFemaleParentGID()));

--- a/src/main/java/org/breedinginsight/brapi/v2/model/response/mappers/GermplasmQueryMapper.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/model/response/mappers/GermplasmQueryMapper.java
@@ -17,10 +17,10 @@ import java.util.stream.Collectors;
 @Singleton
 public class GermplasmQueryMapper extends AbstractQueryMapper {
 
-    private String defaultSortField = "accessionNumber";
-    private SortOrder defaultSortOrder = SortOrder.ASC;
+    private final String defaultSortField = "accessionNumber";
+    private final SortOrder defaultSortOrder = SortOrder.ASC;
 
-    private Map<String, Function<BrAPIGermplasm, ?>> fields;
+    private final Map<String, Function<BrAPIGermplasm, ?>> fields;
 
     public GermplasmQueryMapper() {
         fields = Map.ofEntries(
@@ -31,6 +31,10 @@ public class GermplasmQueryMapper extends AbstractQueryMapper {
                                 germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD).getAsString() :
                                 null),
                 Map.entry("seedSource", BrAPIGermplasm::getSeedSource),
+                Map.entry("pedigree", (germplasm) ->
+                        germplasm.getAdditionalInfo() != null && germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_PEDIGREE_BY_NAME) ?
+                                germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_PEDIGREE_BY_NAME).getAsString() :
+                                null),
                 Map.entry("femaleParentGID", (germplasm) ->
                         germplasm.getAdditionalInfo() != null && germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID) ?
                                 germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID).getAsString() :


### PR DESCRIPTION
# Description
**Story:** [BI-1478 - Add Pedigree to All Germplasm Table](https://breedinginsight.atlassian.net/browse/BI-1478)

Backend logic to support All Germplasm table sorting by additionalInfo.pedigreeByName.

# Dependencies
[bi-web/feature/BI-1478](https://github.com/Breeding-Insight/bi-web/pull/271)

# Testing
see bi-web

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: [_\<please include a link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/3107562107)
