### PR TITLE
[BI-1193-2] BI-API throws timeout exception when BB mat view refresh exceeds 10m

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -160,7 +160,7 @@ brapi:
     pheno-url: ${brapi.server.default-url}
     geno-url: ${brapi.server.default-url}
     reference-source: ${BRAPI_REFERENCE_SOURCE:breedinginsight.org}
-  read-timeout: 10m
+  read-timeout: ${BRAPI_READ_TIMEOUT:10m}
   page-size: 1000
   search:
     wait-time: 1000


### PR DESCRIPTION
# Description
Importing of experiments was failing during QA because the volume of data (for example, ~100,00 germplasm) was causing the time to refresh the phenotype materialized view after obs. unit creation to exceed the limit set in bi-api (10 minutes) when a timeout exception is thrown if it hasn't received a response from the brapi service.

The long-term solution is to update the Breedbase code to query the db directly instead of relying on mat. views.

The short-term solution here is to expose an environment variable that can be used to easily set the timeout value for bi-api. Then it can be adjusted as needed for different test or production environments.


# Dependencies
breedinginsight/breedbase fork running bug/BI-1193 branch

# Testing
_Please include any details needed for reviewers to test this code_


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
