### PR TITLE
[BI-1689] - Incorrect Jobs Count

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -67,7 +67,7 @@ public class ExperimentObservation implements BrAPIImport {
     private String expDescription;
 
     @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
-    @ImportFieldMetadata(id = "expUnit", name = Columns.EXP_UNIT, description = "experiment unit  (Examples: plots, plant, tanks, hives, etc.)")
+    @ImportFieldMetadata(id = "expUnit", name = Columns.EXP_UNIT, description = "Experiment unit  (Examples: plots, plant, tanks, hives, etc.)")
     private String expUnit;
 
     @ImportFieldType(type = ImportFieldTypeEnum.TEXT)

--- a/src/main/java/org/breedinginsight/brapps/importer/services/ImportStatusService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/ImportStatusService.java
@@ -52,7 +52,9 @@ public class ImportStatusService {
         importDAO.update(upload);
     }
 
-    public void finishUpload(ImportUpload upload, String message) {
+    public void finishUpload(ImportUpload upload, long numberObjects, String message) {
+        // Update progress to reflect final finished and inProgress counts.
+        upload.updateProgress(Math.toIntExact(numberObjects), 0);
         upload.getProgress().setMessage(message);
         upload.getProgress().setStatuscode((short) HttpStatus.OK.getCode());
         importDAO.update(upload);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -503,10 +503,6 @@ public class GermplasmProcessor implements Processor {
                 entry.getValue().getGermplasm().setBrAPIObject(createdGermplasmMap.get(germplasmName));
             }
         }
-
-
-
-
     }
 
     private void updateDependencyValues(Map<Integer, PendingImport> mappedBrAPIImport) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
@@ -114,6 +114,9 @@ public class ProcessorManager {
             processor.postBrapiData(mappedBrAPIImport, program, upload);
         }
 
+        // Update progress to reflect final finished and inProgress counts.
+        upload.updateProgress(Math.toIntExact(totalObjects), 0);
+
         log.debug("Completed upload to brapi service");
         statusService.finishUpload(upload, "Completed upload to brapi service");
     }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
@@ -114,11 +114,8 @@ public class ProcessorManager {
             processor.postBrapiData(mappedBrAPIImport, program, upload);
         }
 
-        // Update progress to reflect final finished and inProgress counts.
-        upload.updateProgress(Math.toIntExact(totalObjects), 0);
-
         log.debug("Completed upload to brapi service");
-        statusService.finishUpload(upload, "Completed upload to brapi service");
+        statusService.finishUpload(upload, totalObjects, "Completed upload to brapi service");
     }
 
 }

--- a/src/main/java/org/breedinginsight/services/job/JobService.java
+++ b/src/main/java/org/breedinginsight/services/job/JobService.java
@@ -46,10 +46,7 @@ public class JobService {
             throw new DoesNotExistException("Program id does not exist");
         }
 
-        List<Job> jobs = new ArrayList<>();
-        jobs.addAll(getProgramImports(programId));
-
-        return jobs;
+        return new ArrayList<>(getProgramImports(programId));
     }
 
     @SneakyThrows

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -328,8 +328,7 @@ public class BrAPIDAOUtil {
             }
 
             if (upload != null) {
-                // TODO: consider possible race condition?
-                // Increment finished count and reset inProgress count to 0.
+                // Set finished count, reset inProgress count to 0.
                 upload.updateProgress(finished, 0);
                 progressUpdateMethod.accept(upload);
             }

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -328,7 +328,9 @@ public class BrAPIDAOUtil {
             }
 
             if (upload != null) {
-                upload.updateProgress(listResult.size(), 0);
+                // TODO: consider possible race condition?
+                // Increment finished count and reset inProgress count to 0.
+                upload.updateProgress(finished, 0);
                 progressUpdateMethod.accept(upload);
             }
 


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1689

There were 2 bugs causing the "Complete count" (a.k.a. finished count) to be less than the "Total count" on the jobs page:

1. The first bug was at the end of the `BrAPIDAOUtil.post` method where it was updating the finished count to be `listResult.size()`. The problem was that `listResult` contains all the BrAPI objects created during that call to `post`, but the finished count needs to account for BrAPI objects created during previous calls to `post`. I fixed this by using the local variable `finished` which is initially set to the current finished count (thus accounting for previous calls to `post`) and then incremented after each BrAPI call.
2. The object counts that are generated when a file is parsed, e.g. by `GermplasmProcessor.getStatisticsMap`, count related objects (e.g. pedigree for germplasm). These related objects are not POSTed separately to the BrAPI service, so there isn't a generic way to keep track of them, they would need to be tracked differently for each BrAPI object type. An expedient solution was to update the finished count to account for these related objects at the end of the `ProcessorManager.postBrapiData` method ([Line 118](https://github.com/Breeding-Insight/bi-api/blob/e31b705b0b6e54ad54ac881a144383614ccc6fe3/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java#L118)). There is already logic to make sure the expected number of primary BrAPI objects matches the number created in `BrAPIDAOUtil.post` ([Lines 322-324](https://github.com/Breeding-Insight/bi-api/blob/e31b705b0b6e54ad54ac881a144383614ccc6fe3/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java#L322)).


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/4982646479 (2nd run succeeded)
