### PR TITLE
BI-1741 - Genotype Import

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,8 @@ services:
       GIGWA.serversAllowedToImport: ${BRAPI_REFERENCE_SOURCE}
     networks:
       backend:
+        aliases:
+          - gigwa
     volumes:
       - type: volume
         source: gigwa_data
@@ -154,6 +156,8 @@ services:
         target: /data/db
     networks:
       backend:
+        aliases:
+          - gigwa_db
   localstack:
     container_name: "localstack"
     image: localstack/localstack

--- a/src/main/java/org/breedinginsight/api/v1/controller/ProgramController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ProgramController.java
@@ -59,6 +59,7 @@ import java.util.UUID;
 
 @Slf4j
 @Controller("/${micronaut.bi.api.version}")
+@Secured(SecurityRule.IS_AUTHENTICATED)
 public class ProgramController {
 
     private ProgramService programService;
@@ -87,7 +88,6 @@ public class ProgramController {
 
     @Get("/programs{?queryParams*}")
     @Produces(MediaType.APPLICATION_JSON)
-    @Secured(SecurityRule.IS_AUTHENTICATED)
     public HttpResponse<Response<DataResponse<Program>>> getPrograms(
             @QueryValue @QueryValid(using = ProgramQueryMapper.class) @Valid QueryParams queryParams) {
 
@@ -97,7 +97,6 @@ public class ProgramController {
 
     @Post("/programs/search{?queryParams*}")
     @Produces(MediaType.APPLICATION_JSON)
-    @Secured(SecurityRule.IS_ANONYMOUS)
     public HttpResponse<Response<DataResponse<Program>>> postProgramsSearch(
             @QueryValue @QueryValid(using = ProgramQueryMapper.class) @Valid QueryParams queryParams,
             @Body @SearchValid(using = ProgramQueryMapper.class) SearchRequest searchRequest) {

--- a/src/main/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImpl.java
+++ b/src/main/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImpl.java
@@ -470,10 +470,15 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
         }
         CallsApi callsApi = brAPIEndpointProvider.get(genoBrAPIClient, CallsApi.class);
 
-        BrAPICallsSearchRequest searchRequest = new BrAPICallsSearchRequest();
-        searchRequest.setCallSetDbIds(callSets.stream().map(BrAPICallSet::getCallSetDbId).collect(Collectors.toList()));
+        List<BrAPICall> calls = new ArrayList<>();
+        for(BrAPICallSet callSet : callSets) {
+            BrAPICallsSearchRequest searchRequest = new BrAPICallsSearchRequest();
+            searchRequest.setCallSetDbIds(List.of(callSet.getCallSetDbId()));
 
-        return brAPIDAOUtil.searchWithToken(callsApi::searchCallsPost, callsApi::searchCallsSearchResultsDbIdGet, searchRequest); //breaking bc this uses a pageToken instead of page#
+            calls.addAll(brAPIDAOUtil.searchWithToken(callsApi::searchCallsPost, callsApi::searchCallsSearchResultsDbIdGet, searchRequest)); //breaking bc this uses a pageToken instead of page#
+        }
+
+        return calls;
     }
 
     private List<BrAPIVariant> fetchVariants(BrAPIClient genoBrAPIClient, List<BrAPICall> calls) throws ApiException {

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -167,7 +167,7 @@ public class BrAPIDAOUtil {
             //NOTE: Because of the way Breedbase implements BrAPI searches, the page size is initially set to an
             //arbitrary, large value to ensure that in the event that a 202 response is returned, the searchDbId
             //stored will refer to all records of the BrAPI variable.
-            searchBody.pageSize(1000);
+            searchBody.pageSize(pageSize);
             ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>> response = searchMethod.apply(searchBody);
             if (response.getBody().getLeft().isPresent()) {
                 BrAPIResponse listResponse = (BrAPIResponse) response.getBody().getLeft().get();

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -167,7 +167,7 @@ public class BrAPIDAOUtil {
             //NOTE: Because of the way Breedbase implements BrAPI searches, the page size is initially set to an
             //arbitrary, large value to ensure that in the event that a 202 response is returned, the searchDbId
             //stored will refer to all records of the BrAPI variable.
-            searchBody.pageSize(10000000);
+            searchBody.pageSize(1000);
             ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>> response = searchMethod.apply(searchBody);
             if (response.getBody().getLeft().isPresent()) {
                 BrAPIResponse listResponse = (BrAPIResponse) response.getBody().getLeft().get();
@@ -187,6 +187,26 @@ public class BrAPIDAOUtil {
                                     .getLeft()
                                     .isPresent()) {
                             listResult.addAll(getListResult(response));
+                            listResponse = (BrAPIResponse) response.getBody().getLeft().get();
+                            nextPageToken = ((BrAPITokenPagination) listResponse.getMetadata()
+                                                                                .getPagination()).getNextPageToken();
+                        } else {
+                            nextPageToken = null;
+                        }
+                    }
+                } else if(listResponse.getMetadata().getPagination() instanceof BrAPIIndexPagination) {
+                    if(hasMorePages(listResponse)) {
+                        int currentPage = listResponse.getMetadata().getPagination().getCurrentPage() + 1;
+                        int totalPages = listResponse.getMetadata().getPagination().getTotalPages();
+
+                        while (currentPage < totalPages) {
+                            searchBody.setPage(currentPage);
+                            response = searchMethod.apply(searchBody);
+                            if (response.getBody().getLeft().isPresent()) {
+                                listResult.addAll(getListResult(response));
+                            }
+
+                            currentPage++;
                         }
                     }
                 }

--- a/src/test/java/org/breedinginsight/api/v1/controller/BreedingMethodControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/BreedingMethodControllerIntegrationTest.java
@@ -13,7 +13,9 @@ import io.micronaut.http.netty.cookies.NettyCookie;
 import io.micronaut.test.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.client.v2.typeAdapters.PaginationTypeAdapter;
 import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.BrAPIPagination;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.breedinginsight.BrAPITest;
 import org.breedinginsight.TestUtils;
@@ -79,6 +81,7 @@ public class BreedingMethodControllerIntegrationTest extends BrAPITest {
 
     private Gson gson = new GsonBuilder().registerTypeAdapter(OffsetDateTime.class, (JsonDeserializer<OffsetDateTime>)
                                                  (json, type, context) -> OffsetDateTime.parse(json.getAsString()))
+                                         .registerTypeAdapter(BrAPIPagination.class, new PaginationTypeAdapter())
                                          .create();
 
     @BeforeAll

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ControllerIntegrationTest.java
@@ -28,7 +28,9 @@ import io.micronaut.http.client.annotation.Client;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import lombok.SneakyThrows;
+import org.brapi.client.v2.typeAdapters.PaginationTypeAdapter;
 import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.BrAPIPagination;
 import org.brapi.v2.model.core.BrAPIServerInfo;
 import org.brapi.v2.model.core.BrAPIStudy;
 import org.brapi.v2.model.core.response.BrAPIStudyListResponse;
@@ -72,6 +74,7 @@ public class BrAPIV2ControllerIntegrationTest extends BrAPITest {
 
     private Gson GSON = new GsonBuilder().registerTypeAdapter(OffsetDateTime.class, (JsonDeserializer<OffsetDateTime>)
             (json, type, context) -> OffsetDateTime.parse(json.getAsString()))
+            .registerTypeAdapter(BrAPIPagination.class, new PaginationTypeAdapter())
                                          .create();
 
     @Inject

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -29,7 +29,9 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import lombok.SneakyThrows;
 import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.client.v2.typeAdapters.PaginationTypeAdapter;
 import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.BrAPIPagination;
 import org.brapi.v2.model.core.BrAPISeason;
 import org.brapi.v2.model.core.BrAPIStudy;
 import org.brapi.v2.model.core.BrAPITrial;
@@ -142,6 +144,7 @@ public class ExperimentFileImportTest extends BrAPITest {
 
     private Gson gson = new GsonBuilder().registerTypeAdapter(OffsetDateTime.class, (JsonDeserializer<OffsetDateTime>)
                                                  (json, type, context) -> OffsetDateTime.parse(json.getAsString()))
+                                         .registerTypeAdapter(BrAPIPagination.class, new PaginationTypeAdapter())
                                          .create();
 
     @BeforeAll

--- a/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
@@ -71,7 +71,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jooq.Configuration;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.*;
-import org.mockito.invocation.InvocationOnMock;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -194,7 +193,7 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
 
     @MockBean(BrAPIDAOUtil.class)
     BrAPIDAOUtil brAPIDAOUtil() {
-        return mock(BrAPIDAOUtil.class);
+        return spy(new BrAPIDAOUtil(1000, Duration.of(10, ChronoUnit.MINUTES), 1000, 100));
     }
 
     @MockBean(SimpleStorageService.class)
@@ -272,7 +271,7 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
     }
 
     @BeforeAll
-    public void setup() {
+    public void setup() throws IllegalAccessException, NoSuchFieldException {
         applicationContext.registerSingleton((BeanCreatedEventListener<SimpleStorageServiceConfiguration>) event -> {
             SimpleStorageServiceConfiguration conf = event.getBean();
             if (conf.getEndpoint() != null) {
@@ -365,8 +364,6 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
             }
         }).when(brAPIDAOUtil)
           .search(any(Function.class), any(Function3.class), any());
-
-        doAnswer(InvocationOnMock::callRealMethod).when(brAPIDAOUtil).searchWithToken(any(Function.class), any(Function3.class), any());
 
         doReturn(new BrAPIClient("", 300000)).when(programDAO).getCoreClient(any(UUID.class));
         doReturn(new BrAPIClient("", 300000)).when(programDAO).getPhenoClient(any(UUID.class));


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1741

Updating how calls are fetched to prevent duplication of calls when there is more than one callset per germplasm



# Dependencies
bi-web bug/BI-1741
brapi bug/BI-1741
Mgdb2BrapiV2Impl bug/BI-1741

# Testing
Test using instructions from [BI-1650](https://breedinginsight.atlassian.net/browse/BI-1650)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1650]: https://breedinginsight.atlassian.net/browse/BI-1650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ