### PR TITLE
[BI-1606] Allow germplasm records to be in multiple lists

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -106,10 +106,10 @@ public class GermplasmController {
     @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
     public HttpResponse<Response<DataResponse<List<BrAPIGermplasm>>>> getGermplasmListRecords(
         @PathVariable("programId") UUID programId,
-        @PathVariable("listDbId") String listId,
+        @PathVariable("listDbId") String listDbId,
         @QueryValue @QueryValid(using = GermplasmQueryMapper.class) @Valid GermplasmQuery queryParams) {
         try {
-            List<BrAPIGermplasm> germplasm = germplasmService.getGermplasmByList(programId, listId);
+            List<BrAPIGermplasm> germplasm = germplasmService.getGermplasmByList(programId, listDbId);
             SearchRequest searchRequest = queryParams.constructSearchRequest();
             return ResponseUtils.getBrapiQueryResponse(germplasm, germplasmQueryMapper, queryParams, searchRequest);
         } catch (Exception e) {

--- a/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
@@ -19,6 +19,7 @@ package org.breedinginsight.brapi.v2.constants;
 
 public final class BrAPIAdditionalInfoFields {
     public static final String GERMPLASM_LIST_ENTRY_NUMBERS = "listEntryNumbers";
+    public static final String GERMPLASM_LIST_ID = "listId";
     public static final String GERMPLASM_RAW_PEDIGREE = "rawPedigree";
     public static final String GERMPLASM_PEDIGREE_BY_NAME = "pedigreeByName";
     public static final String GERMPLASM_PEDIGREE_BY_UUID = "pedigreeByUUID";

--- a/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
@@ -18,6 +18,7 @@
 package org.breedinginsight.brapi.v2.constants;
 
 public final class BrAPIAdditionalInfoFields {
+    public static final String GERMPLASM_LIST_ENTRY_NUMBERS = "listEntryNumbers";
     public static final String GERMPLASM_RAW_PEDIGREE = "rawPedigree";
     public static final String GERMPLASM_PEDIGREE_BY_NAME = "pedigreeByName";
     public static final String GERMPLASM_PEDIGREE_BY_UUID = "pedigreeByUUID";

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -186,10 +186,7 @@ public class BrAPIGermplasmService {
         List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
 
         //processGermplasmForDisplay, numbers
-        UUID germplasmListId = new UUID(0,0);
-        if(hasListExternalReference(listData)) {
-            germplasmListId = getGermplasmListId(listData);
-        }
+        UUID germplasmListId = getGermplasmListId(listData);
         germplasm.sort(Comparator.comparingInt(getEntryNumber(germplasmListId)));
 
         String listName = listData.getListName();

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -175,7 +175,7 @@ public class BrAPIGermplasmService {
             return germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
         } else throw new ApiException();
     }
-    public DownloadFile exportGermplasmList(UUID programId, String listId, FileType fileExtension) throws ApiException, IOException {
+    public DownloadFile exportGermplasmList(UUID programId, String listId, FileType fileExtension) throws IllegalArgumentException, ApiException, IOException {
         List<Column> columns = GermplasmFileColumns.getOrderedColumns();
 
         //Retrieve germplasm list data
@@ -239,33 +239,29 @@ public class BrAPIGermplasmService {
                 .anyMatch(e -> referenceSource.concat("/lists").equals(e.getReferenceSource()));
     }
 
-    private ToIntFunction<BrAPIGermplasm> getEntryNumber(UUID germplasmListId) {
-        try {
-            if(germplasmListId.compareTo(new UUID(0,0)) == 0) {
-                return this::getImportEntryNumber;
-            } else {
-                return g -> getGermplasmListEntryNumber(g, germplasmListId);
-            }
-        } catch(RuntimeException e) {
-            throw e;
+    private ToIntFunction<BrAPIGermplasm> getEntryNumber(UUID germplasmListId) throws IllegalArgumentException {
+        if(germplasmListId.compareTo(new UUID(0,0)) == 0) {
+            return this::getImportEntryNumber;
+        } else {
+            return g -> getGermplasmListEntryNumber(g, germplasmListId);
         }
     }
 
-    private Integer getImportEntryNumber(BrAPIGermplasm g) throws RuntimeException {
+    private Integer getImportEntryNumber(BrAPIGermplasm g) throws IllegalArgumentException {
         if(Objects.nonNull(g.getAdditionalInfo()) &&
                 g.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER)) {
             return g.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsInt();
         } else {
-            throw new RuntimeException();
+            throw new IllegalArgumentException();
         }
     }
-    private Integer getGermplasmListEntryNumber(BrAPIGermplasm g, UUID germplasmListId) throws RuntimeException {
+    private Integer getGermplasmListEntryNumber(BrAPIGermplasm g, UUID germplasmListId) throws IllegalArgumentException {
         if(Objects.nonNull(g.getAdditionalInfo()) &&
                 g.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS)) {
             return g.getAdditionalInfo().getAsJsonObject(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS)
                 .get(germplasmListId.toString()).getAsInt();
         } else {
-            throw new RuntimeException();
+            throw new IllegalArgumentException();
         }
     }
 

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -120,7 +120,7 @@ public class BrAPIGermplasmService {
             row.put("GID", Integer.valueOf(germplasmEntry.getAccessionNumber()));
             row.put("Name", germplasmEntry.getGermplasmName());
             row.put("Entry No", germplasmEntry.getAdditionalInfo()
-                    .getAsJsonObject(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS).get(listName).getAsString());
+                    .getAsJsonObject(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS).get(listName).getAsInt());
             row.put("Breeding Method", germplasmEntry.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD).getAsString());
             String source = germplasmEntry.getSeedSource();
             row.put("Source", source);
@@ -176,8 +176,11 @@ public class BrAPIGermplasmService {
         //Retrieve germplasm data
         List<String> germplasmNames = listData.getData();
         List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
+
         //processGermplasmForDisplay, numbers
-        germplasm.sort(Comparator.comparingInt(g -> g.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsInt()));
+        germplasm.sort(Comparator.comparingInt(g ->
+                g.getAdditionalInfo().getAsJsonObject(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS).get(listData.getListName()).getAsInt()));
+
 
         String listName = listData.getListName();
         Optional<Program> optionalProgram = programService.getById(programId);

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -166,14 +166,21 @@ public class BrAPIGermplasmService {
         return processedData;
     }
 
-    public List<BrAPIGermplasm> getGermplasmByList(UUID programId, String listId) throws ApiException {
+    public List<BrAPIGermplasm> getGermplasmByList(UUID programId, String listDbId) throws ApiException {
         // get list germplasm names
-        BrAPIListsSingleResponse listResponse = brAPIListDAO.getListById(listId, programId);
+        BrAPIListsSingleResponse listResponse = brAPIListDAO.getListById(listDbId, programId);
         if(Objects.nonNull(listResponse) && Objects.nonNull(listResponse.getResult())) {
-            List<String> germplasmNames = listResponse.getResult().getData();
+
+            // get the list ID stored in the list external references
+            UUID listId = getGermplasmListId(listResponse.getResult());
 
             // get list BrAPI germplasm variables
-            return germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
+            List<String> germplasmNames = listResponse.getResult().getData();
+            List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
+
+            // set the list ID in the germplasm additional info
+             germplasm.forEach(g -> g.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ID, listId));
+            return germplasm;
         } else throw new ApiException();
     }
     public DownloadFile exportGermplasmList(UUID programId, String listId, FileType fileExtension) throws IllegalArgumentException, ApiException, IOException {

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -11,13 +11,10 @@ import org.brapi.v2.model.core.BrAPIListSummary;
 import org.brapi.v2.model.core.BrAPIListTypes;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.core.response.BrAPIListDetails;
-import org.brapi.v2.model.core.response.BrAPIListsListResponse;
 import org.brapi.v2.model.core.response.BrAPIListsSingleResponse;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
-import org.brapi.v2.model.germ.BrAPIGermplasmSynonyms;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapps.importer.daos.BrAPIListDAO;
-import org.breedinginsight.brapps.importer.model.base.ExternalReference;
 import org.breedinginsight.brapps.importer.model.exports.FileType;
 import org.breedinginsight.model.Column;
 import org.breedinginsight.model.DownloadFile;
@@ -115,7 +112,7 @@ public class BrAPIGermplasmService {
         }
     }
 
-    public List<Map<String, Object>> processData(List<BrAPIGermplasm> germplasm, UUID germplasmListId){
+    public List<Map<String, Object>> processListData(List<BrAPIGermplasm> germplasm, UUID germplasmListId){
         List<Map<String, Object>> processedData =  new ArrayList<>();
 
         for (BrAPIGermplasm germplasmEntry: germplasm) {
@@ -127,7 +124,7 @@ public class BrAPIGermplasmService {
             row.put("Source", source);
 
             // Use the entry number in the list map if generated
-            if(germplasmListId.compareTo(new UUID(0,0)) == 0) {
+            if(new UUID(0,0).compareTo(germplasmListId) == 0) {
                 row.put("Entry No", germplasmEntry.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsInt());
             } else {
                 row.put("Entry No", germplasmEntry.getAdditionalInfo()
@@ -206,7 +203,7 @@ public class BrAPIGermplasmService {
         String fileName = createFileName(listData, listName);
         StreamedFile downloadFile;
         //Convert list data to List<Map<String, Object>> data to pass into file writer
-        List<Map<String, Object>> processedData =  processData(germplasm, germplasmListId);
+        List<Map<String, Object>> processedData =  processListData(germplasm, germplasmListId);
 
         if (fileExtension == FileType.CSV){
             downloadFile = CSVWriter.writeToDownload(columns, processedData, fileExtension);

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -17,6 +17,7 @@ import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.germ.BrAPIGermplasmSynonyms;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapps.importer.daos.BrAPIListDAO;
+import org.breedinginsight.brapps.importer.model.base.ExternalReference;
 import org.breedinginsight.brapps.importer.model.exports.FileType;
 import org.breedinginsight.model.Column;
 import org.breedinginsight.model.DownloadFile;
@@ -210,7 +211,7 @@ public class BrAPIGermplasmService {
     }
 
     public UUID getGermplasmListId(BrAPIListDetails listData) {
-        if(Objects.nonNull(listData.getExternalReferences()) && hasListExternalReference(listData)) {
+        if(Objects.nonNull(listData.getExternalReferences()) && hasListExternalReference(listData.getExternalReferences())) {
             return UUID.fromString(listData.getExternalReferences().stream()
                     .filter(e -> referenceSource.concat("/lists").equals(e.getReferenceSource()))
                     .map(e -> e.getReferenceID()).findAny().orElse("00000000-0000-0000-000000000000"));
@@ -220,7 +221,7 @@ public class BrAPIGermplasmService {
     }
 
     public UUID getGermplasmListId(BrAPIListNewRequest importList) {
-        if(Objects.nonNull(importList.getExternalReferences()) && hasListExternalReference(importList)) {
+        if(Objects.nonNull(importList.getExternalReferences()) && hasListExternalReference(importList.getExternalReferences())) {
             return UUID.fromString(importList.getExternalReferences().stream()
                     .filter(e -> referenceSource.concat("/lists").equals(e.getReferenceSource()))
                     .map(e -> e.getReferenceID()).findAny().orElse("00000000-0000-0000-000000000000"));
@@ -229,14 +230,9 @@ public class BrAPIGermplasmService {
         }
     }
 
-    private boolean hasListExternalReference(BrAPIListDetails listData) {
-        return listData.getExternalReferences().stream()
-                .anyMatch(e -> referenceSource.concat("/lists").equals(e.getReferenceSource()));
-    }
-
-    private boolean hasListExternalReference(BrAPIListNewRequest importList) {
-        return importList.getExternalReferences().stream()
-                .anyMatch(e -> referenceSource.concat("/lists").equals(e.getReferenceSource()));
+    private boolean hasListExternalReference(List<BrAPIExternalReference> refs) throws IllegalArgumentException {
+        if (refs == null) throw new IllegalArgumentException();
+        return refs.stream().anyMatch(e -> referenceSource.concat("/lists").equals(e.getReferenceSource()));
     }
 
     private ToIntFunction<BrAPIGermplasm> getEntryNumber(UUID germplasmListId) throws IllegalArgumentException {

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -112,14 +112,15 @@ public class BrAPIGermplasmService {
         }
     }
 
-    public List<Map<String, Object>> processData(List<BrAPIGermplasm> germplasm){
+    public List<Map<String, Object>> processData(List<BrAPIGermplasm> germplasm, String listName){
         List<Map<String, Object>> processedData =  new ArrayList<>();
 
         for (BrAPIGermplasm germplasmEntry: germplasm) {
             HashMap<String, Object> row = new HashMap<>();
             row.put("GID", Integer.valueOf(germplasmEntry.getAccessionNumber()));
             row.put("Name", germplasmEntry.getGermplasmName());
-            row.put("Entry No", germplasmEntry.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsInt());
+            row.put("Entry No", germplasmEntry.getAdditionalInfo()
+                    .getAsJsonObject(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS).get(listName).getAsString());
             row.put("Breeding Method", germplasmEntry.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD).getAsString());
             String source = germplasmEntry.getSeedSource();
             row.put("Source", source);
@@ -187,7 +188,7 @@ public class BrAPIGermplasmService {
         String fileName = createFileName(listData, listName);
         StreamedFile downloadFile;
         //Convert list data to List<Map<String, Object>> data to pass into file writer
-        List<Map<String, Object>> processedData =  processData(germplasm);
+        List<Map<String, Object>> processedData =  processData(germplasm, listName);
 
         if (fileExtension == FileType.CSV){
             downloadFile = CSVWriter.writeToDownload(columns, processedData, fileExtension);

--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -149,7 +149,6 @@ public class Germplasm implements BrAPIObject {
         germplasm.setDefaultDisplayName(getGermplasmName());
         germplasm.setGermplasmPUI(getGermplasmPUI());
         germplasm.setCollection(getCollection());
-        germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER, entryNo);
         germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID, getFemaleParentDBID());
         germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID, getMaleParentDBID());
         germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_ENTRY_NO, getFemaleParentEntryNo());

--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -131,11 +131,16 @@ public class Germplasm implements BrAPIObject {
         brapiList.setListName(constructGermplasmListName(listName, program));
         brapiList.setListDescription(this.listDescription);
         brapiList.listType(BrAPIListTypes.GERMPLASM);
-        // Set external reference
-        BrAPIExternalReference reference = new BrAPIExternalReference();
-        reference.setReferenceSource(String.format("%s/programs", referenceSource));
-        reference.setReferenceID(program.getId().toString());
-        brapiList.setExternalReferences(List.of(reference));
+
+        // Set external references
+        BrAPIExternalReference programReference = new BrAPIExternalReference();
+        programReference.setReferenceSource(String.format("%s/programs", referenceSource));
+        programReference.setReferenceID(program.getId().toString());
+        BrAPIExternalReference listReference = new BrAPIExternalReference();
+        listReference.setReferenceSource(String.format("%s/lists", referenceSource));
+        listReference.setReferenceID(UUID.randomUUID().toString());
+        brapiList.setExternalReferences(List.of(programReference, listReference));
+
         return brapiList;
     }
 
@@ -143,7 +148,7 @@ public class Germplasm implements BrAPIObject {
         return String.format("%s [%s-germplasm]", listName, program.getKey());
     }
 
-    public BrAPIGermplasm constructBrAPIGermplasm(BreedingMethodEntity breedingMethod, User user, String listName) {
+    public BrAPIGermplasm constructBrAPIGermplasm(BreedingMethodEntity breedingMethod, User user, UUID listId) {
         BrAPIGermplasm germplasm = new BrAPIGermplasm();
         germplasm.setGermplasmName(getGermplasmName());
         germplasm.setDefaultDisplayName(getGermplasmName());
@@ -157,8 +162,8 @@ public class Germplasm implements BrAPIObject {
         createdBy.put(BrAPIAdditionalInfoFields.CREATED_BY_USER_ID, user.getId().toString());
         createdBy.put(BrAPIAdditionalInfoFields.CREATED_BY_USER_NAME, user.getName());
         germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.CREATED_BY, createdBy);
-        Map<String, String> listEntryNumbers = new HashMap<>();
-        listEntryNumbers.put(listName, entryNo);
+        Map<UUID, String> listEntryNumbers = new HashMap<>();
+        listEntryNumbers.put(listId, entryNo);
         germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS, listEntryNumbers);
         //TODO: Need to check that the acquisition date it in date format
         //brAPIGermplasm.setAcquisitionDate(pedigreeImport.getGermplasm().getAcquisitionDate());
@@ -248,8 +253,8 @@ public class Germplasm implements BrAPIObject {
         }
     }
 
-    public BrAPIGermplasm constructBrAPIGermplasm(Program program, BreedingMethodEntity breedingMethod, User user, boolean commit, String referenceSource, Supplier<BigInteger> nextVal, String listName) {
-        BrAPIGermplasm germplasm = constructBrAPIGermplasm(breedingMethod, user, listName);
+    public BrAPIGermplasm constructBrAPIGermplasm(Program program, BreedingMethodEntity breedingMethod, User user, boolean commit, String referenceSource, Supplier<BigInteger> nextVal, UUID listId) {
+        BrAPIGermplasm germplasm = constructBrAPIGermplasm(breedingMethod, user, listId);
         if (commit) {
             setBrAPIGermplasmCommitFields(germplasm, program.getKey(), referenceSource, nextVal);
         }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -250,7 +250,7 @@ public class Germplasm implements BrAPIObject {
     }
 
     public BrAPIGermplasm constructBrAPIGermplasm(Program program, BreedingMethodEntity breedingMethod, User user, boolean commit, String referenceSource, Supplier<BigInteger> nextVal, String listName) {
-        BrAPIGermplasm germplasm = constructBrAPIGermplasm(breedingMethod, user);
+        BrAPIGermplasm germplasm = constructBrAPIGermplasm(breedingMethod, user, listName);
         if (commit) {
             setBrAPIGermplasmCommitFields(germplasm, program.getKey(), referenceSource, nextVal);
         }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -143,7 +143,7 @@ public class Germplasm implements BrAPIObject {
         return String.format("%s [%s-germplasm]", listName, program.getKey());
     }
 
-    private BrAPIGermplasm constructBrAPIGermplasm(ProgramBreedingMethodEntity breedingMethod, User user) {
+    public BrAPIGermplasm constructBrAPIGermplasm(BreedingMethodEntity breedingMethod, User user, String listName) {
         BrAPIGermplasm germplasm = new BrAPIGermplasm();
         germplasm.setGermplasmName(getGermplasmName());
         germplasm.setDefaultDisplayName(getGermplasmName());
@@ -158,6 +158,9 @@ public class Germplasm implements BrAPIObject {
         createdBy.put(BrAPIAdditionalInfoFields.CREATED_BY_USER_ID, user.getId().toString());
         createdBy.put(BrAPIAdditionalInfoFields.CREATED_BY_USER_NAME, user.getName());
         germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.CREATED_BY, createdBy);
+        Map<String, String> listEntryNumbers = new HashMap<>();
+        listEntryNumbers.put(listName, entryNo);
+        germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS, listEntryNumbers);
         //TODO: Need to check that the acquisition date it in date format
         //brAPIGermplasm.setAcquisitionDate(pedigreeImport.getGermplasm().getAcquisitionDate());
         germplasm.setCountryOfOriginCode(getCountryOfOrigin());
@@ -246,7 +249,7 @@ public class Germplasm implements BrAPIObject {
         }
     }
 
-    public BrAPIGermplasm constructBrAPIGermplasm(Program program, ProgramBreedingMethodEntity breedingMethod, User user, boolean commit, String referenceSource, Supplier<BigInteger> nextVal) {
+    public BrAPIGermplasm constructBrAPIGermplasm(Program program, BreedingMethodEntity breedingMethod, User user, boolean commit, String referenceSource, Supplier<BigInteger> nextVal, String listName) {
         BrAPIGermplasm germplasm = constructBrAPIGermplasm(breedingMethod, user);
         if (commit) {
             setBrAPIGermplasmCommitFields(germplasm, program.getKey(), referenceSource, nextVal);

--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -27,6 +27,7 @@ import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.germ.BrAPIGermplasmSynonyms;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapps.importer.model.config.*;
+import org.breedinginsight.dao.db.tables.pojos.BreedingMethodEntity;
 import org.breedinginsight.dao.db.tables.pojos.ProgramBreedingMethodEntity;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
@@ -148,7 +149,7 @@ public class Germplasm implements BrAPIObject {
         return String.format("%s [%s-germplasm]", listName, program.getKey());
     }
 
-    public BrAPIGermplasm constructBrAPIGermplasm(BreedingMethodEntity breedingMethod, User user, UUID listId) {
+    public BrAPIGermplasm constructBrAPIGermplasm(ProgramBreedingMethodEntity breedingMethod, User user, UUID listId) {
         BrAPIGermplasm germplasm = new BrAPIGermplasm();
         germplasm.setGermplasmName(getGermplasmName());
         germplasm.setDefaultDisplayName(getGermplasmName());
@@ -253,7 +254,7 @@ public class Germplasm implements BrAPIObject {
         }
     }
 
-    public BrAPIGermplasm constructBrAPIGermplasm(Program program, BreedingMethodEntity breedingMethod, User user, boolean commit, String referenceSource, Supplier<BigInteger> nextVal, UUID listId) {
+    public BrAPIGermplasm constructBrAPIGermplasm(Program program, ProgramBreedingMethodEntity breedingMethod, User user, boolean commit, String referenceSource, Supplier<BigInteger> nextVal, UUID listId) {
         BrAPIGermplasm germplasm = constructBrAPIGermplasm(breedingMethod, user, listId);
         if (commit) {
             setBrAPIGermplasmCommitFields(germplasm, program.getKey(), referenceSource, nextVal);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -273,10 +273,7 @@ public class GermplasmProcessor implements Processor {
                 entryNumberCounts.put(germplasm.getEntryNo(),
                                       entryNumberCounts.containsKey(germplasm.getEntryNo()) ? entryNumberCounts.get(germplasm.getEntryNo()) + 1 : 1);
 
-                UUID importListId = UUID.fromString(String.valueOf(importList.getExternalReferences().stream()
-                        .filter(e -> BRAPI_REFERENCE_SOURCE.concat("/lists").equals(e.getReferenceSource()))
-                        .map(e -> e.getReferenceID())
-                        .findFirst()));
+                UUID importListId = brAPIGermplasmService.getGermplasmListId(importList);
 
                 BrAPIGermplasm newGermplasm = germplasm.constructBrAPIGermplasm(program, breedingMethod, user, commit, BRAPI_REFERENCE_SOURCE, nextVal, importListId);
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -273,7 +273,12 @@ public class GermplasmProcessor implements Processor {
                 entryNumberCounts.put(germplasm.getEntryNo(),
                                       entryNumberCounts.containsKey(germplasm.getEntryNo()) ? entryNumberCounts.get(germplasm.getEntryNo()) + 1 : 1);
 
-                BrAPIGermplasm newGermplasm = germplasm.constructBrAPIGermplasm(program, breedingMethod, user, commit, BRAPI_REFERENCE_SOURCE, nextVal, importList.getListName());
+                UUID importListId = UUID.fromString(String.valueOf(importList.getExternalReferences().stream()
+                        .filter(e -> BRAPI_REFERENCE_SOURCE.concat("/lists").equals(e.getReferenceSource()))
+                        .map(e -> e.getReferenceID())
+                        .findFirst()));
+
+                BrAPIGermplasm newGermplasm = germplasm.constructBrAPIGermplasm(program, breedingMethod, user, commit, BRAPI_REFERENCE_SOURCE, nextVal, importListId);
 
                 newGermplasmList.add(newGermplasm);
                 // Assign status of the germplasm

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -273,7 +273,7 @@ public class GermplasmProcessor implements Processor {
                 entryNumberCounts.put(germplasm.getEntryNo(),
                                       entryNumberCounts.containsKey(germplasm.getEntryNo()) ? entryNumberCounts.get(germplasm.getEntryNo()) + 1 : 1);
 
-                BrAPIGermplasm newGermplasm = germplasm.constructBrAPIGermplasm(program, breedingMethod, user, commit, BRAPI_REFERENCE_SOURCE, nextVal);
+                BrAPIGermplasm newGermplasm = germplasm.constructBrAPIGermplasm(program, breedingMethod, user, commit, BRAPI_REFERENCE_SOURCE, nextVal, importList.getListName());
 
                 newGermplasmList.add(newGermplasm);
                 // Assign status of the germplasm

--- a/src/main/java/org/breedinginsight/utilities/response/mappers/GermplasmQueryMapper.java
+++ b/src/main/java/org/breedinginsight/utilities/response/mappers/GermplasmQueryMapper.java
@@ -2,6 +2,7 @@ package org.breedinginsight.utilities.response.mappers;
 
 import com.google.gson.JsonObject;
 import lombok.Getter;
+import org.brapi.v2.model.core.response.BrAPIListsSingleResponse;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.breedinginsight.api.v1.controller.metadata.SortOrder;
 import org.breedinginsight.brapi.v1.model.ObservationVariable;
@@ -24,10 +25,24 @@ public class GermplasmQueryMapper extends AbstractQueryMapper {
 
     public GermplasmQueryMapper() {
         fields = Map.ofEntries(
-                Map.entry("importEntryNumber", (germplasm) ->
-                        germplasm.getAdditionalInfo() != null && germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER) ?
-                        germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsString() :
-                        null),
+                Map.entry("importEntryNumber", (germplasm) ->{
+                    String entryNumber = null;
+                        if (germplasm.getAdditionalInfo() != null) {
+                            // if additionalInfo contains the importEntryNumber key then return the value
+                            if (germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER)) {
+                                entryNumber = germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsString();
+                            }
+
+                            // if additionalInfo has both listEntryNumbers and listId keys then return the entry number
+                            // mapped to the listId
+                            if (germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS)
+                                && germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ID)) {
+                                String listId = germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ID).getAsString();
+                                entryNumber = germplasm.getAdditionalInfo().getAsJsonObject(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS).get(listId).getAsString();
+                            }
+                        }
+                    return entryNumber;
+                }),
                 Map.entry("accessionNumber", BrAPIGermplasm::getAccessionNumber),
                 Map.entry("defaultDisplayName", BrAPIGermplasm::getDefaultDisplayName),
                 Map.entry("breedingMethod", (germplasm) ->

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
@@ -608,7 +608,8 @@ public class GermplasmTemplateMap extends BrAPITest {
         for (int i = 0; i < previewRows.size(); i++) {
             JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
             germplasmNames.add(germplasm.get("germplasmName").getAsString());
-            assertEquals(Integer.toString(i+1), germplasm.getAsJsonObject("additionalInfo").get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsString(), "Wrong entry number");
+            int finalI = i;
+            gson.fromJson(germplasm.getAsJsonObject("additionalInfo").getAsJsonObject("listEntryNumbers"), Map.class).forEach((listId, entryNumber) -> assertEquals(Integer.toString(finalI +1), entryNumber, "Wrong entry number"));
         }
 
         // Check the germplasm list

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
@@ -177,7 +177,8 @@ public class GermplasmTemplateMap extends BrAPITest {
         for (int i = 0; i < previewRows.size(); i++) {
             JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
             germplasmNames.add(germplasm.get("germplasmName").getAsString());
-            assertEquals(Integer.toString(i+1), germplasm.getAsJsonObject("additionalInfo").get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsString(), "Wrong entry number");
+            int finalI = i;
+            gson.fromJson(germplasm.getAsJsonObject("additionalInfo").getAsJsonObject("listEntryNumbers"), Map.class).forEach((listId, entryNumber) -> assertEquals(Integer.toString(finalI +1), entryNumber));
         }
 
         // Check the germplasm list

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
@@ -743,7 +743,6 @@ public class GermplasmTemplateMap extends BrAPITest {
         // Entry Number
         gson.fromJson(germplasm.getAsJsonObject("additionalInfo").getAsJsonObject("listEntryNumbers"), Map.class).forEach((listId, entryNumber) -> assertEquals(fileData.getString(i, "Entry No"), entryNumber, "Wrong entry number"));
         JsonObject additionalInfo = germplasm.getAsJsonObject("additionalInfo");
-        assertEquals(fileData.getString(i, "Entry No"), additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsString(), "Wrong entry number");
         // Created By User ID
         assertEquals(testUser.getId().toString(), additionalInfo.getAsJsonObject(BrAPIAdditionalInfoFields.CREATED_BY).get(BrAPIAdditionalInfoFields.CREATED_BY_USER_ID).getAsString(), "Wrong createdBy userId");
         // Created by User name

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
@@ -178,7 +178,7 @@ public class GermplasmTemplateMap extends BrAPITest {
             JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
             germplasmNames.add(germplasm.get("germplasmName").getAsString());
             int finalI = i;
-            gson.fromJson(germplasm.getAsJsonObject("additionalInfo").getAsJsonObject("listEntryNumbers"), Map.class).forEach((listId, entryNumber) -> assertEquals(Integer.toString(finalI +1), entryNumber));
+            gson.fromJson(germplasm.getAsJsonObject("additionalInfo").getAsJsonObject("listEntryNumbers"), Map.class).forEach((listId, entryNumber) -> assertEquals(Integer.toString(finalI +1), entryNumber, "Wrong entry number"));
         }
 
         // Check the germplasm list
@@ -740,6 +740,7 @@ public class GermplasmTemplateMap extends BrAPITest {
         // Germplasm display name
         assertEquals(fileData.getString(i, "Name"), germplasm.get("defaultDisplayName").getAsString(), "Wrong display name");
         // Entry Number
+        gson.fromJson(germplasm.getAsJsonObject("additionalInfo").getAsJsonObject("listEntryNumbers"), Map.class).forEach((listId, entryNumber) -> assertEquals(fileData.getString(i, "Entry No"), entryNumber, "Wrong entry number"));
         JsonObject additionalInfo = germplasm.getAsJsonObject("additionalInfo");
         assertEquals(fileData.getString(i, "Entry No"), additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsString(), "Wrong entry number");
         // Created By User ID


### PR DESCRIPTION
# Description
**Story:** [BI-1606](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1606)

Instead of using the list name(which may or may not be unique in the future) as the key for the mapping described in the card, a UUID is created for new lists and stored as an entry in the list's external references.

1. Updated Germplasm#constructBrAPIList to add a new external reference with referenceSource set to <BRAPI_BASE_URL>/lists and referenceId set to a randomly generated UUID. 

2. Updated Germplasm#constructBrAPIGermplasm(Program, BreedingMethodEntity, User, boolean, String, Supplier) to accept an argument of UUID germplasmListId

3. Updated Germplasm#constructBrAPIGermplasm(BreedingMethodEntity, User) to accept an argument of UUID germplasmListId

4. Updated the code in Germplasm#constructBrAPIGermplasm(BreedingMethodEntity, User) that currently sets GERMPLASM_IMPORT_ENTRY_NUMBER as follows

    a. Created a Map<String, String> and add an entry where:

        i. key → germplasmListId (from list external reference)
        ii. value → import entry number

    b. Set the map in the additionalInfo of the germplasm with a key of listEntryNumbers

5. Updated BrAPIGermplasmService#processData 

    a. Method now accepts an argument of UUID germplasmListId
    b. updated the logic to set the entry number to either look in the map of import entry numbers for the specific germplasmListId or, for germplasm already created in the old format, look in additionalInfo.importEntryNumber 

6. Updated the sorting of germplasm in BrAPIGermplasmService#exportGermplasmList to fetch the entry number for the list name that’s either within the map of list entry numbers or stored in additionalInfo.importEntryNumber.

7. Updated GermplasmProcessor#process to get the ID for the import list and pass it to Germplasm#constructBrAPIGermplasm.

# Dependencies
biweb develop branch

# Testing
1. Import germplasm with user-supplied entry numbers. 
2. Go to the Germpasm Lists tab and use the dev tools console to inspect the list object in the response and verify there is an external reference entry for /lists and note the UUID stored as the refernceID.
3. Then view all imported germplasm and use the dev tools console to inspect the germplasm objects in the response from bi-api. Verify the additionalInfo field "listEntryNumbers" exists and the value is a Map with the imported list ID from step 2 as the key and entry number as value.

4. Import germplasm without user-supplied entry numbers and repeat process above.

5. Download the imported germplasm and verify the exported file records match what is stored.
6. Download a list of previously imported germplasm that store entry number values in additionalInfo.imortEntryNumber and verify the exported file records match what is stored.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: [#136](https://github.com/Breeding-Insight/taf/actions/runs/3526754134)


[BI-1606]: https://breedinginsight.atlassian.net/browse/BI-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ