### PR TITLE
BI-1683 - Missing female parent in biparental cross results in dropped male parent v0.7

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -183,6 +183,8 @@ public class BrAPIGermplasmDAO {
                                 stream().filter(ref -> ref.getReferenceSource().equals(referenceSource)).
                                 map(ref -> ref.getReferenceID()).findFirst().orElse("");
                         additionalInfo.addProperty(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID, femaleParentAccessionNumber);
+                    } else if (germplasm.getAdditionalInfo().has("femaleParentUnknown") && germplasm.getAdditionalInfo().get("femaleParentUnknown").getAsBoolean()) {
+                        namePedigreeString = "Unknown";
                     }
                 }
                 if (parents.size() == 2) {
@@ -197,9 +199,6 @@ public class BrAPIGermplasmDAO {
                     }
                 }
                 //Add Unknown germplasm for display
-                if (germplasm.getAdditionalInfo().has("femaleParentUnknown") && germplasm.getAdditionalInfo().get("femaleParentUnknown").getAsBoolean()) {
-                    namePedigreeString = "Unknown";
-                }
                 if (germplasm.getAdditionalInfo().has("maleParentUnknown") && germplasm.getAdditionalInfo().get("maleParentUnknown").getAsBoolean()) {
                     namePedigreeString += "/Unknown";
                 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -166,6 +166,7 @@ public class BrAPIGermplasmDAO {
                 JsonObject additionalInfo = germplasm.getAdditionalInfo();
                 if(additionalInfo == null) {
                     additionalInfo = new JsonObject();
+                    germplasm.setAdditionalInfo(additionalInfo);
                 }
                 additionalInfo.addProperty(BrAPIAdditionalInfoFields.GERMPLASM_RAW_PEDIGREE, germplasm.getPedigree());
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -82,6 +82,7 @@ public class GermplasmProcessor implements Processor {
     public static String duplicateEntryNoMsg = "Entry numbers must be unique. Duplicated entry numbers found: %s";
     public static String circularDependency = "Circular dependency in the pedigree tree";
     public static String listNameAlreadyExists = "Import group name already exists";
+    public static String missingFemaleParent = "Female parent is missing.  If the female parent is unknown, specify GID or entry number 0 as the female parent";
     public static Function<List<String>, String> arrayOfStringFormatter = (lst) -> {
         List<String> lstCopy = new ArrayList<>(lst);
         Collections.sort(lstCopy);
@@ -259,6 +260,8 @@ public class GermplasmProcessor implements Processor {
                     }
                 }
 
+                validatePedigree(germplasm, i+2, validationErrors);
+
                 // Assign the entry number
                 if (germplasm.getEntryNo() == null) {
                     germplasm.setEntryNo(Integer.toString(i + 1));
@@ -328,6 +331,19 @@ public class GermplasmProcessor implements Processor {
                 "Pedigree Connections", pedigreeConnectStats
         );
 
+    }
+
+    private void validatePedigree(Germplasm germplasm, Integer rowNumber, ValidationErrors validationErrors) {
+        String femaleParentEntryNo = germplasm.getFemaleParentEntryNo();
+        String maleParentEntryNo = germplasm.getMaleParentEntryNo();
+        String femaleParentGID = germplasm.getFemaleParentDBID();
+        String maleParentGID = germplasm.getMaleParentDBID();
+
+        if(StringUtils.isNotBlank(maleParentEntryNo) && StringUtils.isBlank(femaleParentEntryNo) && StringUtils.isBlank(femaleParentGID)) {
+            validationErrors.addError(rowNumber, new ValidationError("Male Parent Entry No", missingFemaleParent, HttpStatus.UNPROCESSABLE_ENTITY));
+        } else if(StringUtils.isNotBlank(maleParentGID) && StringUtils.isBlank(femaleParentEntryNo) && StringUtils.isBlank(femaleParentGID)) {
+            validationErrors.addError(rowNumber, new ValidationError("Male Parent GID", missingFemaleParent, HttpStatus.UNPROCESSABLE_ENTITY));
+        }
     }
 
     private void createPostOrder() {
@@ -441,13 +457,13 @@ public class GermplasmProcessor implements Processor {
             boolean maleParentUnknown = false;
 
             boolean femaleParentFound = false;
-            String pedigreeString = null;
+            StringBuilder pedigreeString = new StringBuilder();
             if (femaleParentDB != null) {
                 if (femaleParentDB.equals("0")) {
                     femaleParentUnknown = true;
                 } else if (germplasmByAccessionNumber.containsKey(femaleParentDB)) {
                     BrAPIGermplasm femaleParent = germplasmByAccessionNumber.get(femaleParentDB).getBrAPIObject();
-                    pedigreeString = commit ? femaleParent.getGermplasmName() : femaleParent.getDefaultDisplayName();
+                    pedigreeString.append(commit ? femaleParent.getGermplasmName() : femaleParent.getDefaultDisplayName());
                     femaleParentFound = true;
                 }
             } else if (femaleParentFile != null) {
@@ -457,7 +473,7 @@ public class GermplasmProcessor implements Processor {
                 else if (germplasmIndexByEntryNo.containsKey(germplasm.getFemaleParentEntryNo())) {
                     Integer femaleParentInd = germplasmIndexByEntryNo.get(femaleParentFile);
                     BrAPIGermplasm femaleParent = mappedBrAPIImport.get(femaleParentInd).getGermplasm().getBrAPIObject();
-                    pedigreeString = commit ? femaleParent.getGermplasmName() : femaleParent.getDefaultDisplayName();
+                    pedigreeString.append(commit ? femaleParent.getGermplasmName() : femaleParent.getDefaultDisplayName());
                     femaleParentFound = true;
                 }
             }
@@ -469,7 +485,7 @@ public class GermplasmProcessor implements Processor {
                     }
                     if ((germplasmByAccessionNumber.containsKey(germplasm.getMaleParentDBID()))) {
                         BrAPIGermplasm maleParent = germplasmByAccessionNumber.get(maleParentDB).getBrAPIObject();
-                        if (!femaleParentUnknown) pedigreeString += String.format("/%s", commit ? maleParent.getGermplasmName() : maleParent.getDefaultDisplayName());
+                        pedigreeString.append(String.format("/%s", commit ? maleParent.getGermplasmName() : maleParent.getDefaultDisplayName()));
                     }
                 } else if (maleParentFile != null){
                     if (maleParentFile.equals("0")) {
@@ -478,11 +494,11 @@ public class GermplasmProcessor implements Processor {
                     if (germplasmIndexByEntryNo.containsKey(germplasm.getMaleParentEntryNo())) {
                         Integer maleParentInd = germplasmIndexByEntryNo.get(maleParentFile);
                         BrAPIGermplasm maleParent = mappedBrAPIImport.get(maleParentInd).getGermplasm().getBrAPIObject();
-                        if (!femaleParentUnknown) pedigreeString += String.format("/%s", commit ? maleParent.getGermplasmName() : maleParent.getDefaultDisplayName());
+                        pedigreeString.append(String.format("/%s", commit ? maleParent.getGermplasmName() : maleParent.getDefaultDisplayName()));
                     }
                 }
             }
-            mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().setPedigree(pedigreeString);
+            mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().setPedigree(pedigreeString.length() > 0 ? pedigreeString.toString() : null);
             //Simpler to just always add boolean, but consider for logic that previous imported values won't have that additional info value
             mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem("femaleParentUnknown", femaleParentUnknown);
             mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem("maleParentUnknown", maleParentUnknown);

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmTemplateMap.java
@@ -354,7 +354,7 @@ public class GermplasmTemplateMap extends BrAPITest {
 
     @Test
     @SneakyThrows
-    public void NoFemaleParentBlankPedigreeStringSuccess() {
+    public void OnlyMaleParentPreviewSuccess() {
         File file = new File("src/test/resources/files/germplasm_import/no_female_parent_blank_pedigree.csv");
 
         Flowable<HttpResponse<String>> call = uploadDataFile(file, "NoFemaleParentList", null, true);
@@ -369,7 +369,8 @@ public class GermplasmTemplateMap extends BrAPITest {
         JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
         for (int i = 0; i < previewRows.size(); i++) {
             JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
-            assertTrue(!germplasm.has("pedigree"), "Pedigree string is populated, but should be empty");
+            assertTrue(germplasm.has("pedigree"), "Pedigree string should be populated, but is empty");
+            assertTrue(germplasm.get("pedigree").getAsString().substring(1).length() > 0, "Male pedigree string should be populated, but is empty");
         }
     }
 

--- a/src/test/resources/files/germplasm_import/no_female_parent_blank_pedigree.csv
+++ b/src/test/resources/files/germplasm_import/no_female_parent_blank_pedigree.csv
@@ -1,4 +1,4 @@
 ﻿Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID,Synonyms
-Germplasm 1,BCR,Wild,,2,,,,1234,
-Germplasm 2,BCR,Wild,,3,,,,5678,
-Germplasm 3,BCR,Wild,,3,,,,9123,
+Germplasm 1,BCR,Wild,0,2,,,,1234,
+Germplasm 2,BCR,Wild,0,3,,,,5678,
+Germplasm 3,BCR,Wild,0,3,,,,9123,


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1683

Added a validation to check if a female parent is provided when only a male parent is provided.  Also allowing only a male parent to be saved when persisting to the BrAPI server

# Dependencies
SGN - https://github.com/Breeding-Insight/sgn/pull/94

# Testing
[Germ_BI-1683.xls](https://github.com/Breeding-Insight/bi-api/files/10290484/Germ_BI-1683.xls)
The attached file has two germplasm records with only a male parent defined (and `0` for the female parent).

- Upload a file with only a male parent defined and no female parent defined.  Ensure an error is returned stating a female parent must be defined
- Upload a file with a male parent defined, and a female parent of `0`.  Ensure the preview works, and then you are able to confirm the import.  After import, confirm the persisted germplasm has the correct pedigree when viewing the germplasm detail page and the all germplasm table


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase - just tested with BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1683]: https://breedinginsight.atlassian.net/browse/BI-1683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-1683]: https://breedinginsight.atlassian.net/browse/BI-1683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-1683]: https://breedinginsight.atlassian.net/browse/BI-1683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ