### PR TITLE
BI-1665 Store observations when importing new environments

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
@@ -37,4 +37,5 @@ public final class BrAPIAdditionalInfoFields {
     public static final String EXPERIMENT_TYPE = "experimentType";
     public static final String EXPERIMENT_NUMBER = "experimentNumber";
     public static final String ENVIRONMENT_NUMBER = "environmentNumber";
+    public static final String STUDY_NAME = "studyName";
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -291,7 +291,6 @@ public class ExperimentObservation implements BrAPIImport {
             BrAPIObservationUnit obsUnit
             ) {
         BrAPIObservation observation = new BrAPIObservation();
-        observation.setGermplasmDbId(getGid());
         observation.setGermplasmName(getGermplasmName());
         if(getEnv() != null) {
             observation.putAdditionalInfoItem(BrAPIAdditionalInfoFields.STUDY_NAME, getEnv());

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -284,12 +284,24 @@ public class ExperimentObservation implements BrAPIImport {
         return observationUnit;
     }
 
-    // TODO: Fill out with rest of data for saving to BRAPI
-    public BrAPIObservation constructBrAPIObservation(String value, String variableName) {
+    public BrAPIObservation constructBrAPIObservation(
+            String value,
+            String variableName,
+            String seasonDbId
+            ) {
         BrAPIObservation observation = new BrAPIObservation();
-
-        observation.setValue(value);
+        observation.setGermplasmDbId(getGid());
+        observation.setGermplasmName(getGermplasmName());
+        if(getEnv() != null) {
+            observation.putAdditionalInfoItem(BrAPIAdditionalInfoFields.STUDY_NAME, getEnv());
+        }
         observation.setObservationVariableName(variableName);
+        observation.setValue(value);
+
+        // The BrApi server needs this.  Breedbase does not.
+        BrAPISeason season = new BrAPISeason();
+        season.setSeasonDbId(seasonDbId);
+        observation.setSeason(season);
 
         return observation;
     }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -287,7 +287,8 @@ public class ExperimentObservation implements BrAPIImport {
     public BrAPIObservation constructBrAPIObservation(
             String value,
             String variableName,
-            String seasonDbId
+            String seasonDbId,
+            BrAPIObservationUnit obsUnit
             ) {
         BrAPIObservation observation = new BrAPIObservation();
         observation.setGermplasmDbId(getGid());
@@ -296,6 +297,8 @@ public class ExperimentObservation implements BrAPIImport {
             observation.putAdditionalInfoItem(BrAPIAdditionalInfoFields.STUDY_NAME, getEnv());
         }
         observation.setObservationVariableName(variableName);
+        observation.setObservationDbId(obsUnit.getObservationUnitDbId());
+        observation.setObservationUnitName(obsUnit.getObservationUnitName());
         observation.setValue(value);
 
         // The BrApi server needs this.  Breedbase does not.

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -733,15 +733,13 @@ public class ExperimentProcessor implements Processor {
 
         // Update ObservationVariable DbIds
         List<Trait> traits = getTraitList(program);
+        Map<String, Trait> traitMap = traits.stream().collect(Collectors.toMap(trait -> trait.getObservationVariableName(), trait -> trait));
+
         for(PendingImportObject<BrAPIObservation> observation: this.observationByHash.values()){
-            traitsLoop:
-            for(Trait trait: traits){
-                if(     observation.getBrAPIObject()!=null && observation.getBrAPIObject().getObservationVariableName()!=null
-                        && observation.getBrAPIObject().getObservationVariableName().equals(trait.getObservationVariableName())
-                ){
-                    observation.getBrAPIObject().setObservationVariableDbId(trait.getObservationVariableDbId());
-                    break traitsLoop;
-                }
+            String observationVariableName = observation.getBrAPIObject().getObservationVariableName();
+            if( observationVariableName!=null && traitMap.containsKey(observationVariableName)){
+                String observationVariableDbId = traitMap.get(observationVariableName).getObservationVariableDbId();
+                observation.getBrAPIObject().setObservationVariableDbId( observationVariableDbId );
             }
         }
     }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -369,15 +369,11 @@ public class ExperimentProcessor implements Processor {
         }
     }
 
-//    private String createObservationUnitKey(ExperimentObservation importRow) {
-//        String key = importRow.getEnv() + importRow.getExpUnitId();
-//        return key;
-//    }
-
     private String createObservationUnitKey(ExperimentObservation importRow) {
-                String key = createObservationUnitKey( importRow.getEnv(), importRow.getExpUnitId() );
-                return key;
+        String key = createObservationUnitKey( importRow.getEnv(), importRow.getExpUnitId() );
+        return key;
     }
+
     private String createObservationUnitKey(String studyName, String obsUnitName) {
         String key = studyName + obsUnitName;
         return key;
@@ -657,7 +653,7 @@ public class ExperimentProcessor implements Processor {
         List<BrAPILocation> newLocations = ProcessorData.getNewObjects(this.locationByName);
         List<BrAPIStudy> newStudies = ProcessorData.getNewObjects(this.studyByNameNoScope);
         List<BrAPIObservationUnit> newObservationUnits = ProcessorData.getNewObjects(this.observationUnitByNameNoScope);
-        // Do not save observations with no 'value'
+        // filter out observations with no 'value' so they will not be saved
         List<BrAPIObservation> newObservations = ProcessorData.getNewObjects(this.observationByHash).stream()
                 .filter(obs -> !obs.getValue().isBlank())
                 .collect(Collectors.toList());
@@ -696,15 +692,16 @@ public class ExperimentProcessor implements Processor {
             }
 
             updateObsUnitDependencyValues(program.getKey());
-            //brAPIObservationUnitDAO.createBrAPIObservationUnits(newObservationUnits, program.getId(), upload);
             List<BrAPIObservationUnit> createdObservationUnits = brAPIObservationUnitDAO.createBrAPIObservationUnits(newObservationUnits, program.getId(), upload);
 
             // set the DbId to the for each newly created Observation Unit
             for( BrAPIObservationUnit createdObservationUnit : createdObservationUnits){
+                // retrieve the BrAPI ObservationUnit from this.observationUnitByNameNoScope
                 String createdObservationUnit_StripedStudyName = Utilities.removeProgramKeyAndUnknownAdditionalData( createdObservationUnit.getStudyName(),program.getKey() );
                 String createdObservationUnit_StripedObsUnitName = Utilities.removeProgramKeyAndUnknownAdditionalData( createdObservationUnit.getObservationUnitName(),program.getKey() );
                 String createdObsUnit_key = createObservationUnitKey(createdObservationUnit_StripedStudyName, createdObservationUnit_StripedObsUnitName);
                 PendingImportObject<BrAPIObservationUnit> pi = this.observationUnitByNameNoScope.get(createdObsUnit_key);
+                // update the retrieved BrAPI object
                 BrAPIObservationUnit brAPIObservationUnit = pi.getBrAPIObject();
                 brAPIObservationUnit.setObservationUnitDbId ( createdObservationUnit.getObservationUnitDbId() );
             }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -775,11 +775,11 @@ public class ExperimentProcessor implements Processor {
                                          .get(BrAPIAdditionalInfoFields.STUDY_NAME)
                                          .getAsString()
                                          .equals(obsUnit.getStudyName())
-                                      && obs.getBrAPIObject()
-                                            .getObservationUnitName()
-                                            .equals(Utilities.removeProgramKeyAndUnknownAdditionalData(obsUnit.getObservationUnitName(), programKey)))
+                                      && Utilities.removeProgramKeyAndUnknownAdditionalData(obs.getBrAPIObject()
+                                                                                               .getObservationUnitName(), programKey)
+                                                  .equals(Utilities.removeProgramKeyAndUnknownAdditionalData(obsUnit.getObservationUnitName(), programKey)))
                 .forEach(obs -> {
-                    if(obs.getBrAPIObject().getObservationUnitDbId() == null) {
+                    if(StringUtils.isBlank(obs.getBrAPIObject().getObservationUnitDbId())) {
                         obs.getBrAPIObject().setObservationUnitDbId(obsUnit.getObservationUnitDbId());
                     }
                     obs.getBrAPIObject().setStudyDbId(obsUnit.getStudyDbId());

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -748,22 +748,27 @@ public class ExperimentProcessor implements Processor {
         return traits;
     }
 
+    // Update each ovservation's observationUnit DbId, study DbId, and germplasm DbId
     private void updateObservationDbIds(BrAPIObservationUnit obsUnit, String programKey) {
-        // Match on Env and Exp Unit ID
+        // FILTER LOGIC: Match on Env and Exp Unit ID
         this.observationByHash.values().stream()
-                              .filter(obs ->
-                                      obs.getBrAPIObject()
-                                                .getAdditionalInfo() != null && obs.getBrAPIObject()
-                                                                                   .getAdditionalInfo()
-                                                                                   .get(BrAPIAdditionalInfoFields.STUDY_NAME) != null
-                                      && obs.getBrAPIObject()
-                                         .getAdditionalInfo()
-                                         .get(BrAPIAdditionalInfoFields.STUDY_NAME)
-                                         .getAsString()
-                                         .equals(obsUnit.getStudyName())
-                                      && Utilities.removeProgramKeyAndUnknownAdditionalData(obs.getBrAPIObject()
-                                                                                               .getObservationUnitName(), programKey)
-                                                  .equals(Utilities.removeProgramKeyAndUnknownAdditionalData(obsUnit.getObservationUnitName(), programKey)))
+                .filter(obs ->
+                        obs.getBrAPIObject().getAdditionalInfo() != null
+                                && obs.getBrAPIObject()
+                                .getAdditionalInfo()
+                                .get(BrAPIAdditionalInfoFields.STUDY_NAME) != null
+                                && obs.getBrAPIObject()
+                                .getAdditionalInfo()
+                                .get(BrAPIAdditionalInfoFields.STUDY_NAME)
+                                .getAsString()
+                                .equals(obsUnit.getStudyName())
+                                && Utilities.removeProgramKeyAndUnknownAdditionalData(
+                                        obs.getBrAPIObject().getObservationUnitName(), programKey)
+                                .equals(
+                                        Utilities.removeProgramKeyAndUnknownAdditionalData(
+                                                obsUnit.getObservationUnitName(), programKey)
+                                )
+                )
                 .forEach(obs -> {
                     if(StringUtils.isBlank(obs.getBrAPIObject().getObservationUnitDbId())) {
                         obs.getBrAPIObject().setObservationUnitDbId(obsUnit.getObservationUnitDbId());

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -364,9 +364,7 @@ public class ExperimentProcessor implements Processor {
                 //column.name() gets phenotype name
                 String seasonDbId = this.yearToSeasonDbId(importRow.getEnvYear(), program.getId());
                 PendingImportObject<BrAPIObservation> obsPIO = createObservationPIO(importRow, column.name(), column.getString(i), dateTimeValue, commit, seasonDbId);
-                if(obsPIO.getBrAPIObject() != null && !obsPIO.getBrAPIObject().getValue().isBlank()) {
-                    this.observationByHash.put(getImportObservationHash(importRow, getVariableNameFromColumn(column)), obsPIO);
-                }
+                this.observationByHash.put(getImportObservationHash(importRow, getVariableNameFromColumn(column)), obsPIO);
             }
         }
     }
@@ -659,8 +657,10 @@ public class ExperimentProcessor implements Processor {
         List<BrAPILocation> newLocations = ProcessorData.getNewObjects(this.locationByName);
         List<BrAPIStudy> newStudies = ProcessorData.getNewObjects(this.studyByNameNoScope);
         List<BrAPIObservationUnit> newObservationUnits = ProcessorData.getNewObjects(this.observationUnitByNameNoScope);
-        List<BrAPIObservation> newObservations = ProcessorData.getNewObjects(this.observationByHash);
-
+        // Do not save observations with no 'value'
+        List<BrAPIObservation> newObservations = ProcessorData.getNewObjects(this.observationByHash).stream()
+                .filter(obs -> !obs.getValue().isBlank())
+                .collect(Collectors.toList());
         try {
             List<BrAPITrial> createdTrials = new ArrayList<>(brapiTrialDAO.createBrAPITrial(newTrials, program.getId(), upload));
             // set the DbId to the for each newly created trial

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -603,7 +603,8 @@ public class ExperimentProcessor implements Processor {
             BrAPIStudy newStudy = importRow.constructBrAPIStudy(program, commit, BRAPI_REFERENCE_SOURCE, expSequenceValue, trialID, id, envNextVal);
 
             if( commit) {
-                String seasonID = this.yearsToSeasonDbId(newStudy.getSeasons(), program.getId());
+                String year = newStudy.getSeasons().get(0); // It is assumed that the study has only one season
+                String seasonID = this.yearToSeasonDbId(year, program.getId());
                 newStudy.setSeasons(Arrays.asList(seasonID));
             }
 
@@ -1056,22 +1057,6 @@ public class ExperimentProcessor implements Processor {
     private boolean validCategory(List<BrAPIScaleValidValuesCategories> categories, String value) {
         Set<String> categoryValues = categories.stream().map(category -> category.getValue().toLowerCase()).collect(Collectors.toSet());
         return categoryValues.contains(value.toLowerCase());
-    }
-
-    /**
-     * Converts year String to SeasonDbId
-     * <br>
-     * NOTE: This assumes that the only Season records of interest are ones
-     * with a blank name or a name that is the same as the year.
-     *
-     * @param years this only looks at the first year of the list.
-     * @param programId the program ID.
-     * @return the DbId of the season-record associated with the first year
-     * of the 'years' list (see NOTE above)
-     */
-    private String yearsToSeasonDbId(List<String> years, UUID programId) {
-        String year = years.get(0);
-        return this.yearToSeasonDbId(year, programId);
     }
 
     /**

--- a/src/main/java/org/breedinginsight/model/Trait.java
+++ b/src/main/java/org/breedinginsight/model/Trait.java
@@ -63,6 +63,7 @@ public class Trait extends TraitEntity {
     private User updatedByUser;
 
     // Properties from brapi
+    private String observationVariableDbId;
     private String traitClass;
     private String traitDescription;
     private String attribute;
@@ -120,7 +121,7 @@ public class Trait extends TraitEntity {
             this.setMainAbbreviation(brApiVariable.getTrait().getMainAbbreviation());
             this.setSynonyms(brApiVariable.getTrait().getSynonyms());
         }
-
+        this.setObservationVariableDbId(brApiVariable.getObservationVariableDbId());
         this.setDefaultValue(brApiVariable.getDefaultValue());
     }
 

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -190,11 +190,17 @@ public class BrAPIDAOUtil {
                     progressUpdateMethod.accept(upload);
                 }
                 ApiResponse response = postMethod.apply(postChunk);
-                if (response.getBody() == null) throw new ApiException("Response is missing body");
+                if (response.getBody() == null) {
+                    throw new ApiException("Response is missing body", response.getStatusCode(), response.getHeaders(), null);
+                }
                 BrAPIResponse body = (BrAPIResponse) response.getBody();
-                if (body.getResult() == null) throw new ApiException("Response body is missing result");
+                if (body.getResult() == null) {
+                    throw new ApiException("Response body is missing result", response.getStatusCode(), response.getHeaders(), response.getBody().toString());
+                }
                 BrAPIResponseResult result = (BrAPIResponseResult) body.getResult();
-                if (result.getData() == null) throw new ApiException("Response result is missing data");
+                if (result.getData() == null) {
+                    throw new ApiException("Response result is missing data", response.getStatusCode(), response.getHeaders(), response.getBody().toString());
+                }
                 List<T> data = result.getData();
                 // TODO: Maybe move this outside of the loop
                 if (data.size() != postChunk.size()) throw new ApiException("Number of brapi objects returned does not equal number sent");


### PR DESCRIPTION
# Description
[BI-1665](https://breedinginsight.atlassian.net/browse/BI-1665)

# Dependencies
sgn:  feture/BI-1665 branch
bi-web: develop branch

# Set Up
in your _sgn_local.conf_ add the key-value pair:
`brapi_observations_require_login 0`

# Testing

1. Import an Experiments & Observation file with at least one phenotype column with the corresponding timestamp column(s).
2. Confirm the import.
3. Insure that the data has been saved in he backing BrAPI server  

# Checklist:

- [x] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1665]: https://breedinginsight.atlassian.net/browse/BI-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ