### PR TITLE
[BI-1615] - Add termType to Trait DB Table

### DIFF
--- a/src/main/java/org/breedinginsight/model/Trait.java
+++ b/src/main/java/org/breedinginsight/model/Trait.java
@@ -91,6 +91,7 @@ public class Trait extends TraitEntity {
         this.setUpdatedAt(traitEntity.getUpdatedAt());
         this.setUpdatedBy(traitEntity.getUpdatedBy());
         this.setActive(traitEntity.getActive());
+        this.setTermType(traitEntity.getTermType());
     }
 
     public static Trait parseSqlRecord(Record record) {
@@ -106,6 +107,7 @@ public class Trait extends TraitEntity {
             .updatedAt(record.getValue(TRAIT.UPDATED_AT))
             .updatedBy(record.getValue(TRAIT.UPDATED_BY))
             .active(record.getValue(TRAIT.ACTIVE))
+            .termType(record.getValue(TRAIT.TERM_TYPE))
             .build();
     }
 

--- a/src/main/java/org/breedinginsight/services/TraitService.java
+++ b/src/main/java/org/breedinginsight/services/TraitService.java
@@ -217,6 +217,7 @@ public class TraitService {
                             .createdBy(actingUser.getId())
                             .updatedBy(actingUser.getId())
                             .active(true)
+                            .termType(trait.getTermType())
                             .build();
                     traitDAO.insert(jooqTrait);
                     trait.setId(jooqTrait.getId());
@@ -416,6 +417,7 @@ public class TraitService {
                     existingTraitEntity.setObservationVariableName(updatedTrait.getObservationVariableName());
                     existingTraitEntity.setProgramObservationLevelId(updatedTrait.getProgramObservationLevel().getId());
                     existingTraitEntity.setUpdatedBy(user.getId());
+                    existingTraitEntity.setTermType(updatedTrait.getTermType());
                     traitDAO.update(existingTraitEntity);
 
                     // Update in brapi

--- a/src/main/java/org/breedinginsight/utilities/response/mappers/TraitQueryMapper.java
+++ b/src/main/java/org/breedinginsight/utilities/response/mappers/TraitQueryMapper.java
@@ -73,7 +73,8 @@ public class TraitQueryMapper extends AbstractQueryMapper {
                 Map.entry("updatedByUserId",
                         trait -> trait.getUpdatedByUser() != null ? trait.getUpdatedByUser().getId() : null),
                 Map.entry("updatedByUserName",
-                        trait -> trait.getUpdatedByUser() != null ? trait.getUpdatedByUser().getName() : null)
+                        trait -> trait.getUpdatedByUser() != null ? trait.getUpdatedByUser().getName() : null),
+                Map.entry("termType", Trait::getTermType)
         );
     }
 

--- a/src/main/resources/db/migration/V1.0.10__add_onto_term_type.sql
+++ b/src/main/resources/db/migration/V1.0.10__add_onto_term_type.sql
@@ -1,0 +1,25 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+CREATE TYPE "term_type" AS ENUM (
+  'PHENOTYPE',
+  'GERM_ATTRIBUTE',
+  'GERM_PASSPORT'
+);
+
+ALTER TABLE trait ADD COLUMN term_type term_type NOT NULL DEFAULT 'PHENOTYPE';
+UPDATE trait SET term_type='PHENOTYPE';


### PR DESCRIPTION
# Description
**Story:** [BI-1615 - Add termType to Trait DB Table](https://breedinginsight.atlassian.net/browse/BI-1615)

Created migration to create term_type enum in backend and a term_type column in the trait table and populate said column with default of "PHENOTYPE"
Added support to save/update values to term_type in backend

# Dependencies
[bi-web/BI-1615](https://github.com/Breeding-Insight/bi-web/pull/285)

# Testing
see bi-web

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: [_\<please include a link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/3624530763)
