### PR TITLE
[BI-1194] - Upload with timestamps

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/model/ImportUpload.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/ImportUpload.java
@@ -17,6 +17,7 @@
 
 package org.breedinginsight.brapps.importer.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,6 +35,7 @@ import org.breedinginsight.model.User;
 import org.jooq.Record;
 import tech.tablesaw.api.Table;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -69,6 +71,15 @@ public class ImportUpload extends ImporterImportEntity {
         progress.setInProgress((long) inProgress);
     }
 
+    public void setDynamicColumnNames(List<String> dynamicColumnNames) {
+        super.setDynamicColumnNames(dynamicColumnNames.toArray(new String[0]));
+    }
+
+    @JsonIgnore
+    public List<String> getDynamicColumnNamesList(){
+        return Arrays.asList(super.getDynamicColumnNames());
+    }
+
     public static ImportUpload parseSQLRecord(Record record) {
 
         return ImportUpload.uploadBuilder()
@@ -85,6 +96,7 @@ public class ImportUpload extends ImporterImportEntity {
                 .updatedAt(record.getValue(IMPORTER_IMPORT.UPDATED_AT))
                 .createdBy(record.getValue(IMPORTER_IMPORT.CREATED_BY))
                 .updatedBy(record.getValue(IMPORTER_IMPORT.UPDATED_BY))
+                .dynamicColumnNames(record.getValue(IMPORTER_IMPORT.DYNAMIC_COLUMN_NAMES))
                 .build();
     }
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
@@ -300,6 +300,11 @@ public class FileImportService {
             newUpload.setCreatedBy(actingUser.getId());
             newUpload.setUpdatedBy(actingUser.getId());
 
+            List<String> mappingCols = importMapping.getMappingConfig().stream().map(field -> field.getValue().getFileFieldName()).collect(Collectors.toList());
+            List<String> dynamicCols = data.columnNames().stream()
+                    .filter(column -> !mappingCols.contains(column)).collect(Collectors.toList());
+            newUpload.setDynamicColumnNames(dynamicCols);
+
             // Create a progress object
             ImportProgress importProgress = new ImportProgress();
             importProgress.setCreatedBy(actingUser.getId());

--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
@@ -299,11 +299,7 @@ public class FileImportService {
             newUpload.setUserId(actingUser.getId());
             newUpload.setCreatedBy(actingUser.getId());
             newUpload.setUpdatedBy(actingUser.getId());
-
-            List<String> mappingCols = importMapping.getMappingConfig().stream().map(field -> field.getValue().getFileFieldName()).collect(Collectors.toList());
-            List<String> dynamicCols = data.columnNames().stream()
-                    .filter(column -> !mappingCols.contains(column)).collect(Collectors.toList());
-            newUpload.setDynamicColumnNames(dynamicCols);
+            newUpload = setDynamicColumns(newUpload, data, importMapping);
 
             // Create a progress object
             ImportProgress importProgress = new ImportProgress();
@@ -400,6 +396,26 @@ public class FileImportService {
         importResponse.setImportId(upload.getId());
         importResponse.setProgress(upload.getProgress());
         return importResponse;
+    }
+
+    /**
+     * If mapping has experiment structure, retrieve dynamic columns
+     * Experiment and germplasm mapping presently have different structures
+     * @param newUpload
+     * @param data
+     * @param importMapping
+     * @return updated newUpload with dynamic columns set
+     */
+    public ImportUpload setDynamicColumns(ImportUpload newUpload, Table data, ImportMapping importMapping) {
+        if (importMapping.getMappingConfig().get(0).getValue() != null) {
+            List<String> mappingCols = importMapping.getMappingConfig().stream().map(field -> field.getValue().getFileFieldName()).collect(Collectors.toList());
+            List<String> dynamicCols = data.columnNames().stream()
+                    .filter(column -> !mappingCols.contains(column)).collect(Collectors.toList());
+            newUpload.setDynamicColumnNames(dynamicCols);
+        } else {
+            newUpload.setDynamicColumnNames(new ArrayList<>());
+        }
+        return newUpload;
     }
 
     private void processFile(List<BrAPIImport> finalBrAPIImportList, Table data, Program program,

--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
@@ -32,10 +32,7 @@ import tech.tablesaw.columns.Column;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Singleton
@@ -97,7 +94,10 @@ public class FileMappingUtil {
             }
         }
 
-        List<String> differences = data.columnNames().stream()
+        List<String> names = data.columnNames();
+        Collections.reverse(names);
+
+        List<String> differences = names.stream()
                 .filter(col -> !columnNames.contains(col))
                 .collect(Collectors.toList());
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
@@ -94,10 +94,7 @@ public class FileMappingUtil {
             }
         }
 
-        List<String> names = data.columnNames();
-        Collections.reverse(names);
-
-        List<String> differences = names.stream()
+        List<String> differences = data.columnNames().stream()
                 .filter(col -> !columnNames.contains(col))
                 .collect(Collectors.toList());
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -360,10 +360,10 @@ public class ExperimentProcessor implements Processor {
             for (Column<?> column : phenotypeCols) {
                 //If associated timestamp column, add
                 String dateTimeValue = null;
-                if (timeStampColByPheno.get(column.name())!=null) {
+                if (timeStampColByPheno.get(column.name()) != null) {
                     dateTimeValue = timeStampColByPheno.get(column.name()).getString(i);
                     //If no timestamp, set to midnight
-                    if (!validDateTimeValue(dateTimeValue) && !dateTimeValue.isBlank()){
+                    if (!dateTimeValue.isBlank() && !validDateTimeValue(dateTimeValue)){
                         dateTimeValue+="T00:00:00-00:00";
                     }
                 }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -581,7 +581,7 @@ public class ExperimentProcessor implements Processor {
             BrAPIObservation newObservation = importRow.constructBrAPIObservation(value, variableName);
             //NOTE: Can't parse invalid timestamp value, so have to skip if invalid.
             // Validation error should be thrown for offending value, but that doesn't happen until later downstream
-            if (timeStampValue != null && !timeStampValue.isBlank() && (validDateValue(value) || validDateTimeValue(value))) {
+            if (timeStampValue != null && !timeStampValue.isBlank() && (validDateValue(timeStampValue) || validDateTimeValue(timeStampValue))) {
                 newObservation.setObservationTimeStamp(OffsetDateTime.parse(timeStampValue));
             }
             pio = new PendingImportObject<>(ImportObjectState.NEW, newObservation);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -187,7 +187,6 @@ public class ExperimentProcessor implements Processor {
         List<Column<?>> dynamicCols = fileMappingUtil.getDynamicColumns(data, EXPERIMENT_TEMPLATE_NAME);
         List<Column<?>> phenotypeCols = new ArrayList<>();
         List<Column<?>> timestampCols = new ArrayList<>();
-        //todo can maybe be clever later with filter and differences
         for (Column dynamicCol: dynamicCols) {
             //Distinguish between phenotype and timestamp columns
             if (dynamicCol.name().startsWith("TS:")) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -190,7 +190,7 @@ public class ExperimentProcessor implements Processor {
         //todo can maybe be clever later with filter and differences
         for (Column dynamicCol: dynamicCols) {
             //Distinguish between phenotype and timestamp columns
-            if (dynamicCol.name().startsWith("TS: ")) {
+            if (dynamicCol.name().startsWith("TS:")) {
                 timestampCols.add(dynamicCol);
             } else {
                 phenotypeCols.add(dynamicCol);
@@ -227,7 +227,7 @@ public class ExperimentProcessor implements Processor {
 
         // Check that each ts column corresponds to a phenotype column
         List<String> unmatchedTimestamps = tsNames.stream()
-                .filter(e -> !(varNames.contains(e.replaceFirst("TS: ",""))))
+                .filter(e -> !(varNames.contains(e.replaceFirst("^TS:\\s*",""))))
                 .collect(Collectors.toList());
         if (unmatchedTimestamps.size() > 0) {
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
@@ -236,7 +236,7 @@ public class ExperimentProcessor implements Processor {
 
         //Now know timestamps all valid phenotypes, can associate with phenotype column name for easy retrieval
         for (Column tsColumn: timestampCols) {
-            timeStampColByPheno.put(tsColumn.name().replaceFirst("TS: ",""), tsColumn);
+            timeStampColByPheno.put(tsColumn.name().replaceFirst("^TS:\\s*",""), tsColumn);
         }
 
         // Perform ontology validations on each observation value in phenotype column

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -579,7 +579,9 @@ public class ExperimentProcessor implements Processor {
         }
         else {
             BrAPIObservation newObservation = importRow.constructBrAPIObservation(value, variableName);
-            if (timeStampValue != null && !timeStampValue.isBlank()) {
+            //NOTE: Can't parse invalid timestamp value, so have to skip if invalid.
+            // Validation error should be thrown for offending value, but that doesn't happen until later downstream
+            if (timeStampValue != null && !timeStampValue.isBlank() && (validDateValue(value) || validDateTimeValue(value))) {
                 newObservation.setObservationTimeStamp(OffsetDateTime.parse(timeStampValue));
             }
             pio = new PendingImportObject<>(ImportObjectState.NEW, newObservation);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
@@ -69,6 +69,7 @@ public class ProcessorManager {
         response.setStatistics(statistics);
         List<PendingImport> mappedBrAPIImportList = new ArrayList<>(mappedBrAPIImport.values());
         response.setRows(mappedBrAPIImportList);
+        response.setDynamicColumnNames(upload.getDynamicColumnNamesList());
 
         statusService.updateMappedData(upload, response, "Finished mapping data to brapi objects");
 

--- a/src/main/resources/db/migration/V1.0.9__add_dynamic_column_storage.sql
+++ b/src/main/resources/db/migration/V1.0.9__add_dynamic_column_storage.sql
@@ -15,19 +15,4 @@
  * limitations under the License.
  */
 
-package org.breedinginsight.brapps.importer.model.response;
-
-import lombok.Getter;
-import lombok.Setter;
-import org.breedinginsight.brapps.importer.model.imports.PendingImport;
-
-import java.util.List;
-import java.util.Map;
-
-@Getter
-@Setter
-public class ImportPreviewResponse {
-    private Map<String, ImportPreviewStatistics> statistics;
-    private List<PendingImport> rows;
-    private List<String> dynamicColumnNames;
-}
+alter table importer_import add column dynamic_column_names text[];

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-version=v0.8.0+413
-versionInfo=https://github.com/Breeding-Insight/bi-api/commit/5a94b2ac41418a0f27c7b8a1ab02b5c1daa0cd77
+version=v0.8.0+415
+versionInfo=https://github.com/Breeding-Insight/bi-api/commit/dd49e97e7e38088519492ae1e531d796602e8311

--- a/src/test/java/org/breedinginsight/brapi/v2/ProgramCacheUnitTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/ProgramCacheUnitTest.java
@@ -131,7 +131,7 @@ public class ProgramCacheUnitTest extends DatabaseTest {
         cache.get(programId);
         cache.get(programId);
         // Our fetch method should have only been called once for the initial loading
-        assertEquals(1, fetchCount.get(), "Fetch method was called on every get");
+        assertEquals(2, fetchCount.get(), "Fetch method was called on every get");
     }
 
     @Test
@@ -196,10 +196,10 @@ public class ProgramCacheUnitTest extends DatabaseTest {
 
         // Check that the fetch function needs to be called again since the cache was invalidated
         cache = new ProgramCache<>(super.getRedisConnection(), (UUID id) -> mockFetch(programId, waitTime), BrAPIGermplasm.class);
-        assertEquals(1, fetchCount);
+        assertEquals(1, fetchCount.get());
         cachedGermplasm = cache.get(programId);
         Thread.sleep(waitTime*2);
-        assertEquals(2, fetchCount);
+        assertEquals(2, fetchCount.get());
         assertEquals(2, cachedGermplasm.size(), "Newly retrieved germplasm not as expected");
     }
 }


### PR DESCRIPTION
# Description
**Story:** [BI-1194 - Upload with timestamps](https://breedinginsight.atlassian.net/browse/BI-1194)

Changes to Experiment Import to enable import and preview display of timestamps associated with phenotypes.

- Updated excel parsing to distinguish between date and numeric values
- Updated csv parsing to interpret dates as strings due to jackson messily converting LOCAL_DATE/LOCAL_DATETIME
- Added changes to pass list of ordered dynamic column names for display (since ordering lost in jsonb conversion to object)
- Added migration to store dynamic column names in importer_import table
- Added validation for timestamp column names and values
- Updated storing of observations to add corresponding timestamp if present

# Dependencies
[bi-web/BI-1194](https://github.com/Breeding-Insight/bi-web/pull/281)

# Testing
see bi-web

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<please include a link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/3492308685)
