### PR TITLE
BI-1548 - Experiments: User and Creation Date Refinement

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/model/request/query/ExperimentQuery.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/model/request/query/ExperimentQuery.java
@@ -15,6 +15,8 @@ import java.util.List;
 public class ExperimentQuery extends BrapiQuery {
     private String name;
     private String active;
+    private String createdBy;
+    private String createdDate;
 
     public SearchRequest constructSearchRequest() {
         List<FilterRequest> filters = new ArrayList<>();
@@ -23,6 +25,12 @@ public class ExperimentQuery extends BrapiQuery {
         }
         if (!StringUtils.isBlank(getActive())) {
             filters.add(constructFilterRequest("active", getActive()));
+        }
+        if (!StringUtils.isBlank(getCreatedBy())) {
+            filters.add(constructFilterRequest("createdBy", getCreatedBy()));
+        }
+        if (!StringUtils.isBlank(getCreatedDate())) {
+            filters.add(constructFilterRequest("createdDate", getCreatedDate()));
         }
         return new SearchRequest(filters);
     }

--- a/src/main/java/org/breedinginsight/utilities/response/mappers/ExperimentQueryMapper.java
+++ b/src/main/java/org/breedinginsight/utilities/response/mappers/ExperimentQueryMapper.java
@@ -17,6 +17,7 @@
 
 package org.breedinginsight.utilities.response.mappers;
 
+import com.google.gson.JsonObject;
 import lombok.Getter;
 import org.brapi.v2.model.core.BrAPITrial;
 import org.breedinginsight.api.v1.controller.metadata.SortOrder;
@@ -37,7 +38,13 @@ public class ExperimentQueryMapper extends AbstractQueryMapper {
     public ExperimentQueryMapper() {
         fields = Map.ofEntries(
                 Map.entry("name", BrAPITrial::getTrialName),
-                Map.entry("active", BrAPITrial::isActive)
+                Map.entry("active", BrAPITrial::isActive),
+                Map.entry("createdDate",
+                        brAPITrial -> brAPITrial.getAdditionalInfo().get("createdDate").getAsString()),
+                Map.entry("createdBy",
+                        brAPITrial -> brAPITrial.getAdditionalInfo()
+                        .get("createdBy").getAsJsonObject()
+                        .get("userName").getAsString())
         );
     }
 
@@ -51,4 +58,6 @@ public class ExperimentQueryMapper extends AbstractQueryMapper {
         if (fields.containsKey(fieldName)) return fields.get(fieldName);
         else throw new NullPointerException();
     }
+
+
 }


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1548?atlOrigin=eyJpIjoiMDU3NTE2YWExOTFlNGMxZWJlOTA2N2Y2YWRhOWY3NDYiLCJwIjoiaiJ9

- Added createdBy and createDate experiment filtering

# Dependencies
- bi-web BI-1548

# Testing
- Test sorting and filtering for experiments CreatedBy and createDate

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
