### PR TITLE
BI-1440 - ISSUE: ERROR message in banner calls out "scale data type" when field is "scale class"

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2208,7 +2208,7 @@ paths:
                         httpStatus: "CONFLICT"
                         httpStatusCode: 409
                       - field: "scale.dataType"
-                        errorMessage: "Missing scale data type"
+                        errorMessage: "Missing scale class"
                         httpStatus: "UNPROCESSABLE_ENTITY"
                         httpStatusCode: 422
                       - field: "scale.categories"
@@ -2346,7 +2346,7 @@ paths:
                         httpStatus: "CONFLICT"
                         httpStatusCode: 409
                       - field: "scale.dataType"
-                        errorMessage: "Missing scale data type"
+                        errorMessage: "Missing scale class"
                         httpStatus: "UNPROCESSABLE_ENTITY"
                         httpStatusCode: 422
                       - field: "scale.categories"

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
@@ -62,7 +62,7 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getMissingScaleDataTypeMsg() {
-        return new ValidationError("scale.dataType", "Missing scale data type", HttpStatus.BAD_REQUEST);
+        return new ValidationError("scale.dataType", "Missing scale class", HttpStatus.BAD_REQUEST);
     }
 
     @Override


### PR DESCRIPTION
# Description
**Story:** [_Please include a link to the story in Jira_](https://breedinginsight.atlassian.net/browse/BI-1440?atlOrigin=eyJpIjoiZmRjZDRmMWMzNzJhNDhjMGJhMzlhYzY4ZDU4YTYzZmEiLCJwIjoiaiJ9)

- Changed scale datatype to scale class in message

# Dependencies
- bi-web develop

# Testing
- Follow process in JIRA card and verify error message is as expected.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
