### PR TITLE
[BI-1193] Associate phenotypes with experiment observation dataset

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
@@ -40,4 +40,5 @@ public final class BrAPIAdditionalInfoFields {
     public static final String EXPERIMENT_NUMBER = "experimentNumber";
     public static final String ENVIRONMENT_NUMBER = "environmentNumber";
     public static final String STUDY_NAME = "studyName";
+    public static final String OBSERVATION_DATASET_ID = "observationDatasetId";
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIListDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIListDAO.java
@@ -124,14 +124,14 @@ public class BrAPIListDAO {
         if(response != null) {
             BrAPIListsSingleResponse body = response.getBody();
             if (body == null) {
-                throw new ApiException("Response is missing body");
+                throw new ApiException("Response is missing body", 0, response.getHeaders(), null);
             }
             BrAPIListDetails result = body.getResult();
             if (result == null) {
-                throw new ApiException("Response body is missing result");
+                throw new ApiException("Response body is missing result", 0, response.getHeaders(), response.getBody().toString());
             }
             if (result.getData() == null) {
-                throw new ApiException("Response result is missing data");
+                throw new ApiException("Response result is missing data", 0, response.getHeaders(), response.getBody().toString());
             }
             return result.getData();
         }
@@ -152,14 +152,14 @@ public class BrAPIListDAO {
         if(response != null) {
             BrAPIResponse<BrAPIListsListResponseResult> body = response.getBody();
             if (body == null) {
-                throw new ApiException("Response is missing body");
+                throw new ApiException("Response is missing body", 0, response.getHeaders(), null);
             }
             BrAPIResponseResult<BrAPIListSummary> result = body.getResult();
             if (result == null) {
-                throw new ApiException("Response body is missing result");
+                throw new ApiException("Response body is missing result", 0, response.getHeaders(), response.getBody().toString());
             }
             if (result.getData() == null) {
-                throw new ApiException("Response result is missing data");
+                throw new ApiException("Response result is missing data", 0, response.getHeaders(), response.getBody().toString());
             }
             return result.getData();
         }

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIListDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIListDAO.java
@@ -12,6 +12,8 @@ import org.brapi.v2.model.core.BrAPIListSummary;
 import org.brapi.v2.model.core.BrAPIListTypes;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.core.request.BrAPIListSearchRequest;
+import org.brapi.v2.model.core.response.BrAPIListsListResponse;
+import org.brapi.v2.model.core.response.BrAPIListsListResponseResult;
 import org.brapi.v2.model.core.response.BrAPIListsSingleResponse;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
@@ -98,10 +100,10 @@ public class BrAPIListDAO {
         return filteredLists;
     }
 
-    public List<BrAPIObservation> createBrAPILists(List<BrAPIListNewRequest> brapiLists, UUID programId, ImportUpload upload) throws ApiException {
+    public List<BrAPIListSummary> createBrAPILists(List<BrAPIListNewRequest> brapiLists, UUID programId, ImportUpload upload) throws ApiException {
         ListsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ListsApi.class);
         // Do manually, it doesn't like List<Object> to List<BrAPIListNewRequest> for some reason
-        ApiResponse response;
+        ApiResponse<BrAPIListsListResponse> response;
         try {
             response = api.listsPost(brapiLists);
         } catch (ApiException e) {
@@ -109,11 +111,11 @@ public class BrAPIListDAO {
             throw e;
         }
         if(response != null) {
-            BrAPIResponse body = (BrAPIResponse) response.getBody();
+            BrAPIResponse<BrAPIListsListResponseResult> body = response.getBody();
             if (body == null) {
                 throw new ApiException("Response is missing body");
             }
-            BrAPIResponseResult result = (BrAPIResponseResult) body.getResult();
+            BrAPIResponseResult<BrAPIListSummary> result = body.getResult();
             if (result == null) {
                 throw new ApiException("Response body is missing result");
             }

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIListDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIListDAO.java
@@ -97,19 +97,32 @@ public class BrAPIListDAO {
         }
         return filteredLists;
     }
-    public List<String> updateBrAPIList(String brAPIListDbId, List<String> data, UUID programId) throws ApiException {
+    public List<String> updateBrAPIList(String brAPIListDbId, BrAPIListDetails mutatedList, UUID programId) throws ApiException {
         ListsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ListsApi.class);
+        BrAPIListNewRequest request = new BrAPIListNewRequest();
+        request.setAdditionalInfo(mutatedList.getAdditionalInfo());
+        request.setDateCreated(mutatedList.getDateCreated());
+        request.setDateModified(mutatedList.getDateModified());
+        request.setExternalReferences(mutatedList.getExternalReferences());
+        request.setListDescription(mutatedList.getListDescription());
+        request.setListName(mutatedList.getListName());
+        request.setListOwnerName(mutatedList.getListOwnerName());
+        request.setListOwnerPersonDbId(mutatedList.getListOwnerPersonDbId());
+        request.setListSize(mutatedList.getListSize());
+        request.setListSource(mutatedList.getListSource());
+        request.setListType(mutatedList.getListType());
+        request.setData(mutatedList.getData());
 
         // Do manually, it doesn't like List<Object> to List<BrAPIListNewRequest> for some reason
-        ApiResponse<BrAPIListResponse> response;
+        ApiResponse<BrAPIListsSingleResponse> response;
         try {
-            response = api.listsListDbIdItemsPost(brAPIListDbId, data);
+            response = api.listsListDbIdPut(brAPIListDbId, request);
         } catch (ApiException e) {
-            log.warn(Utilities.generateApiExceptionLogMessage(e));
+            log.error(Utilities.generateApiExceptionLogMessage(e));
             throw e;
         }
         if(response != null) {
-            BrAPIListResponse body = response.getBody();
+            BrAPIListsSingleResponse body = response.getBody();
             if (body == null) {
                 throw new ApiException("Response is missing body");
             }

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
@@ -21,6 +21,9 @@ import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.core.TrialsApi;
 import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.core.request.BrAPITrialSearchRequest;
+import org.brapi.v2.model.core.response.BrAPIListDetails;
+import org.brapi.v2.model.core.response.BrAPIListResponse;
+import org.brapi.v2.model.core.response.BrAPITrialSingleResponse;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.daos.ProgramDAO;
@@ -76,7 +79,10 @@ public class BrAPITrialDAO {
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
         return brAPIDAOUtil.post(brAPITrialList, upload, api::trialsPost, importDAO::update);
     }
-
+    public List<BrAPITrial> updateBrAPITrial(String trialDbId, BrAPITrial trial, UUID programId) {
+        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
+        return brAPIDAOUtil.put(trialDbId, trial, api::trialsTrialDbIdPut);
+    }
     /**
      * Fetch formatted trials/experiments for this program
      * @param programId

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
@@ -79,7 +79,7 @@ public class BrAPITrialDAO {
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
         return brAPIDAOUtil.post(brAPITrialList, upload, api::trialsPost, importDAO::update);
     }
-    public List<BrAPITrial> updateBrAPITrial(String trialDbId, BrAPITrial trial, UUID programId) {
+    public BrAPITrial updateBrAPITrial(String trialDbId, BrAPITrial trial, UUID programId) throws ApiException {
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
         return brAPIDAOUtil.put(trialDbId, trial, api::trialsTrialDbIdPut);
     }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -206,6 +206,7 @@ public class ExperimentObservation implements BrAPIImport {
         BrAPIListDetails dataSetDetails = new BrAPIListDetails();
         dataSetDetails.setListName(name);
         dataSetDetails.setListType(BrAPIListTypes.OBSERVATIONVARIABLES);
+        dataSetDetails.setData(new ArrayList<>());
         List<BrAPIExternalReference> refs = new ArrayList<>();
         addReference(refs, program.getId(), referenceSourceBase, ExternalReferenceSource.PROGRAMS);
         addReference(refs, UUID.fromString(trialID), referenceSourceBase, ExternalReferenceSource.TRIALS);

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -200,17 +200,19 @@ public class ExperimentObservation implements BrAPIImport {
 
     public BrAPIListDetails constructDatasetDetails(
             String name,
-            UUID datasetID,
+            UUID datasetId,
             String referenceSourceBase,
-            Program program, String trialID) {
+            Program program, String trialId) {
         BrAPIListDetails dataSetDetails = new BrAPIListDetails();
         dataSetDetails.setListName(name);
         dataSetDetails.setListType(BrAPIListTypes.OBSERVATIONVARIABLES);
         dataSetDetails.setData(new ArrayList<>());
+        dataSetDetails.putAdditionalInfoItem("datasetType", "observationDataset");
         List<BrAPIExternalReference> refs = new ArrayList<>();
         addReference(refs, program.getId(), referenceSourceBase, ExternalReferenceSource.PROGRAMS);
-        addReference(refs, UUID.fromString(trialID), referenceSourceBase, ExternalReferenceSource.TRIALS);
-        addReference(refs, datasetID, referenceSourceBase, ExternalReferenceSource.DATASET);
+        addReference(refs, UUID.fromString(trialId), referenceSourceBase, ExternalReferenceSource.TRIALS);
+        addReference(refs, datasetId, referenceSourceBase, ExternalReferenceSource.DATASET);
+        dataSetDetails.setExternalReferences(refs);
         return dataSetDetails;
     }
     public BrAPIObservationUnit constructBrAPIObservationUnit(

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -22,6 +22,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.*;
+import org.brapi.v2.model.core.response.BrAPIListDetails;
 import org.brapi.v2.model.pheno.*;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapps.importer.model.config.*;
@@ -197,6 +198,20 @@ public class ExperimentObservation implements BrAPIImport {
         return study;
     }
 
+    public BrAPIListDetails constructDatasetDetails(
+            String name,
+            UUID datasetID,
+            String referenceSourceBase,
+            Program program, String trialID) {
+        BrAPIListDetails dataSetDetails = new BrAPIListDetails();
+        dataSetDetails.setListName(name);
+        dataSetDetails.setListType(BrAPIListTypes.OBSERVATIONVARIABLES);
+        List<BrAPIExternalReference> refs = new ArrayList<>();
+        addReference(refs, program.getId(), referenceSourceBase, ExternalReferenceSource.PROGRAMS);
+        addReference(refs, UUID.fromString(trialID), referenceSourceBase, ExternalReferenceSource.TRIALS);
+        addReference(refs, datasetID, referenceSourceBase, ExternalReferenceSource.DATASET);
+        return dataSetDetails;
+    }
     public BrAPIObservationUnit constructBrAPIObservationUnit(
             Program program,
             String seqVal,
@@ -340,8 +355,7 @@ public class ExperimentObservation implements BrAPIImport {
 
 
     private void addReference(List<BrAPIExternalReference> refs, UUID uuid, String referenceBaseNameSource, ExternalReferenceSource refSourceName) {
-        BrAPIExternalReference reference;
-        reference = new BrAPIExternalReference();
+        BrAPIExternalReference reference = new BrAPIExternalReference();
         reference.setReferenceSource(String.format("%s/%s", referenceBaseNameSource, refSourceName.getName()));
         reference.setReferenceID(uuid.toString());
         refs.add(reference);

--- a/src/main/java/org/breedinginsight/brapps/importer/model/response/ImportObjectState.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/response/ImportObjectState.java
@@ -19,5 +19,6 @@ package org.breedinginsight.brapps.importer.model.response;
 
 public enum ImportObjectState {
     NEW,
-    EXISTING
+    EXISTING,
+    MUTATED
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/response/PendingImportObject.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/response/PendingImportObject.java
@@ -28,7 +28,6 @@ public class PendingImportObject<T> {
     private ImportObjectState state;
     @NonNull
     private T brAPIObject;
-    private T diff;
     private UUID id;
 
     public PendingImportObject(ImportObjectState state, T brAPIObject, UUID id) {
@@ -40,7 +39,4 @@ public class PendingImportObject<T> {
         this(state, brAPIObject, UUID.randomUUID());
     }
 
-    public Boolean hasDiff() {
-        return this.getDiff() != null;
-    }
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/response/PendingImportObject.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/response/PendingImportObject.java
@@ -28,6 +28,7 @@ public class PendingImportObject<T> {
     private ImportObjectState state;
     @NonNull
     private T brAPIObject;
+    private T diff;
     private UUID id;
 
     public PendingImportObject(ImportObjectState state, T brAPIObject, UUID id) {

--- a/src/main/java/org/breedinginsight/brapps/importer/model/response/PendingImportObject.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/response/PendingImportObject.java
@@ -39,4 +39,8 @@ public class PendingImportObject<T> {
     public PendingImportObject(ImportObjectState state, T brAPIObject) {
         this(state, brAPIObject, UUID.randomUUID());
     }
+
+    public Boolean hasDiff() {
+        return this.getDiff() != null;
+    }
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/ExternalReferenceSource.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/ExternalReferenceSource.java
@@ -8,6 +8,7 @@ public enum ExternalReferenceSource {
     TRIALS("trials"),
     STUDIES("studies"),
     OBSERVATION_UNITS("observationunits"),
+    DATASET("dataset"),
     LISTS("lists");
 
     private String name;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
@@ -330,8 +330,7 @@ public class FileImportService {
         User user = userService.getById(actingUser.getId()).get();
 
         // Find the import
-        ImportUpload upload = impopwd
-        rtDAO.getUploadById(uploadId)
+        ImportUpload upload = importDAO.getUploadById(uploadId)
                                        .orElseThrow(() -> new DoesNotExistException("Upload with that id does not exist"));
 
         if (upload.getProgress() != null && upload.getProgress().getStatuscode().equals((short) HttpStatus.ACCEPTED.getCode())) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
@@ -330,7 +330,8 @@ public class FileImportService {
         User user = userService.getById(actingUser.getId()).get();
 
         // Find the import
-        ImportUpload upload = importDAO.getUploadById(uploadId)
+        ImportUpload upload = impopwd
+        rtDAO.getUploadById(uploadId)
                                        .orElseThrow(() -> new DoesNotExistException("Upload with that id does not exist"));
 
         if (upload.getProgress() != null && upload.getProgress().getStatuscode().equals((short) HttpStatus.ACCEPTED.getCode())) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -29,7 +29,6 @@ import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.*;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.core.response.BrAPIListDetails;
-import org.brapi.v2.model.core.response.BrAPIListsSingleResponse;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
@@ -487,7 +486,7 @@ public class ExperimentProcessor implements Processor {
             }
 
             if (commit) {
-                fetchOrCreateDatasetPIO(expSeqValue, importRow, program, referencedTraits);
+                fetchOrCreateDatasetPIO(importRow, program, referencedTraits);
             }
 
             fetchOrCreateLocationPIO(importRow);
@@ -832,7 +831,7 @@ public class ExperimentProcessor implements Processor {
             }
         });
     }
-    private PendingImportObject<BrAPIListDetails> fetchOrCreateDatasetPIO(String expSeqValue, ExperimentObservation importRow, Program program, List<Trait> referencedTraits) {
+    private PendingImportObject<BrAPIListDetails> fetchOrCreateDatasetPIO(ExperimentObservation importRow, Program program, List<Trait> referencedTraits) {
         PendingImportObject<BrAPIListDetails> pio;
         PendingImportObject<BrAPITrial> trialPIO = trialByNameNoScope.get(importRow.getExpTitle());
         String name = String.format("Observation Dataset [%s-%s]",
@@ -856,9 +855,9 @@ public class ExperimentProcessor implements Processor {
             if (ImportObjectState.EXISTING == trialPIO.getState()) {
                 trialPIO.setState(ImportObjectState.MUTATED);
             }
+            obsVarDatasetByName.put(name, pio);
         }
         addObsVarsToDatasetDetails(pio, referencedTraits);
-        obsVarDatasetByName.put(name, pio);
         return pio;
     }
 
@@ -1205,7 +1204,7 @@ public class ExperimentProcessor implements Processor {
                     program.getId(),
                     String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.DATASET.getName()),
                     UUID.fromString(datasetId));
-            if (existingDatasets.isEmpty() || existingDatasets == null) {
+            if (existingDatasets == null || existingDatasets.isEmpty()) {
               throw new InternalServerException("existing dataset summary not returned from brapi server");
             }
             BrAPIListDetails dataSetDetails = brAPIListDAO

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -361,7 +361,10 @@ public class ExperimentProcessor implements Processor {
                         .getData()
                         .stream()
                         .filter(obsVarId -> !existingObsVarIds.contains(obsVarId)).collect(Collectors.toList());
-                brAPIListDAO.updateBrAPIList(id, newObsVarIds, program.getId());
+                List<String> obsVarIds = new ArrayList<>(existingObsVarIds);
+                obsVarIds.addAll(newObsVarIds);
+                dataset.setData(obsVarIds);
+                brAPIListDAO.updateBrAPIList(id, dataset, program.getId());
             } catch (ApiException e) {
                 log.error("Error updating dataset observation variables: " + Utilities.generateApiExceptionLogMessage(e), e);
                 throw new InternalServerException("Error saving experiment import", e);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -29,6 +29,7 @@ import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPISeason;
 import org.brapi.v2.model.core.BrAPIStudy;
 import org.brapi.v2.model.core.BrAPITrial;
+import org.brapi.v2.model.core.response.BrAPIListDetails;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
@@ -103,6 +104,7 @@ public class ExperimentProcessor implements Processor {
     private final BrAPIObservationDAO brAPIObservationDAO;
     private final BrAPISeasonDAO brAPISeasonDAO;
     private final BrAPIGermplasmDAO brAPIGermplasmDAO;
+    private final BrAPIListDAO brAPIListDAO;
     private final OntologyService ontologyService;
     private final FileMappingUtil fileMappingUtil;
 
@@ -117,6 +119,7 @@ public class ExperimentProcessor implements Processor {
     private Map<String, PendingImportObject<BrAPITrial>> trialByNameNoScope = null;
     private Map<String, PendingImportObject<ProgramLocation>> locationByName = null;
     private Map<String, PendingImportObject<BrAPIStudy>> studyByNameNoScope = null;
+    private Map<String, PendingImportObject<BrAPIListDetails>> dataSetOvbsVars = null;
     //  It is assumed that there are no preexisting Observation Units for the given environment (so this will not be
     // initialized by getExistingBrapiData() )
     private Map<String, PendingImportObject<BrAPIObservationUnit>> observationUnitByNameNoScope = null;
@@ -138,7 +141,7 @@ public class ExperimentProcessor implements Processor {
                                BrAPIObservationDAO brAPIObservationDAO,
                                BrAPISeasonDAO brAPISeasonDAO,
                                BrAPIGermplasmDAO brAPIGermplasmDAO,
-                               OntologyService ontologyService,
+                               BrAPIListDAO brAPIListDAO, OntologyService ontologyService,
                                FileMappingUtil fileMappingUtil) {
         this.dsl = dsl;
         this.brapiTrialDAO = brapiTrialDAO;
@@ -148,6 +151,7 @@ public class ExperimentProcessor implements Processor {
         this.brAPIObservationDAO = brAPIObservationDAO;
         this.brAPISeasonDAO = brAPISeasonDAO;
         this.brAPIGermplasmDAO = brAPIGermplasmDAO;
+        this.brAPIListDAO = brAPIListDAO;
         this.ontologyService = ontologyService;
         this.fileMappingUtil = fileMappingUtil;
     }
@@ -174,6 +178,7 @@ public class ExperimentProcessor implements Processor {
         this.trialByNameNoScope = initializeTrialByNameNoScope(program, experimentImportRows);
         this.studyByNameNoScope = initializeStudyByNameNoScope(program, experimentImportRows);
         this.locationByName = initializeUniqueLocationNames(program, experimentImportRows);
+        this.dataSetOvbsVars = initializeDatasetObsVars(program, experimentImportRows);
         this.existingGermplasmByGID = initializeExistingGermplasmByGID(program, experimentImportRows);
     }
 
@@ -1090,7 +1095,10 @@ public class ExperimentProcessor implements Processor {
         existingLocations.forEach(existingLocation -> locationByName.put(existingLocation.getName(), new PendingImportObject<>(ImportObjectState.EXISTING, existingLocation, existingLocation.getId())));
         return locationByName;
     }
-
+    private Map<String, PendingImportObject<BrAPIListDetails>> initializeDatasetObsVars(Program program, List<ExperimentObservation> experimentImportRows) {
+        Map<String, PendingImportObject<BrAPIListDetails>> existingDatasetObsVars = new HashMap<>();
+        return existingDatasetObsVars;
+    }
     private Map<String, PendingImportObject<BrAPIGermplasm>> initializeExistingGermplasmByGID(Program program, List<ExperimentObservation> experimentImportRows) {
         Map<String, PendingImportObject<BrAPIGermplasm>> existingGermplasmByGID = new HashMap<>();
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -818,10 +818,10 @@ public class ExperimentProcessor implements Processor {
         }
         return pio;
     }
-    private void addObsVarsToDatasetDetails(PendingImportObject<BrAPIListDetails> pio, List<Trait> referencedTraits) {
+    private void addObsVarsToDatasetDetails(PendingImportObject<BrAPIListDetails> pio, List<Trait> referencedTraits, Program program) {
         BrAPIListDetails details = pio.getBrAPIObject();
         referencedTraits.forEach(trait -> {
-            String id = trait.getObservationVariableDbId().toString();
+            String id = Utilities.appendProgramKey(trait.getObservationVariableName(), program.getKey());
             if (!details.getData().contains(id) && ImportObjectState.EXISTING != pio.getState()) {
                 details.getData().add(id);
             }
@@ -857,7 +857,7 @@ public class ExperimentProcessor implements Processor {
             }
             obsVarDatasetByName.put(name, pio);
         }
-        addObsVarsToDatasetDetails(pio, referencedTraits);
+        addObsVarsToDatasetDetails(pio, referencedTraits, program);
         return pio;
     }
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorData.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorData.java
@@ -47,8 +47,9 @@ public class ProcessorData {
     }
     static <T, V> Map<String, T> getMutationsByObjectId(Map<V, PendingImportObject<T>> objectsByName) {
         return objectsByName.entrySet().stream()
-                .filter(entry -> entry.getValue().hasDiff())
+                .filter(entry -> ImportObjectState.MUTATED == entry.getValue().getState())
                 .collect(Collectors
-                        .toMap(entry -> entry.getValue().getId().toString(), entry -> entry.getValue().getDiff()));
+                        .toMap(entry -> entry.getValue().getId().toString(),
+                                entry -> entry.getValue().getBrAPIObject()));
     }
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorData.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorData.java
@@ -47,6 +47,7 @@ public class ProcessorData {
     }
     static <T, V> Map<String, T> getMutationsByObjectId(Map<V, PendingImportObject<T>> objectsByName) {
         return objectsByName.entrySet().stream()
+                .filter(entry -> ImportObjectState.MUTATED == entry.getValue().getState())
                 .collect(Collectors
                         .toMap(entry -> entry.getValue().getId().toString(), entry -> entry.getValue().getDiff()));
     }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorData.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorData.java
@@ -45,5 +45,9 @@ public class ProcessorData {
                 .map(preview -> preview.getBrAPIObject())
                 .collect(Collectors.toList());
     }
-
+    static <T, V> Map<String, T> getMutationsByObjectId(Map<V, PendingImportObject<T>> objectsByName) {
+        return objectsByName.entrySet().stream()
+                .collect(Collectors
+                        .toMap(entry -> entry.getValue().getId().toString(), entry -> entry.getValue().getDiff()));
+    }
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorData.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorData.java
@@ -47,7 +47,7 @@ public class ProcessorData {
     }
     static <T, V> Map<String, T> getMutationsByObjectId(Map<V, PendingImportObject<T>> objectsByName) {
         return objectsByName.entrySet().stream()
-                .filter(entry -> ImportObjectState.MUTATED == entry.getValue().getState())
+                .filter(entry -> entry.getValue().hasDiff())
                 .collect(Collectors
                         .toMap(entry -> entry.getValue().getId().toString(), entry -> entry.getValue().getDiff()));
     }

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -357,7 +357,7 @@ public class BrAPIDAOUtil {
                 List<T> data = result.getData();
 
             return data.get(0);
-            
+
         } catch (ApiException e) {
             log.warn(Utilities.generateApiExceptionLogMessage(e));
             throw e;

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -350,13 +350,7 @@ public class BrAPIDAOUtil {
                 if (body.getResult() == null) {
                     throw new ApiException("Response body is missing result", response.getStatusCode(), response.getHeaders(), response.getBody().toString());
                 }
-                BrAPIResponseResult result = (BrAPIResponseResult) body.getResult();
-                if (result.getData() == null) {
-                    throw new ApiException("Response result is missing data", response.getStatusCode(), response.getHeaders(), response.getBody().toString());
-                }
-                List<T> data = result.getData();
-
-            return data.get(0);
+                return (T) body.getResult();
 
         } catch (ApiException e) {
             log.warn(Utilities.generateApiExceptionLogMessage(e));

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -353,7 +353,7 @@ public class BrAPIDAOUtil {
                 return (T) body.getResult();
 
         } catch (ApiException e) {
-            log.warn(Utilities.generateApiExceptionLogMessage(e));
+            log.error(Utilities.generateApiExceptionLogMessage(e));
             throw e;
         } catch (Exception e) {
             throw new InternalServerException(e.toString(), e);

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -77,7 +77,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.*;
-import java.util.regex.Pattern;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -77,6 +77,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -164,11 +165,13 @@ public class ExperimentFileImportTest extends BrAPITest {
     - new env, existing location
     - new experiment, missing required cols (check all required cols)
     - new env, missing required cols (check all req cols)
+    - new exp/env with observation variables (new dataset)
     - new exp/env with observations
     - new exp/env with invalid observations
     - existing env with missing OU ID
     - existing env with new observations
     - existing env that already has obs
+    - existing env that already has observation variables (existing dataset)
      */
 
     @Test
@@ -388,6 +391,42 @@ public class ExperimentFileImportTest extends BrAPITest {
 
     @Test
     @SneakyThrows
+    public void importNewExpWithObsVar() {
+        List<Trait> traits = createTraits(1);
+        Program program = createProgram("New Exp with Observations", "EXPVAR", "EXPVAR", BRAPI_REFERENCE_SOURCE, createGermplasm(1), traits);
+        Map<String, Object> newExp = new HashMap<>();
+        newExp.put(Columns.GERMPLASM_GID, "1");
+        newExp.put(Columns.TEST_CHECK, "T");
+        newExp.put(Columns.EXP_TITLE, "Test Exp");
+        newExp.put(Columns.EXP_UNIT, "Plot");
+        newExp.put(Columns.EXP_TYPE, "Phenotyping");
+        newExp.put(Columns.ENV, "New Env");
+        newExp.put(Columns.ENV_LOCATION, "Location A");
+        newExp.put(Columns.ENV_YEAR, "2023");
+        newExp.put(Columns.EXP_UNIT_ID, "a-1");
+        newExp.put(Columns.REP_NUM, "1");
+        newExp.put(Columns.BLOCK_NUM, "1");
+        newExp.put(Columns.ROW, "1");
+        newExp.put(Columns.COLUMN, "1");
+        newExp.put(traits.get(0).getObservationVariableName(), null);
+
+        JsonObject result = importTestUtils.uploadAndFetch(writeDataToFile(List.of(newExp), traits), null, true, client, program, mappingId);
+
+        JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
+        assertEquals(1, previewRows.size());
+        JsonObject row = previewRows.get(0).getAsJsonObject();
+
+        assertEquals("NEW", row.getAsJsonObject("trial").get("state").getAsString());
+        assertTrue(row.getAsJsonObject("trial").get("additionalInfo").getAsJsonObject().has("observationDatasetId"));
+        assertTrue(importTestUtils.UUID_REGEX.matcher(row.getAsJsonObject("trial").get("additionalInfo").getAsJsonObject().get("observationDatasetId").getAsString()).matches());
+        assertEquals("NEW", row.getAsJsonObject("location").get("state").getAsString());
+        assertEquals("NEW", row.getAsJsonObject("study").get("state").getAsString());
+        assertEquals("NEW", row.getAsJsonObject("observationUnit").get("state").getAsString());
+        assertRowSaved(newExp, program, traits);
+    }
+
+    @Test
+    @SneakyThrows
     public void importNewExpWithObs() {
         List<Trait> traits = createTraits(1);
         Program program = createProgram("New Exp with Observations", "EXPOBS", "EXPOBS", BRAPI_REFERENCE_SOURCE, createGermplasm(1), traits);
@@ -481,6 +520,70 @@ public class ExperimentFileImportTest extends BrAPITest {
         assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt(), "Returned data: " + result);
 
         assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Experiment Units are missing Observation Unit Id."));
+    }
+
+    @Test
+    @SneakyThrows
+    public void importNewObsVarExisingOu() {
+        List<Trait> traits = createTraits(2);
+        Program program = createProgram("New ObsVar Existing OU", "OUVAR", "OUVAR", BRAPI_REFERENCE_SOURCE, createGermplasm(1), traits);
+        Map<String, Object> newExp = new HashMap<>();
+        newExp.put(Columns.GERMPLASM_GID, "1");
+        newExp.put(Columns.TEST_CHECK, "T");
+        newExp.put(Columns.EXP_TITLE, "Test Exp");
+        newExp.put(Columns.EXP_UNIT, "Plot");
+        newExp.put(Columns.EXP_TYPE, "Phenotyping");
+        newExp.put(Columns.ENV, "New Env");
+        newExp.put(Columns.ENV_LOCATION, "Location A");
+        newExp.put(Columns.ENV_YEAR, "2023");
+        newExp.put(Columns.EXP_UNIT_ID, "a-1");
+        newExp.put(Columns.REP_NUM, "1");
+        newExp.put(Columns.BLOCK_NUM, "1");
+        newExp.put(Columns.ROW, "1");
+        newExp.put(Columns.COLUMN, "1");
+        newExp.put(traits.get(0).getObservationVariableName(), null);
+
+        importTestUtils.uploadAndFetch(writeDataToFile(List.of(newExp), null), null, true, client, program, mappingId);
+
+        BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of(Utilities.appendProgramKey((String)newExp.get(Columns.EXP_TITLE), program.getKey())), program).get(0);
+        Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
+        assertTrue(trialIdXref.isPresent());
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceID()), program).get(0);
+
+        BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
+        Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
+        assertTrue(ouIdXref.isPresent());
+
+        Map<String, Object> newObsVar = new HashMap<>();
+        newObsVar.put(Columns.GERMPLASM_GID, "1");
+        newObsVar.put(Columns.TEST_CHECK, "T");
+        newObsVar.put(Columns.EXP_TITLE, "Test Exp");
+        newObsVar.put(Columns.EXP_UNIT, "Plot");
+        newObsVar.put(Columns.EXP_TYPE, "Phenotyping");
+        newObsVar.put(Columns.ENV, "New Env");
+        newObsVar.put(Columns.ENV_LOCATION, "Location A");
+        newObsVar.put(Columns.ENV_YEAR, "2023");
+        newObsVar.put(Columns.EXP_UNIT_ID, "a-1");
+        newObsVar.put(Columns.REP_NUM, "1");
+        newObsVar.put(Columns.BLOCK_NUM, "1");
+        newObsVar.put(Columns.ROW, "1");
+        newObsVar.put(Columns.COLUMN, "1");
+        newObsVar.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceID());
+        newObsVar.put(traits.get(1).getObservationVariableName(), null);
+
+        JsonObject result = importTestUtils.uploadAndFetch(writeDataToFile(List.of(newObsVar), traits), null, true, client, program, mappingId);
+
+        JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
+        assertEquals(1, previewRows.size());
+        JsonObject row = previewRows.get(0).getAsJsonObject();
+
+        assertEquals("EXISTING", row.getAsJsonObject("trial").get("state").getAsString());
+        assertTrue(row.getAsJsonObject("trial").get("additionalInfo").getAsJsonObject().has("observationDatasetId"));
+        assertTrue(importTestUtils.UUID_REGEX.matcher(row.getAsJsonObject("trial").get("additionalInfo").getAsJsonObject().get("observationDatasetId").getAsString()).matches());
+        assertEquals("EXISTING", row.getAsJsonObject("location").get("state").getAsString());
+        assertEquals("EXISTING", row.getAsJsonObject("study").get("state").getAsString());
+        assertEquals("EXISTING", row.getAsJsonObject("observationUnit").get("state").getAsString());
+        assertRowSaved(newObsVar, program, traits);
     }
 
     @Test

--- a/src/test/java/org/breedinginsight/brapps/importer/ImportTestUtils.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ImportTestUtils.java
@@ -40,6 +40,7 @@ import org.jooq.DSLContext;
 
 import java.io.File;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static io.micronaut.http.HttpRequest.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -50,6 +51,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * To use, instantiate a new instance of this class, then use it like a regular static utility class
  */
 public class ImportTestUtils {
+
+    Pattern UUID_REGEX = Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
     public Program insertAndFetchTestProgram(ProgramRequest programRequest, RxHttpClient client, Gson gson) {
 


### PR DESCRIPTION
# Description
**Story:** [BI-1193](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1193)

Changes made to `ExperimentProcessor`:
- new field `obsVarDatasetByName` to hold a map for dataset pending import objects
- #getExistingBrAPIData--dataset pios for any existing trials set in the map
- #process--new datasets created and existing or new trial additionalInfo.observationDatasetId set; and additional obsvars added to existing dataset
- #post--new obsvars added to existing datasets and existing trials updated with additionalInfo

To handle the case when an import object needs to be updated the following were added:
- `ImportObjectState.MUTATED`
- `BrAPIDAOUtil#put`
- `ProcessorData#getMutationsByObjectId`

For updating Trials:
- `AdditionalInfoField.observationDatasetId`
- `BrAPITrialDAO#updateBrAPITrial`

For creating/updating Datasets
- `ExternalReferenceSource.DATASET`
- `ExperimentObservation#contructDatasetDetails`
- `BrAPIListDAO#updateBrAPIList`




# Dependencies
none

# Testing
see acceptance criteria in the card


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1193]: https://breedinginsight.atlassian.net/browse/BI-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ