### PR TITLE
[BI-1147] ﻿﻿2.0 Experimental Data Preview Universal Elements

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -29,9 +29,12 @@ import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.model.BrAPIConstants;
 import org.breedinginsight.model.Program;
+import org.breedinginsight.model.User;
 import org.breedinginsight.utilities.Utilities;
 
 import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.Supplier;
 
@@ -110,14 +113,11 @@ public class ExperimentObservation implements BrAPIImport {
     @ImportFieldMetadata(id="obsUnitID", name="Observation Unit ID", description = "A database generated unique identifier for experimental observation units")
     private String obsUnitID;
 
-    public BrAPITrial constructBrAPITrial(Program program, boolean commit, String referenceSource, UUID id, String expSeqValue) {
+    public BrAPITrial constructBrAPITrial(Program program, User user, boolean commit, String referenceSource, UUID id, String expSeqValue) {
         BrAPIProgram brapiProgram = program.getBrapiProgram();
         BrAPITrial trial = new BrAPITrial();
-        if( commit ){
-            trial.setTrialName( Utilities.appendProgramKey(getExpTitle(), program.getKey() ));
-
-            // Set external reference
-            trial.setExternalReferences(getTrialExternalReferences(program, referenceSource, id));
+        if (commit) {
+            setBrAPITrialCommitFields(program, trial, referenceSource, id);
         }
         else{
             trial.setTrialName( getExpTitle() );
@@ -127,11 +127,28 @@ public class ExperimentObservation implements BrAPIImport {
         trial.setProgramDbId(brapiProgram.getProgramDbId());
         trial.setProgramName(brapiProgram.getProgramName());
 
+        Map<String, String> createdBy = new HashMap<>();
+        createdBy.put(BrAPIAdditionalInfoFields.CREATED_BY_USER_ID, user.getId().toString());
+        createdBy.put(BrAPIAdditionalInfoFields.CREATED_BY_USER_NAME, user.getName());
+        trial.putAdditionalInfoItem(BrAPIAdditionalInfoFields.CREATED_BY, createdBy);
         trial.putAdditionalInfoItem( BrAPIAdditionalInfoFields.DEFAULT_OBSERVATION_LEVEL, getExpUnit());
         trial.putAdditionalInfoItem( BrAPIAdditionalInfoFields.EXPERIMENT_TYPE, getExpType());
         trial.putAdditionalInfoItem( BrAPIAdditionalInfoFields.EXPERIMENT_NUMBER, expSeqValue);
 
         return trial;
+    }
+
+    private void setBrAPITrialCommitFields(Program program, BrAPITrial trial, String referenceSource, UUID id) {
+        trial.setTrialName( Utilities.appendProgramKey(getExpTitle(), program.getKey() ));
+
+        // Set external reference
+        trial.setExternalReferences(getTrialExternalReferences(program, referenceSource, id));
+
+        // Set createdDate field
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
+        LocalDateTime now = LocalDateTime.now();
+        trial.putAdditionalInfoItem(BrAPIAdditionalInfoFields.CREATED_DATE, formatter.format(now));
+
     }
 
     public BrAPILocation constructBrAPILocation() {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -153,7 +153,7 @@ public class ExperimentProcessor implements Processor {
         ValidationErrors validationErrors = new ValidationErrors();
 
         // add "New" pending data to the BrapiData objects
-        getNewBrapiData(importRows, program, commit);
+        getNewBrapiData(importRows, program, user, commit);
 
         // For each import row
         for (int i = 0; i < importRows.size(); i++) {
@@ -191,7 +191,7 @@ public class ExperimentProcessor implements Processor {
         return getStatisticsMap(importRows);
     }
 
-    private void getNewBrapiData(List<BrAPIImport> importRows, Program program, boolean commit) {
+    private void getNewBrapiData(List<BrAPIImport> importRows, Program program, User user, boolean commit) {
 
         String expSequenceName = program.getExpSequence();
         if (expSequenceName == null) {
@@ -210,7 +210,7 @@ public class ExperimentProcessor implements Processor {
         for (BrAPIImport row : importRows) {
             ExperimentObservation importRow = (ExperimentObservation) row;
 
-            PendingImportObject<BrAPITrial> trialPIO = createTrialPIO(program, commit, importRow, expNextVal);
+            PendingImportObject<BrAPITrial> trialPIO = createTrialPIO(program, user, commit, importRow, expNextVal);
             this.trialByNameNoScope.put(importRow.getExpTitle(), trialPIO);
 
             String expSeqValue = null;
@@ -442,7 +442,7 @@ public class ExperimentProcessor implements Processor {
         return pio;
     }
 
-    private PendingImportObject<BrAPITrial> createTrialPIO(Program program, boolean commit, ExperimentObservation importRow, Supplier<BigInteger> expNextVal) {
+    private PendingImportObject<BrAPITrial> createTrialPIO(Program program, User user, boolean commit, ExperimentObservation importRow, Supplier<BigInteger> expNextVal) {
         PendingImportObject<BrAPITrial> pio = null;
         if( trialByNameNoScope.containsKey( importRow.getExpTitle()) ) {
             pio = trialByNameNoScope.get( importRow.getExpTitle() ) ;
@@ -453,7 +453,7 @@ public class ExperimentProcessor implements Processor {
             if(commit){
                 expSeqValue = expNextVal.get().toString();
             }
-            BrAPITrial newTrial = importRow.constructBrAPITrial(program, commit, BRAPI_REFERENCE_SOURCE, id, expSeqValue);
+            BrAPITrial newTrial = importRow.constructBrAPITrial(program, user, commit, BRAPI_REFERENCE_SOURCE, id, expSeqValue);
             pio = new PendingImportObject<>(ImportObjectState.NEW, newTrial, id);
         }
         return pio;


### PR DESCRIPTION
# Description
**Story:** [BI-1147](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1147)

The ExperimentProcessor was changed to pass user information when committing a new trial brapi object to the database and the ExperimentObservation model was updated to write createdBy and createdDate into additionalInfo.

# Dependencies
bi-web BI-1147 branch

# Testing
import an experiment and re-import experiment with different environments. Verify the preview reponse from the bi-api server contains a trial brapi object that has a createdBy object and createdDate field assigned to additinalInfo.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
