### PR TITLE
Check for empty pedigree female parent

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -135,8 +135,12 @@ public class BrAPIGermplasmService {
 
             if ((germplasmEntry.getPedigree() != null) && (!germplasmEntry.getPedigree().isEmpty())) {
                 Pedigree germPedigree = Pedigree.parsePedigreeString(germplasmEntry.getPedigree());
-                row.put("Female Parent GID", Integer.parseInt(germPedigree.femaleParent));
-                if (!germPedigree.maleParent.isEmpty()) row.put("Male Parent GID", Integer.parseInt(germPedigree.maleParent));
+                if (!germPedigree.maleParent.isEmpty()) {
+                    row.put("Male Parent GID", Integer.parseInt(germPedigree.maleParent));
+                }
+                if (!germPedigree.femaleParent.isEmpty()) {
+                    row.put("Female Parent GID", Integer.parseInt(germPedigree.femaleParent));
+                }
             }
 
             // Synonyms


### PR DESCRIPTION
# Description
**Story:** [BI-1129](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1129)

The germplasm processor was only checking for a possible empty value of the male pedigree parent. A check was put in place for the female parent as well.



# Dependencies
bi-web: develop

# Testing
Import germplasm where one of the accessions references a male parent but has a value of 0 entered for the gid of the female parent. Download the list and verify the contents of the download are correct.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1129]: https://breedinginsight.atlassian.net/browse/BI-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ