### PR TITLE
[BI-1456] Ontology Share - Improvement

### DIFF
--- a/src/main/java/org/breedinginsight/services/OntologyService.java
+++ b/src/main/java/org/breedinginsight/services/OntologyService.java
@@ -51,15 +51,42 @@ public class OntologyService {
         // Get program with that id
         Program program = getProgram(programId);
 
+        // Get any programs targeted for sharing by this program
         List<SharedOntology> formattedPrograms = getSharedProgramsFormatted(program);
         Set<UUID> sharedProgramIds = formattedPrograms.stream().map(SharedOntology::getProgramId).collect(Collectors.toSet());
 
-        // Add other programs
+        // Add other sharable programs
         if (!sharedOnly) {
             // TODO: Test if localhost vs localhost/brapi/v2 makes a difference
             List<Program> matchingPrograms = getMatchingPrograms(program);
+
+            // Collect the ids of any matching programs that are either sharing-sources or
+            // sharing-targets that have accepted
+            Set<UUID> shareSourceIds = new HashSet<>();
+            Set<UUID> shareTargetIds = new HashSet<>();
+            for (Program candidate: matchingPrograms) {
+                List<SharedOntology> shareTargetsFormatted = getSharedProgramsFormatted(candidate);
+                if (!shareTargetsFormatted.isEmpty()) {
+
+                    // The program is sharing its ontology, so collect its id as a source
+                    shareSourceIds.add(candidate.getId());
+
+                    // Collect the ids of target-programs that have accepted
+                    shareTargetIds.addAll(shareTargetsFormatted
+                            .stream()
+                            .filter(SharedOntology::getAccepted)
+                            .map(SharedOntology::getProgramId)
+                            .collect(Collectors.toSet())
+                    );
+                }
+            }
+
+            Set<UUID> unsharableIds = new HashSet<>();
+            unsharableIds.addAll(sharedProgramIds);
+            unsharableIds.addAll(shareSourceIds);
+            unsharableIds.addAll(shareTargetIds);
             formattedPrograms.addAll(matchingPrograms.stream()
-                    .filter(matchingProgram -> !sharedProgramIds.contains(matchingProgram.getId()))
+                    .filter(matchingProgram -> !unsharableIds.contains(matchingProgram.getId()))
                     .map(matchingProgram -> formatResponse(matchingProgram))
                     .collect(Collectors.toList()));
         }


### PR DESCRIPTION
# Description
**Story:** [BI-1456](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1456)

`OntologyService::getSharedOntology` was updated to filter out from the list of sharable programs any programs currently sharing with each other.



# Dependencies
none

# Testing
- create three test programs A, B, and C
- import ontology into A and C but not B
- Have A share its ontology with B but do not have B accept
- Go to the Configuration tab of C and click "Share Ontology"
- verify that programs A is not present but B is present in the list of programs
- got to the configuration tab of B and accept sharing with A
- Go to the configuration tab of C and click "Share Ontology"
- verify neither A nor B are present in the list


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1456]: https://breedinginsight.atlassian.net/browse/BI-1456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ