### PR TITLE
[BI-1629] Add filtering to Ontology Table

### DIFF
--- a/src/main/java/org/breedinginsight/api/model/v1/request/query/TraitsQuery.java
+++ b/src/main/java/org/breedinginsight/api/model/v1/request/query/TraitsQuery.java
@@ -19,9 +19,117 @@ package org.breedinginsight.api.model.v1.request.query;
 
 import io.micronaut.core.annotation.Introspected;
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Introspected
 public class TraitsQuery extends QueryParams {
+    private String name;
+    private String traitDescription;
+    private String entityAttribute;
+    private String mainAbbreviation;
+    private String synonyms;
+    private String level;
+    private String status;
+    private String methodDescription;
+    private String methodClass;
+    private String methodFormula;
+    private String scaleName;
+    private String scaleClass;
+    private String scaleDecimalPlaces;
+    private String scaleLowerLimit;
+    private String scaleUpperLimit;
+    private String scaleCategories;
+    private String createdAt;
+    private String updatedAt;
+    private String createdByUserId;
+    private String createdByUserName;
+    private String updatedByUserId;
+    private String updatedByUserName;
+    private String termType;
+
+    public SearchRequest constructSearchRequest() {
+        List<FilterRequest> filters = new ArrayList<>();
+        if (!StringUtils.isBlank(getName())) {
+            filters.add(constructFilterRequest("name", getName()));
+        }
+        if (!StringUtils.isBlank(getTraitDescription())) {
+            filters.add(constructFilterRequest("traitDescription", getTraitDescription()));
+        }
+        if (!StringUtils.isBlank(getEntityAttribute())) {
+            filters.add(constructFilterRequest("entityAttribute", getEntityAttribute()));
+        }
+        if (!StringUtils.isBlank(getMainAbbreviation())) {
+            filters.add(constructFilterRequest("mainAbbreviation", getMainAbbreviation()));
+        }
+        if (!StringUtils.isBlank(getSynonyms())) {
+            filters.add(constructFilterRequest("synonyms", getSynonyms()));
+        }
+        if (!StringUtils.isBlank(getLevel())) {
+            filters.add(constructFilterRequest("level", getLevel()));
+        }
+        if (!StringUtils.isBlank(getStatus())) {
+            filters.add(constructFilterRequest("status", getStatus()));
+        }
+        if (!StringUtils.isBlank(getMethodDescription())) {
+            filters.add(constructFilterRequest("methodDescription", getMethodDescription()));
+        }
+        if (!StringUtils.isBlank(getMethodClass())) {
+            filters.add(constructFilterRequest("methodClass", getMethodClass()));
+        }
+        if (!StringUtils.isBlank(getMethodFormula())) {
+            filters.add(constructFilterRequest("methodFormula", getMethodFormula()));
+        }
+        if (!StringUtils.isBlank(getScaleName())) {
+            filters.add(constructFilterRequest("scaleName", getScaleName()));
+        }
+        if (!StringUtils.isBlank(getScaleClass())) {
+            filters.add(constructFilterRequest("scaleClass", getScaleClass()));
+        }
+        if (!StringUtils.isBlank(getScaleDecimalPlaces())) {
+            filters.add(constructFilterRequest("scaleDecimalPlaces", getScaleDecimalPlaces()));
+        }
+        if (!StringUtils.isBlank(getScaleLowerLimit())) {
+            filters.add(constructFilterRequest("scaleLowerLimit", getScaleLowerLimit()));
+        }
+        if (!StringUtils.isBlank(getScaleUpperLimit())) {
+            filters.add(constructFilterRequest("scaleUpperLimit", getScaleUpperLimit()));
+        }
+        if (!StringUtils.isBlank(getScaleCategories())) {
+            filters.add(constructFilterRequest("scaleCategories", getScaleCategories()));
+        }
+        if (!StringUtils.isBlank(getCreatedAt())) {
+            filters.add(constructFilterRequest("createdAt", getCreatedAt()));
+        }
+        if (!StringUtils.isBlank(getUpdatedAt())) {
+            filters.add(constructFilterRequest("updatedAt", getUpdatedAt()));
+        }
+        if (!StringUtils.isBlank(getCreatedByUserId())) {
+            filters.add(constructFilterRequest("createdByUserId", getCreatedByUserId()));
+        }
+        if (!StringUtils.isBlank(getCreatedByUserName())) {
+            filters.add(constructFilterRequest("createdByUserName", getCreatedByUserName()));
+        }
+        if (!StringUtils.isBlank(getUpdatedByUserId())) {
+            filters.add(constructFilterRequest("updatedByUserId", getUpdatedByUserId()));
+        }
+        if (!StringUtils.isBlank(getUpdatedByUserName())) {
+            filters.add(constructFilterRequest("updatedByUserName", getUpdatedByUserName()));
+        }
+        if (!StringUtils.isBlank(getTermType())) {
+            filters.add(constructFilterRequest("termType", getTermType()));
+        }
+        return new SearchRequest(filters);
+    }
+    private FilterRequest constructFilterRequest(String field, String value) {
+        return FilterRequest.builder()
+                .field(field)
+                .value(value)
+                .build();
+    }
+
+
     Boolean full = false;
 }

--- a/src/main/java/org/breedinginsight/api/model/v1/request/query/TraitsQuery.java
+++ b/src/main/java/org/breedinginsight/api/model/v1/request/query/TraitsQuery.java
@@ -36,6 +36,7 @@ public class TraitsQuery extends QueryParams {
     private String methodDescription;
     private String methodClass;
     private String methodFormula;
+    private String methodHandle;
     private String scaleName;
     private String scaleClass;
     private String scaleDecimalPlaces;
@@ -81,6 +82,9 @@ public class TraitsQuery extends QueryParams {
         }
         if (!StringUtils.isBlank(getMethodFormula())) {
             filters.add(constructFilterRequest("methodFormula", getMethodFormula()));
+        }
+        if (!StringUtils.isBlank(getMethodHandle())) {
+            filters.add(constructFilterRequest("methodHandle", getMethodHandle()));
         }
         if (!StringUtils.isBlank(getScaleName())) {
             filters.add(constructFilterRequest("scaleName", getScaleName()));

--- a/src/main/java/org/breedinginsight/api/v1/controller/TraitController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/TraitController.java
@@ -81,7 +81,8 @@ public class TraitController {
 
         try {
             List<Trait> traits = ontologyService.getTraitsByProgramId(programId, traitsQuery.getFull());
-            return ResponseUtils.getQueryResponse(traits, traitQueryMapper, traitsQuery);
+            SearchRequest searchRequest = traitsQuery.constructSearchRequest();
+            return ResponseUtils.getQueryResponse(traits, traitQueryMapper, searchRequest, traitsQuery);
         } catch (DoesNotExistException e) {
             return HttpResponse.notFound();
         }

--- a/src/main/java/org/breedinginsight/utilities/response/mappers/TraitQueryMapper.java
+++ b/src/main/java/org/breedinginsight/utilities/response/mappers/TraitQueryMapper.java
@@ -48,6 +48,9 @@ public class TraitQueryMapper extends AbstractQueryMapper {
                         trait -> trait.getMethod() != null ? trait.getMethod().getMethodClass() : null),
                 Map.entry("methodFormula",
                         trait -> trait.getMethod() != null ? trait.getMethod().getFormula() : null),
+                Map.entry("methodHandle",
+                        trait -> trait.getMethod() != null ?
+                                trait.getMethod().getDescription() + " " + trait.getMethod().getMethodClass() : null ),
                 Map.entry("scaleName",
                         trait -> trait.getScale() != null ? trait.getScale().getScaleName() : null),
                 Map.entry("scaleClass",


### PR DESCRIPTION
# Description
**Story:** [BI-1629](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1629)

`TraitsQuery#constructSearchRequest` was created and called in the GET /traits controller of `TraitsController`.
The query params and search request are then passed to the same `ResponseUtils` method used by POST /traits for returning filtered traits.



# Dependencies
none

# Testing
call `GET /traits?<field>=<value>` using a searchable field for traits and verify only filtered traits returned.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1629]: https://breedinginsight.atlassian.net/browse/BI-1629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ