### PR TITLE
[BI-1129] View Germplasm List

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -32,6 +32,7 @@ import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapi.v2.model.request.query.GermplasmQuery;
 import org.breedinginsight.brapi.v2.model.response.mappers.GermplasmQueryMapper;
 import org.breedinginsight.brapi.v2.services.BrAPIGermplasmService;
+import org.breedinginsight.brapps.importer.model.base.Germplasm;
 import org.breedinginsight.brapps.importer.model.exports.FileType;
 import org.breedinginsight.daos.ProgramDAO;
 import org.breedinginsight.model.DownloadFile;
@@ -99,6 +100,22 @@ public class GermplasmController {
         } catch (ApiException e) {
             log.info(e.getMessage(), e);
             return HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, "Error retrieving germplasm");
+        }
+    }
+
+    @Get("/${micronaut.bi.api.version/programs/{programId}/germplasm/lists/{listDbId}/records{?queryParams*}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
+    public HttpResponse<Response<DataResponse<List<BrAPIGermplasm>>>> getGermplasmListRecords(
+        @PathVariable("programId") UUID programId,
+        @PathVariable("listDbId") String listId){
+        try {
+            List<Germplasm> dummyData = new ArrayList<>();
+            dummyData.add(new Germplasm());
+            return ResponseUtils.getQueryResponse(dummyData, );
+        } catch (ApiException e) {
+            log.info(e.getMessage(), e);
+            return HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, "Error retrieving germplasm list records");
         }
     }
 

--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -111,10 +111,9 @@ public class GermplasmController {
         @PathVariable("listDbId") String listId,
         @QueryValue @QueryValid(using = GermplasmQueryMapper.class) @Valid GermplasmQuery queryParams) {
         try {
-            List<BrAPIGermplasm> dummyData = new ArrayList<>();
-            dummyData.add(new BrAPIGermplasm());
+            List<BrAPIGermplasm> germplasm = germplasmService.getGermplasmByList(programId, listId);
             SearchRequest searchRequest = queryParams.constructSearchRequest();
-            return ResponseUtils.getBrapiQueryResponse(dummyData, germplasmQueryMapper, queryParams, searchRequest);
+            return ResponseUtils.getBrapiQueryResponse(germplasm, germplasmQueryMapper, queryParams, searchRequest);
         } catch (Exception e) {
             log.info(e.getMessage(), e);
             return HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, "Error retrieving germplasm list records");

--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -108,11 +108,13 @@ public class GermplasmController {
     @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
     public HttpResponse<Response<DataResponse<List<BrAPIGermplasm>>>> getGermplasmListRecords(
         @PathVariable("programId") UUID programId,
-        @PathVariable("listDbId") String listId){
+        @PathVariable("listDbId") String listId)
+        @QueryValue @QueryValid(using = GermplasmQueryMapper.class) @Valid GermplasmQuery queryParams) {
         try {
             List<Germplasm> dummyData = new ArrayList<>();
             dummyData.add(new Germplasm());
-            return ResponseUtils.getQueryResponse(dummyData, );
+            SearchRequest searchRequest = queryParams.constructSearchRequest();
+            return ResponseUtils.getQueryResponse(dummyData, germplasmQueryMapper, queryParams, searchRequest );
         } catch (ApiException e) {
             log.info(e.getMessage(), e);
             return HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, "Error retrieving germplasm list records");

--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -103,19 +103,19 @@ public class GermplasmController {
         }
     }
 
-    @Get("/${micronaut.bi.api.version/programs/{programId}/germplasm/lists/{listDbId}/records{?queryParams*}")
+    @Get("/${micronaut.bi.api.version}/programs/{programId}/germplasm/lists/{listDbId}/records{?queryParams*}")
     @Produces(MediaType.APPLICATION_JSON)
     @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
     public HttpResponse<Response<DataResponse<List<BrAPIGermplasm>>>> getGermplasmListRecords(
         @PathVariable("programId") UUID programId,
-        @PathVariable("listDbId") String listId)
+        @PathVariable("listDbId") String listId,
         @QueryValue @QueryValid(using = GermplasmQueryMapper.class) @Valid GermplasmQuery queryParams) {
         try {
-            List<Germplasm> dummyData = new ArrayList<>();
-            dummyData.add(new Germplasm());
+            List<BrAPIGermplasm> dummyData = new ArrayList<>();
+            dummyData.add(new BrAPIGermplasm());
             SearchRequest searchRequest = queryParams.constructSearchRequest();
-            return ResponseUtils.getQueryResponse(dummyData, germplasmQueryMapper, queryParams, searchRequest );
-        } catch (ApiException e) {
+            return ResponseUtils.getBrapiQueryResponse(dummyData, germplasmQueryMapper, queryParams, searchRequest);
+        } catch (Exception e) {
             log.info(e.getMessage(), e);
             return HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, "Error retrieving germplasm list records");
         }

--- a/src/main/java/org/breedinginsight/brapi/v2/model/request/query/GermplasmQuery.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/model/request/query/GermplasmQuery.java
@@ -13,6 +13,7 @@ import java.util.List;
 @Getter
 @Introspected
 public class GermplasmQuery extends BrapiQuery {
+    private String importEntryNumber;
     private String accessionNumber;
     private String defaultDisplayName;
     private String breedingMethod;
@@ -26,6 +27,9 @@ public class GermplasmQuery extends BrapiQuery {
 
     public SearchRequest constructSearchRequest() {
         List<FilterRequest> filters = new ArrayList<>();
+        if (!StringUtils.isBlank(getImportEntryNumber())) {
+            filters.add(constructFilterRequest("importEntryNumber", getImportEntryNumber()));
+        }
         if (!StringUtils.isBlank(getAccessionNumber())) {
             filters.add(constructFilterRequest("accessionNumber", getAccessionNumber()));
         }

--- a/src/main/java/org/breedinginsight/brapi/v2/model/response/mappers/GermplasmQueryMapper.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/model/response/mappers/GermplasmQueryMapper.java
@@ -24,6 +24,10 @@ public class GermplasmQueryMapper extends AbstractQueryMapper {
 
     public GermplasmQueryMapper() {
         fields = Map.ofEntries(
+                Map.entry("importEntryNumber", (germplasm) ->
+                        germplasm.getAdditionalInfo() != null && germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER) ?
+                        germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsString() :
+                        null),
                 Map.entry("accessionNumber", BrAPIGermplasm::getAccessionNumber),
                 Map.entry("defaultDisplayName", BrAPIGermplasm::getDefaultDisplayName),
                 Map.entry("breedingMethod", (germplasm) ->

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -155,9 +155,8 @@ public class BrAPIGermplasmService {
     public List<BrAPIGermplasm> getGermplasmByList(UUID programId, String listId) throws ApiException {
         // get list germplasm names
         BrAPIListsSingleResponse listResponse = brAPIListDAO.getListById(listId, programId);
-        if(Objects.nonNull(listResponse)) {
-            BrAPIListDetails listData = listResponse.getResult();
-            List<String> germplasmNames = listData.getData();
+        if(Objects.nonNull(listResponse) && Objects.nonNull(listResponse.getResult())) {
+            List<String> germplasmNames = listResponse.getResult().getData();
 
             // get list BrAPI germplasm variables
             return germplasmDAO.getGermplasmByRawName(germplasmNames, programId);

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -151,6 +151,14 @@ public class BrAPIGermplasmService {
         return processedData;
     }
 
+    public List<BrAPIGermplasm> getGermplasmByList(UUID programId, String listId) throws ApiException {
+        // get list germplasm names
+        BrAPIListDetails listData = brAPIListDAO.getListById(listId, programId).getResult();
+        List<String> germplasmNames = listData.getData();
+
+        // get list BrAPI germplasm variables
+        return germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
+    }
     public DownloadFile exportGermplasmList(UUID programId, String listId, FileType fileExtension) throws ApiException, IOException {
         List<Column> columns = GermplasmFileColumns.getOrderedColumns();
 

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -11,6 +11,7 @@ import org.brapi.v2.model.core.BrAPIListSummary;
 import org.brapi.v2.model.core.BrAPIListTypes;
 import org.brapi.v2.model.core.response.BrAPIListDetails;
 import org.brapi.v2.model.core.response.BrAPIListsListResponse;
+import org.brapi.v2.model.core.response.BrAPIListsSingleResponse;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.germ.BrAPIGermplasmSynonyms;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
@@ -153,11 +154,14 @@ public class BrAPIGermplasmService {
 
     public List<BrAPIGermplasm> getGermplasmByList(UUID programId, String listId) throws ApiException {
         // get list germplasm names
-        BrAPIListDetails listData = brAPIListDAO.getListById(listId, programId).getResult();
-        List<String> germplasmNames = listData.getData();
+        BrAPIListsSingleResponse listResponse = brAPIListDAO.getListById(listId, programId);
+        if(Objects.nonNull(listResponse)) {
+            BrAPIListDetails listData = listResponse.getResult();
+            List<String> germplasmNames = listData.getData();
 
-        // get list BrAPI germplasm variables
-        return germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
+            // get list BrAPI germplasm variables
+            return germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
+        } else throw new ApiException();
     }
     public DownloadFile exportGermplasmList(UUID programId, String listId, FileType fileExtension) throws ApiException, IOException {
         List<Column> columns = GermplasmFileColumns.getOrderedColumns();


### PR DESCRIPTION
# Description
**Story:** [BI-1129](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1129)

- a GET endpoint was added to `brapi/v2/GermplasmController.java` with the signature `programs/<program-ID>/germplasm/lists/<list-ID>/records`
- `/brapi/v2/services/BrAPIGermplasmService.getGermplasmByList()` created to fetch germplasm records in a list

# Dependencies
none

# Testing
Send a GET request `/v1/programs/<program-id>/germplasm/lists/<list-id>/records?sortField=importEntryNumber&sortOrder=ASC&page=0&pageSize=50`
and verify the response contains all germplasm records stored for the given program and list ID.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
