### PR TITLE
[BI-1638] - Cache germplasm data immediately after saving to BrAPI

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -219,8 +219,12 @@ public class BrAPIGermplasmDAO {
 
     public List<BrAPIGermplasm> importBrAPIGermplasm(List<BrAPIGermplasm> brAPIGermplasmList, UUID programId, ImportUpload upload) throws ApiException {
         GermplasmApi api = new GermplasmApi(programDAO.getCoreClient(programId));
+        var program = programDAO.fetchOneById(programId);
         try {
-            Callable<List<BrAPIGermplasm>> postFunction = () -> brAPIDAOUtil.post(brAPIGermplasmList, upload, api::germplasmPost, importDAO::update);
+            Callable<Map<String, BrAPIGermplasm>> postFunction = () -> {
+                List<BrAPIGermplasm> postResponse = brAPIDAOUtil.post(brAPIGermplasmList, upload, api::germplasmPost, importDAO::update);
+                return processGermplasmForDisplay(postResponse, program.getKey());
+            };
             return programGermplasmCache.post(programId, postFunction);
         } catch (ApiException e) {
             throw e;

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/ProgramCache.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/ProgramCache.java
@@ -129,9 +129,17 @@ public class ProgramCache<K, R> {
         }
     }
 
-    public List<R> post(UUID programId, Callable<List<R>> postMethod) throws Exception {
-        List<R> response = postMethod.call();
+    public List<R> post(UUID programId, Callable<Map<K, R>> postMethod) throws Exception {
+        Map<K, R> response = postMethod.call();
+
+        Map<K, R> map = cache.getIfPresent(programId);
+        if(map != null) {
+            map.putAll(response);
+        } else {
+            cache.put(programId, response);
+        }
+
         updateCache(programId);
-        return response;
+        return new ArrayList<>(response.values());
     }
 }

--- a/src/test/java/org/breedinginsight/brapi/v2/ProgramCacheUnitTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/ProgramCacheUnitTest.java
@@ -20,6 +20,7 @@ import org.mockito.stubbing.Answer;
 import javax.inject.Inject;
 import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -36,7 +37,7 @@ public class ProgramCacheUnitTest {
     // POSTing refresh tracking separate for each program
     // Cache refresh failure invalidates cache
 
-    Integer fetchCount = 0;
+    AtomicInteger fetchCount = new AtomicInteger(0);
     Integer waitTime = 1000;
     Map<UUID, List<BrAPIGermplasm>> mockBrAPI = new HashMap<>();
 
@@ -53,26 +54,28 @@ public class ProgramCacheUnitTest {
     void setupNextTest() {
         // There is some thread sleeping used in this testing, wait for all processes to clean out between tests
         Thread.sleep(5000);
-        fetchCount = 0;
+        fetchCount.set(0);
         mockBrAPI = new HashMap<>();
     }
 
     @SneakyThrows
     public Map<String, BrAPIGermplasm> mockFetch(UUID programId, Integer sleepTime) {
-        fetchCount += 1;
+        fetchCount.incrementAndGet();
         Thread.sleep(sleepTime);
         return mockBrAPI.containsKey(programId) ? new HashMap<>(mockBrAPI.get(programId).stream().collect(Collectors.toMap(germplasm -> UUID.randomUUID().toString(), germplasm -> germplasm))) : new HashMap<>();
     }
 
     @SneakyThrows
-    public List<BrAPIGermplasm> mockPost(UUID programId, List<BrAPIGermplasm> germplasm) {
+    public Map<String, BrAPIGermplasm> mockPost(UUID programId, List<BrAPIGermplasm> germplasm) {
         if (!mockBrAPI.containsKey(programId)) {
             mockBrAPI.put(programId, germplasm);
         } else {
             List<BrAPIGermplasm> allGermplasm = mockBrAPI.get(programId);
             allGermplasm.addAll(germplasm);
         }
-        return germplasm;
+        Map<String, BrAPIGermplasm> germMap = new HashMap<>();
+        germplasm.forEach(brAPIGermplasm -> germMap.put(brAPIGermplasm.getGermplasmDbId(), brAPIGermplasm));
+        return germMap;
     }
 
     @Test
@@ -85,11 +88,11 @@ public class ProgramCacheUnitTest {
         int currPost = 0;
         while (currPost < numPost) {
             List<BrAPIGermplasm> newList = new ArrayList<>();
-            newList.add(new BrAPIGermplasm());
+            newList.add(new BrAPIGermplasm().germplasmDbId(UUID.randomUUID().toString()));
             cache.post(programId, () -> mockPost(programId, new ArrayList<>(newList)));
             currPost += 1;
         }
-        assertTrue(fetchCount < numPost, "A fetch call was made for every post. It shouldn't.");
+        assertTrue(fetchCount.get() < numPost, "A fetch call was made for every post. It shouldn't.");
         assertEquals(1, mockBrAPI.size(), "More than one program existed in mocked brapi db.");
         assertEquals(numPost, mockBrAPI.get(programId).size(), "Wrong number of germplasm in db");
         Map<String, BrAPIGermplasm> cachedGermplasm = cache.get(programId);
@@ -106,13 +109,12 @@ public class ProgramCacheUnitTest {
         while (currPost < numPost) {
             UUID id = UUID.randomUUID();
             List<BrAPIGermplasm> newList = new ArrayList<>();
-            newList.add(new BrAPIGermplasm());
+            newList.add(new BrAPIGermplasm().germplasmDbId(UUID.randomUUID().toString()));
             cache.post(id, () -> mockPost(id, new ArrayList<>(newList)));
-            // This doesn't have to do with our code, our mock function is just tripping over itself trying to update the number of fetches
-            Thread.sleep(waitTime/5);
             currPost += 1;
         }
-        assertEquals(numPost, fetchCount, "A fetch call should have been made for every post");
+        Thread.sleep(waitTime);
+        assertEquals(numPost, fetchCount.get(), "A fetch call should have been made for every post");
         assertEquals(numPost, mockBrAPI.size(), "Less programs existed than existed in mock brapi db.");
         for (UUID key: mockBrAPI.keySet()) {
             assertEquals(1, mockBrAPI.get(key).size(), "Wrong number of germplasm in db");
@@ -128,19 +130,19 @@ public class ProgramCacheUnitTest {
         ProgramCache<String, BrAPIGermplasm> cache = new ProgramCache<>((UUID id) -> mockFetch(id, waitTime), List.of(programId));
         cache.get(programId);
         // Our fetch method should have only been called once for the initial loading
-        assertEquals(1, fetchCount, "Fetch method was called on get");
+        assertEquals(1, fetchCount.get(), "Fetch method was called on get");
     }
 
     @Test
     @SneakyThrows
-    public void getMethodDoesNotWaitForRefresh() {
+    public void postTriggersRefresh() {
         // Test that the get method does not wait for a refresh when there is data present
         UUID programId = UUID.randomUUID();
         List<BrAPIGermplasm> newList = new ArrayList<>();
-        newList.add(new BrAPIGermplasm());
+        newList.add(new BrAPIGermplasm().germplasmDbId(UUID.randomUUID().toString()));
         mockBrAPI.put(programId, new ArrayList<>(newList));
         ProgramCache<String, BrAPIGermplasm> cache = new ProgramCache<>((UUID id) -> mockFetch(id, waitTime*2), List.of(programId));
-        Callable<List<BrAPIGermplasm>> postFunction = () -> mockPost(programId, new ArrayList<>(newList));
+        Callable<Map<String, BrAPIGermplasm>> postFunction = () -> mockPost(programId, new ArrayList<>(newList));
 
         // Get waits for initial fetch
         Map<String, BrAPIGermplasm> cachedGermplasm = cache.get(programId);
@@ -149,7 +151,7 @@ public class ProgramCacheUnitTest {
         // Now post another object and call get immediately to see that it returns the old data
         cache.post(programId, postFunction);
         cachedGermplasm = cache.get(programId);
-        assertEquals(1, cachedGermplasm.size(), "Get method seemed to have waited for refresh method");
+        assertEquals(2, cachedGermplasm.size(), "Get post method didn't insert the new data");
 
         // Now wait for the fetch after the post to finish
         Thread.sleep(waitTime*3);
@@ -167,7 +169,7 @@ public class ProgramCacheUnitTest {
         // Set starter data
         UUID programId = UUID.randomUUID();
         List<BrAPIGermplasm> newList = new ArrayList<>();
-        newList.add(new BrAPIGermplasm());
+        newList.add(new BrAPIGermplasm().germplasmDbId(UUID.randomUUID().toString()));
         mockBrAPI.put(programId, new ArrayList<>(newList));
 
         // Mock our method


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1638

Updated the `post` method in `ProgramCache` to add records to the cache before calling the `updateCache` method.  This will allows the cache to have the records that were just saved, while the new data to refresh the cache with is pulled in the background.

# Dependencies
bi-web: release/0.7

# Testing
1. Upload a germplasm file (preferably a larger file so that refreshing the cache takes a few minutes)
2. After the upload is complete, immediatly navigate to the All Germplasm table, and verify that the new records are there
3. Switch to the Germplasm List tab, and verify the new list is there, and that the page loads without error


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
