### PR TITLE
[BI-1193] addressed bug in BI-1193

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -284,20 +284,19 @@ public class ExperimentProcessor implements Processor {
         AuthenticatedUser actingUser = new AuthenticatedUser(upload.getUpdatedByUser().getName(), new ArrayList<>(), upload.getUpdatedByUser().getId(), new ArrayList<>());
 
         try {
+            List<BrAPIListSummary> createdDatasets = new ArrayList<>(brAPIListDAO.createBrAPILists(newDatasetRequests, program.getId(), upload));
+            createdDatasets.forEach(summary -> {
+                obsVarDatasetByName.get(summary.getListName()).getBrAPIObject().setListDbId(summary.getListDbId());
+            });
+
             List<BrAPITrial> createdTrials = new ArrayList<>(brapiTrialDAO.createBrAPITrials(newTrials, program.getId(), upload));
             // set the DbId to the for each newly created trial
             for (BrAPITrial createdTrial : createdTrials) {
                 String createdTrialName = Utilities.removeProgramKey(createdTrial.getTrialName(), program.getKey());
                 this.trialByNameNoScope.get(createdTrialName)
-                                       .getBrAPIObject()
-                                       .setTrialDbId(createdTrial.getTrialDbId());
+                        .getBrAPIObject()
+                        .setTrialDbId(createdTrial.getTrialDbId());
             }
-
-
-            List<BrAPIListSummary> createdDatasets = new ArrayList<>(brAPIListDAO.createBrAPILists(newDatasetRequests, program.getId(), upload));
-            createdDatasets.forEach(summary -> {
-                obsVarDatasetByName.get(summary.getListName()).getBrAPIObject().setListDbId(summary.getListDbId());
-            });
 
             List<ProgramLocation> createdLocations = new ArrayList<>(locationService.create(actingUser, program.getId(), newLocations));
             // set the DbId to the for each newly created trial


### PR DESCRIPTION
# Description
[BI-1193](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1193)

The order that new Trials and dataset Lists are posted was changed from first-Trial-then-List to first-List-then-Trial to prevent the case where a network interruption would result in a Trial saved to the db containing a reference to a dataset List that was never created.



# Dependencies
none

# Testing
same as card and PR for BI-1193


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1193]: https://breedinginsight.atlassian.net/browse/BI-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ