### PR TITLE
[BI-1630] - De-activated programs still visible on Shared Ontology

### DIFF
--- a/src/main/java/org/breedinginsight/services/OntologyService.java
+++ b/src/main/java/org/breedinginsight/services/OntologyService.java
@@ -85,7 +85,7 @@ public class OntologyService {
     }
 
     private List<Program> getMatchingPrograms(Program program) {
-        List<Program> allPrograms = programDAO.getAll();
+        List<Program> allPrograms = programDAO.getActive();
         List<Program> matchingPrograms = new ArrayList<>();
         for (Program candidate: allPrograms) {
 


### PR DESCRIPTION
# Description
**Story:** [BI-1630 - De-activated programs still visible on Shared Ontology](https://breedinginsight.atlassian.net/browse/BI-1630)

Change a getAll to getActive call in order to retrieve only active programs for sharing ontology.

# Dependencies
bi-web/develop

# Testing
Create programs of the same species and storage
Deactivate one program
Check that only active programs show when clicking Share Ontology under Program Management > Configuration

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
