### PR TITLE
BI-1779 - Import germplasm with unspecified breeding method

### DIFF
--- a/src/main/java/org/breedinginsight/api/v1/controller/BreedingMethodController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/BreedingMethodController.java
@@ -135,7 +135,9 @@ public class BreedingMethodController {
     }
 
     @Put("programs/{programId}/breeding-methods/enable")
-    @ProgramSecured(roles = {ProgramSecuredRole.BREEDER})
+// BI-1779 - Removing the ability to choose predefined methods for a program until we make the germplasm import template dynamically generated
+//    @ProgramSecured(roles = {ProgramSecuredRole.BREEDER})
+    @Secured(SecurityRule.DENY_ALL)
     public HttpResponse enableSystemBreedingMethods(@PathVariable UUID programId, @Body List<UUID> systemBreedingMethodIds) throws ApiException, BadRequestException {
         log.debug("enabling system breeding methods for program: "+programId);
 

--- a/src/test/java/org/breedinginsight/api/v1/controller/BreedingMethodControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/BreedingMethodControllerIntegrationTest.java
@@ -33,6 +33,7 @@ import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
 import org.breedinginsight.utilities.Utilities;
 import org.jooq.DSLContext;
+import org.junit.Ignore;
 import org.junit.jupiter.api.*;
 
 import javax.inject.Inject;
@@ -160,6 +161,7 @@ public class BreedingMethodControllerIntegrationTest extends BrAPITest {
                                                                           .collect(Collectors.toList())));
     }
 
+    @Ignore //BI-1779 - Removing the ability to choose predefined methods for a program until we make the germplasm import template dynamically generated
     @Test
     public void enableSystemMethods() {
         Program program = createProgram("enableProgramBM", "EBM", "ENBM");
@@ -498,6 +500,7 @@ public class BreedingMethodControllerIntegrationTest extends BrAPITest {
         assertThat(programMethods.stream().map(ProgramBreedingMethodEntity::getId).collect(Collectors.toList()), hasItem(createdMethod.getId()));
     }
 
+    @Ignore //BI-1779 - Removing the ability to choose predefined methods for a program until we make the germplasm import template dynamically generated
     @Test
     public void tryDisableSystemMethodInUse() {
         Program program = createProgram("tryDeleteSystemBM", "TDSBM", "TRDSBM");

--- a/src/test/java/org/breedinginsight/api/v1/controller/BreedingMethodControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/BreedingMethodControllerIntegrationTest.java
@@ -33,7 +33,6 @@ import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
 import org.breedinginsight.utilities.Utilities;
 import org.jooq.DSLContext;
-import org.junit.Ignore;
 import org.junit.jupiter.api.*;
 
 import javax.inject.Inject;
@@ -161,7 +160,7 @@ public class BreedingMethodControllerIntegrationTest extends BrAPITest {
                                                                           .collect(Collectors.toList())));
     }
 
-    @Ignore //BI-1779 - Removing the ability to choose predefined methods for a program until we make the germplasm import template dynamically generated
+    @Disabled //BI-1779 - Removing the ability to choose predefined methods for a program until we make the germplasm import template dynamically generated
     @Test
     public void enableSystemMethods() {
         Program program = createProgram("enableProgramBM", "EBM", "ENBM");
@@ -500,7 +499,7 @@ public class BreedingMethodControllerIntegrationTest extends BrAPITest {
         assertThat(programMethods.stream().map(ProgramBreedingMethodEntity::getId).collect(Collectors.toList()), hasItem(createdMethod.getId()));
     }
 
-    @Ignore //BI-1779 - Removing the ability to choose predefined methods for a program until we make the germplasm import template dynamically generated
+    @Disabled //BI-1779 - Removing the ability to choose predefined methods for a program until we make the germplasm import template dynamically generated
     @Test
     public void tryDisableSystemMethodInUse() {
         Program program = createProgram("tryDeleteSystemBM", "TDSBM", "TRDSBM");


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1779

Updated controller method for enabling/disabling system breeding methods in a program to `DENY_ALL`

# Dependencies
bi-web/bug/BI-1779

# Testing
See bi-web#313

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/4884247833
