### PR TITLE
[BI-1618] Import File Selection Behavior

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
@@ -162,7 +162,7 @@ public class FileImportService {
                 //TODO: Allow them to pass in header row index in the future
                 df = FileUtil.parseTableFromExcel(file.getInputStream(), 0);
             } catch (IOException | ParsingException e) {
-                throw new HttpStatusException(HttpStatus.BAD_REQUEST, String.format("Error(s) detected in file, %s.  %s. Import cannot proceed.", file.getFilename(), e.getMessage()));
+                throw new HttpStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
             }
         } else {
             throw new UnsupportedTypeException("Unsupported mime type");

--- a/src/main/java/org/breedinginsight/services/TraitUploadService.java
+++ b/src/main/java/org/breedinginsight/services/TraitUploadService.java
@@ -116,7 +116,7 @@ public class TraitUploadService {
                 traits = parser.parseExcel(new BOMInputStream(file.getInputStream(), false));
             } catch(IOException | ParsingException e) {
                 log.error(e.getMessage());
-                throw new HttpStatusException( HttpStatus.BAD_REQUEST, String.format("Error(s) detected in file, %s.  %s. Import cannot proceed.", file.getFilename(), e.getMessage()) );
+                throw new HttpStatusException( HttpStatus.BAD_REQUEST, e.getMessage() );
             }
         } else {
             throw new UnsupportedTypeException("Unsupported mime type");


### PR DESCRIPTION
# Description
[BI-1618 ](https://breedinginsight.atlassian.net/browse/BI-1618)- Import File Selection Behavior

Cleaned up the error message generated on the back-end.  Formatting and augmentation of the error messages will now happen on the front-end.


# Dependencies
**bi-web:**  feature/BI-1618

# Testing
see testing on [bi-web PR](https://github.com/Breeding-Insight/bi-web/pull/319)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [] I have tested that my code works with both the brapi-java-server and BreedBase
- [] I have create/modified unit tests to cover this change
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: _\<please include a link to TAF run>_
