### PR TITLE
BI-1653 - Update Experiment Preview to show observations

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
@@ -32,10 +32,7 @@ import tech.tablesaw.columns.Column;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Singleton
@@ -97,7 +94,10 @@ public class FileMappingUtil {
             }
         }
 
-        List<String> differences = data.columnNames().stream()
+        List<String> names = data.columnNames();
+        Collections.reverse(names);
+
+        List<String> differences = names.stream()
                 .filter(col -> !columnNames.contains(col))
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1653?atlOrigin=eyJpIjoiYTQ2OTczYjI2YWFlNGQxYTlhY2MyYWNmNzVjZWM5N2IiLCJwIjoiaiJ9

- The tablesaw Table columns are ordered weirdly at the point of processor processing, not sure if it's something happening in the mapping stage or how to get order matching file because the indices seemed all weird. I just reversed the column name order for a quick fix but not sure if that will work for all cases. Should be looked at more but I ran out of time.

# Dependencies
- bi-web feature/BI-1653

# Testing
- Import experiments with different phenotype column orderings and without phenotype columns and verify import preview phenotype columns match file.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
