### PR TITLE
[BI-1580] BrAPIDAOUtils pagination only fetching first page of results

### DIFF
--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -53,12 +53,18 @@ public class BrAPIDAOUtil {
 
         try {
             List<V> listResult = new ArrayList<>();
-            searchBody.pageSize(pageSize);
+            //NOTE: Because of the way Breedbase implements BrAPI searches, the page size is initially set to an
+            //arbitrary, large value to ensure that in the event that a 202 response is returned, the searchDbId
+            //stored will refer to all records of the BrAPI variable.
+            searchBody.pageSize(10000000);
             ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>> response = searchMethod.apply(searchBody);
             if (response.getBody().getLeft().isPresent()) {
                 BrAPIResponse listResponse = (BrAPIResponse) response.getBody().getLeft().get();
                 listResult = getListResult(response);
 
+            /*  NOTE: may want to check for additional pages depending on whether BrAPI standard specifies how
+                pagination params are handled for POST search endpoints or the corresponding endpoints in Breedbase are
+                changed or updated
                 if(hasMorePages(listResponse)) {
                     int currentPage = listResponse.getMetadata().getPagination().getCurrentPage() + 1;
                     int totalPages = listResponse.getMetadata().getPagination().getTotalPages();
@@ -73,6 +79,7 @@ public class BrAPIDAOUtil {
                         currentPage++;
                     }
                 }
+            */
             } else {
                 // Hit the get endpoint until we get a response
                 Integer accruedWait = 0;

--- a/src/test/java/org/breedinginsight/daos/BrAPIDAOUtilUnitTest.java
+++ b/src/test/java/org/breedinginsight/daos/BrAPIDAOUtilUnitTest.java
@@ -1,0 +1,172 @@
+package org.breedinginsight.daos;
+
+import com.google.gson.JsonObject;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.tuple.Pair;
+import org.brapi.client.v2.ApiResponse;
+import org.brapi.v2.model.BrAPIAcceptedSearchResponse;
+import org.brapi.v2.model.BrAPIAcceptedSearchResponseResult;
+import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.germ.BrAPIGermplasm;
+import org.brapi.v2.model.germ.request.BrAPIGermplasmSearchRequest;
+import org.brapi.v2.model.germ.response.BrAPIGermplasmListResponse;
+import org.brapi.v2.model.germ.response.BrAPIGermplasmListResponseResult;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.utilities.BrAPIDAOUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import java.lang.reflect.Field;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class BrAPIDAOUtilUnitTest {
+    private String referenceSource;
+    private BrAPIDAOUtil brAPIDAOUtil;
+    private List<BrAPIGermplasm> germplasm;
+    private Program testProgram;
+    private HashMap<String, BrAPIGermplasm> germplasmMap;
+    private List<BrAPIGermplasm>  paginatedGermplasm;
+    private BrAPIGermplasmSearchRequest germplasmSearch;
+
+    public void fetchPaginatedGermplasm(int page, int pageSize) {
+        paginatedGermplasm = new ArrayList<>();
+        int pageStart = page * pageSize;
+        int pageEnd = pageStart + pageSize;
+        if (!(pageEnd  > germplasm.size())) {
+            for (int i = pageStart; i < pageEnd; i++) {
+                paginatedGermplasm.add(germplasm.get(i));
+            }
+        } else {
+            paginatedGermplasm = germplasm;
+        }
+    }
+
+    public ApiResponse<Pair<Optional<BrAPIGermplasmListResponse>, Optional<BrAPIAcceptedSearchResponse>>> getStubbedGermplasm(int page, int pageSize) {
+        fetchPaginatedGermplasm(page, pageSize);
+        BrAPIGermplasmListResponse searchPostResponse = new BrAPIGermplasmListResponse();
+        searchPostResponse.setResult(new BrAPIGermplasmListResponseResult().data(paginatedGermplasm));
+
+        Pair<Optional<BrAPIGermplasmListResponse>, Optional<BrAPIAcceptedSearchResponse>> searchPostResponsePair =
+                Pair.of(Optional.of(searchPostResponse), Optional.empty());
+        return new ApiResponse<Pair<Optional<BrAPIGermplasmListResponse>, Optional<BrAPIAcceptedSearchResponse>>>(200, new HashMap<>(), searchPostResponsePair);
+    }
+
+    @SneakyThrows
+    @BeforeEach
+    void setup() {
+        //Create instance of DAO
+        brAPIDAOUtil = new BrAPIDAOUtil();
+
+        //Set the page size field
+        Field pageSize = BrAPIDAOUtil.class.getDeclaredField("pageSize");
+        pageSize.setAccessible(true);
+        pageSize.set(brAPIDAOUtil, 1);
+
+        referenceSource = "breedinginsight.org";
+
+        //Create Program
+        testProgram = new Program();
+        testProgram.setName("Test Program");
+        testProgram.setKey("TEST");
+        testProgram.setId(UUID.randomUUID());
+        testProgram.setBrapiUrl("http://brapiserver:8083");
+
+        //Create Germplasm
+        List<String> shortNames = new ArrayList<String>();
+        shortNames.add("A");
+        shortNames.add("B");
+        shortNames.add("C");
+        shortNames.add("D");
+        shortNames.add("E");
+        shortNames.add("F");
+        shortNames.add("G");
+        shortNames.add("H");
+        shortNames.add("I");
+        shortNames.add("J");
+
+        germplasm = new ArrayList();
+        germplasmMap = new HashMap<>();
+
+        for (int i = 0; i < shortNames.size(); i++) {
+            String entry = String.valueOf(i + 2);
+            String nameIndex = String.valueOf(i+1);
+            BrAPIGermplasm testGermplasm = new BrAPIGermplasm();
+            testGermplasm.setGermplasmName(String.format("Germplasm %1$s [TEST-%2$s]",
+                    shortNames.get(i), nameIndex));
+            testGermplasm.setSeedSource("Wild");
+            testGermplasm.setAccessionNumber(nameIndex);
+            testGermplasm.setDefaultDisplayName(String.format("Germplasm %s", shortNames.get(i)));
+            if(!shortNames.get(i).equals("A")) {
+                testGermplasm.setPedigree("Germplasm A [TEST-1]");
+            }
+            JsonObject additionalInfo = new JsonObject();
+            additionalInfo.addProperty("importEntryNumber", entry);
+            additionalInfo.addProperty("breedingMethod", "Allopolyploid");
+            testGermplasm.setAdditionalInfo(additionalInfo);
+            List<BrAPIExternalReference> externalRef = new ArrayList<>();
+            BrAPIExternalReference testReference = new BrAPIExternalReference();
+            testReference.setReferenceSource(referenceSource);
+            testReference.setReferenceID(UUID.randomUUID().toString());
+            externalRef.add(testReference);
+            testGermplasm.setExternalReferences(externalRef);
+            germplasm.add(testGermplasm);
+            germplasmMap.put(testReference.getReferenceID(), testGermplasm);
+        }
+
+        // Set query params
+        germplasmSearch = new BrAPIGermplasmSearchRequest();
+        germplasmSearch.externalReferenceIDs(List.of(testProgram.getId().toString()));
+        germplasmSearch.externalReferenceSources(List.of(String.format("%s/programs", referenceSource)));
+    }
+
+    @Test
+    @SneakyThrows
+    public void searchGermplasmPost() {
+        // Set query params
+        germplasmSearch.setPage(0);
+
+        List<BrAPIGermplasm> searchResult = brAPIDAOUtil.search(
+                searchBody -> {
+                  return getStubbedGermplasm(searchBody.getPage(), searchBody.getPageSize());
+                },
+                (searchId, page, pageSize) -> {
+                    return null;
+                },
+                germplasmSearch
+        );
+
+        //Check if all requested germplasm are returned
+        for (BrAPIGermplasm germplasm : searchResult) {
+            assertTrue(germplasmMap.containsKey(germplasm.getExternalReferences().get(0).getReferenceID()));
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    public void searchGermplasmDbIdGet() {
+        List<BrAPIGermplasm> searchResult = brAPIDAOUtil.search(
+                searchBody -> {
+                    BrAPIAcceptedSearchResponse searchPostResponse = new BrAPIAcceptedSearchResponse();
+                    searchPostResponse.setResult(new BrAPIAcceptedSearchResponseResult().searchResultsDbId(UUID.randomUUID().toString()));
+
+                    Pair<Optional<BrAPIGermplasmListResponse>, Optional<BrAPIAcceptedSearchResponse>> searchPostResponsePair =
+                            Pair.of(Optional.empty(), Optional.of(searchPostResponse));
+                    return new ApiResponse<Pair<Optional<BrAPIGermplasmListResponse>, Optional<BrAPIAcceptedSearchResponse>>>(200, new HashMap<>(), searchPostResponsePair);
+
+                },
+                (searchId, page, pageSize) -> {
+                    return getStubbedGermplasm(page, pageSize);
+                },
+                germplasmSearch
+        );
+
+        //Check if all germplasm are returned
+        for (BrAPIGermplasm germplasm : searchResult) {
+            assertTrue(germplasmMap.containsKey(germplasm.getExternalReferences().get(0).getReferenceID()));
+        }
+    }
+}

--- a/src/test/java/org/breedinginsight/daos/BrAPIDAOUtilUnitTest.java
+++ b/src/test/java/org/breedinginsight/daos/BrAPIDAOUtilUnitTest.java
@@ -26,7 +26,6 @@ public class BrAPIDAOUtilUnitTest {
     private BrAPIDAOUtil brAPIDAOUtil;
     private List<BrAPIGermplasm> germplasm;
     private Program testProgram;
-    private HashMap<String, BrAPIGermplasm> germplasmMap;
     private List<BrAPIGermplasm>  paginatedGermplasm;
     private BrAPIGermplasmSearchRequest germplasmSearch;
 
@@ -35,7 +34,6 @@ public class BrAPIDAOUtilUnitTest {
         int pageStart = page * pageSize;
         int pageEnd = pageStart + pageSize;
         Integer totalPages = (int) Math.ceil(germplasm.size() / pageSize);
-        //(germplasm.size() - germplasm.size() % pageSize) / pageSize;
         if (!(pageEnd  > germplasm.size())) {
             for (int i = pageStart; i < pageEnd; i++) {
                 paginatedGermplasm.add(germplasm.get(i));
@@ -92,7 +90,6 @@ public class BrAPIDAOUtilUnitTest {
         shortNames.add("J");
 
         germplasm = new ArrayList();
-        germplasmMap = new HashMap<>();
 
         for (int i = 0; i < shortNames.size(); i++) {
             String entry = String.valueOf(i + 2);
@@ -117,7 +114,6 @@ public class BrAPIDAOUtilUnitTest {
             externalRef.add(testReference);
             testGermplasm.setExternalReferences(externalRef);
             germplasm.add(testGermplasm);
-            germplasmMap.put(testReference.getReferenceID(), testGermplasm);
         }
 
         // Set query params


### PR DESCRIPTION
# Description
**Story:** [BI-1580](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1580)
The page size used by bi-api when POSTing a search for a BrAPI variable was hard-coded to a value large enough to ensure that all records for the BrAPI variable would fit in a single page. This work-around ensures that when Breedbase returns a 202 response to the initial POST search the GET search will apply to all records of the BrAPI variable stored in Breedbase.

This change is a work-around until either Breedbase or the BrAPI spec is updated.

A unit test was created to test the search method using both the POST search callback and GET search callback.

# Dependencies
none

# Testing
run the unit test for BrAPIDAOUtil.search(),
src/test/java/org/breedinginsight/daos/BrAPIDAOUtilUnitTest.java,
and verify all tests pass

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
