### PR TITLE
[BI-1294] Implement Caching Layer for Experiments

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
@@ -59,7 +59,8 @@ public class BrAPITrialDAO {
     private final ProgramService programService;
     private final BrAPIEndpointProvider brAPIEndpointProvider;
     private final String referenceSource;
-
+    @Property(name = "micronaut.bi.api.run-scheduled-tasks")
+    private boolean runScheduledTasks;
     @Inject
     public BrAPITrialDAO(ProgramCacheProvider programCacheProvider, ProgramDAO programDAO, ImportDAO importDAO, BrAPIDAOUtil brAPIDAOUtil, ProgramService programService, @Property(name = "brapi.server.reference-source") String referenceSource, BrAPIEndpointProvider brAPIEndpointProvider) {
         this.programExperimentCache = programCacheProvider.getProgramCache(this::fetchProgramExperiments, BrAPITrial.class);
@@ -72,8 +73,12 @@ public class BrAPITrialDAO {
     }
 
 
-    @PostConstruct
+    @Scheduled(initialDelay = "2s")
     public void setup() {
+        if(!runScheduledTasks) {
+            return;
+        }
+
         // Populate the experiment cache for all programs on startup
         log.debug("populating experiment cache");
         List<Program> programs = programDAO.getActive();

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
@@ -276,6 +276,22 @@ public class BrAPITrialDAO {
         List<BrAPITrial> trials = getTrialsByDbIds(List.of(trialDbId), program);
         return Utilities.getSingleOptional(trials);
     }
+
+    public List<BrAPITrial> getTrialsByDbIds(Collection<String> trialDbIds, Program program) throws ApiException {
+        Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
+        List<BrAPITrial> trials = new ArrayList<>();
+        if (cache != null) {
+            trials.addAll(cache
+                    .values()
+                    .stream()
+                    .filter(t -> trialDbIds.contains(t.getTrialDbId()))
+                    .collect(Collectors.toList()));
+        }
+
+        return trials;
+    }
+
+    /*
     public List<BrAPITrial> getTrialsByDbIds(Collection<String> trialDbIds, Program program) throws ApiException {
         if(trialDbIds.isEmpty()) {
             return Collections.emptyList();
@@ -290,26 +306,7 @@ public class BrAPITrialDAO {
                 api::searchTrialsSearchResultsDbIdGet,
                 trialSearch
         );
-    }
-
-    public List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException {
-        if(experimentIds.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        BrAPITrialSearchRequest trialSearch = new BrAPITrialSearchRequest();
-        trialSearch.programDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
-        //trialSearch.trialDbIds(experimentIds.stream().map(id -> id.toString()).collect(Collectors.toList()));
-        trialSearch.externalReferenceSources(List.of(referenceSource + "/" + ExternalReferenceSource.TRIALS.getName()));
-        trialSearch.externalReferenceIDs(experimentIds.stream().map(id -> id.toString()).collect(Collectors.toList()));
-        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), TrialsApi.class);
-        return brAPIDAOUtil.search(
-                api::searchTrialsPost,
-                api::searchTrialsSearchResultsDbIdGet,
-                trialSearch
-        );
-    }
-
+    }*/
 }
 
 

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
@@ -243,6 +243,21 @@ public class BrAPITrialDAO {
 
         return trials;
     }
+    public List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException {
+        if(experimentIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        BrAPITrialSearchRequest trialSearch = new BrAPITrialSearchRequest();
+        trialSearch.programDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
+        trialSearch.externalReferenceSources(List.of(referenceSource + "/" + ExternalReferenceSource.TRIALS.getName()));
+        trialSearch.externalReferenceIDs(experimentIds.stream().map(id -> id.toString()).collect(Collectors.toList()));
+        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), TrialsApi.class);
+        return brAPIDAOUtil.search(
+                api::searchTrialsPost,
+                api::searchTrialsSearchResultsDbIdGet,
+                trialSearch
+        );
+    }
 }
 
 

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
@@ -104,7 +104,7 @@ public class BrAPITrialDAO {
                 trialSearch
         );
 
-        return experimentById(programExperiments);
+        return experimentById(processExperimentsForDisplay(programExperiments, program.getKey()));
     }
 
     private Map<String, BrAPITrial> experimentById(List<BrAPITrial> trials) {
@@ -201,23 +201,13 @@ public class BrAPITrialDAO {
         return new ArrayList<>(programExperimentCache.get(programId).values());
     }
 
-    //Removes program key from trial name and adds dataset information
+    //Removes program key from trial name
     private List<BrAPITrial> processExperimentsForDisplay(
             List<BrAPITrial> trials,
-            String programKey,
-            UUID programId,
-            boolean metadata) throws ApiException {
+            String programKey) throws ApiException {
         List<BrAPITrial> displayExperiments = new ArrayList<>();
         for (BrAPITrial trial: trials) {
             trial.setTrialName(Utilities.removeProgramKey(trial.getTrialName(), programKey, ""));
-            List<String> datasets = new ArrayList<>();
-
-            if (metadata) {
-                //todo presumably BI-1193 replace dummy value with list of datasets once datasets implemented
-                datasets.add("Observation Dataset");
-                trial.putAdditionalInfoItem("datasets", datasets);
-            }
-
             displayExperiments.add(trial);
         }
         return displayExperiments;
@@ -227,7 +217,7 @@ public class BrAPITrialDAO {
         Map<String, BrAPITrial> cache = programExperimentCache.get(programId);
         BrAPITrial trial = null;
         if (cache != null) {
-            trial = cache.get(trialId);
+            trial = cache.get(trialId.toString());
         }
 
         return Optional.ofNullable(trial);

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
@@ -19,6 +19,7 @@ package org.breedinginsight.brapps.importer.daos;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.http.server.exceptions.InternalServerException;
+import io.micronaut.scheduling.annotation.Scheduled;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.model.exceptions.ApiException;
@@ -69,6 +70,7 @@ public class BrAPITrialDAO {
         this.referenceSource = referenceSource;
         this.brAPIEndpointProvider = brAPIEndpointProvider;
     }
+
 
     @PostConstruct
     public void setup() {

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
@@ -62,7 +62,7 @@ public class BrAPITrialDAO {
 
     @Inject
     public BrAPITrialDAO(ProgramCacheProvider programCacheProvider, ProgramDAO programDAO, ImportDAO importDAO, BrAPIDAOUtil brAPIDAOUtil, ProgramService programService, @Property(name = "brapi.server.reference-source") String referenceSource, BrAPIEndpointProvider brAPIEndpointProvider) {
-        this.programExperimentCache = programCacheProvider.getProgramCache(this::fetchProgramExperiment, BrAPITrial.class);
+        this.programExperimentCache = programCacheProvider.getProgramCache(this::fetchProgramExperiments, BrAPITrial.class);
         this.programDAO = programDAO;
         this.importDAO = importDAO;
         this.brAPIDAOUtil = brAPIDAOUtil;
@@ -82,7 +82,7 @@ public class BrAPITrialDAO {
         }
     }
 
-    private Map<String, BrAPITrial> fetchProgramExperiment(UUID programId) throws ApiException {
+    private Map<String, BrAPITrial> fetchProgramExperiments(UUID programId) throws ApiException {
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
 
         // Get the program
@@ -124,6 +124,8 @@ public class BrAPITrialDAO {
         Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
         List<BrAPITrial> trials = new ArrayList<>();
         if (cache != null) {
+
+            // TODO: replace with more performant cache search, e.g. RediSearch
             trials.addAll(cache
                     .values()
                     .stream()

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
@@ -1,268 +1,31 @@
-/*
- * See the NOTICE file distributed with this work for additional information
- * regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.breedinginsight.brapps.importer.daos;
 
-import io.micronaut.context.annotation.Context;
-import io.micronaut.context.annotation.Property;
-import io.micronaut.http.server.exceptions.InternalServerException;
-import io.micronaut.scheduling.annotation.Scheduled;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.model.exceptions.ApiException;
-import org.brapi.client.v2.modules.core.TrialsApi;
-import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPITrial;
-import org.brapi.v2.model.core.request.BrAPITrialSearchRequest;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
-import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
-import org.breedinginsight.daos.ProgramDAO;
-import org.breedinginsight.daos.cache.ProgramCache;
-import org.breedinginsight.daos.cache.ProgramCacheProvider;
 import org.breedinginsight.model.Program;
-import org.breedinginsight.services.ProgramService;
-import org.breedinginsight.services.brapi.BrAPIEndpointProvider;
 import org.breedinginsight.services.exceptions.DoesNotExistException;
-import org.breedinginsight.utilities.BrAPIDAOUtil;
-import org.breedinginsight.utilities.Utilities;
 
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.stream.Collectors;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
-@Slf4j
-@Context
-@Singleton
-public class BrAPITrialDAO {
-    @Property(name = "brapi.server.reference-source")
-    private String BRAPI_REFERENCE_SOURCE;
-    private final ProgramCache<BrAPITrial> programExperimentCache;
-    private final ProgramDAO programDAO;
-    private final ImportDAO importDAO;
-    private final BrAPIDAOUtil brAPIDAOUtil;
-    private final ProgramService programService;
-    private final BrAPIEndpointProvider brAPIEndpointProvider;
-    private final String referenceSource;
-    @Property(name = "micronaut.bi.api.run-scheduled-tasks")
-    private boolean runScheduledTasks;
-    @Inject
-    public BrAPITrialDAO(ProgramCacheProvider programCacheProvider, ProgramDAO programDAO, ImportDAO importDAO, BrAPIDAOUtil brAPIDAOUtil, ProgramService programService, @Property(name = "brapi.server.reference-source") String referenceSource, BrAPIEndpointProvider brAPIEndpointProvider) {
-        this.programExperimentCache = programCacheProvider.getProgramCache(this::fetchProgramExperiments, BrAPITrial.class);
-        this.programDAO = programDAO;
-        this.importDAO = importDAO;
-        this.brAPIDAOUtil = brAPIDAOUtil;
-        this.programService = programService;
-        this.referenceSource = referenceSource;
-        this.brAPIEndpointProvider = brAPIEndpointProvider;
-    }
+public interface BrAPITrialDAO {
+    List<BrAPITrial> getTrialsByName(List<String> trialNames, Program program) throws ApiException;
 
+    List<BrAPITrial> createBrAPITrials(List<BrAPITrial> brAPITrialList, UUID programId, ImportUpload upload)
+            throws ApiException;
 
-    @Scheduled(initialDelay = "2s")
-    public void setup() {
-        if(!runScheduledTasks) {
-            return;
-        }
+    BrAPITrial updateBrAPITrial(String trialDbId, BrAPITrial trial, UUID programId) throws ApiException;
 
-        // Populate the experiment cache for all programs on startup
-        log.debug("populating experiment cache");
-        List<Program> programs = programDAO.getActive();
-        if (programs != null) {
-            programExperimentCache.populate(programs.stream().map(Program::getId).collect(Collectors.toList()));
-        }
-    }
+    List<BrAPITrial> getTrials(UUID programId) throws ApiException;
 
-    private Map<String, BrAPITrial> fetchProgramExperiments(UUID programId) throws ApiException {
-        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
+    Optional<BrAPITrial> getTrialById(UUID programId, UUID trialId) throws ApiException, DoesNotExistException;
 
-        // Get the program
-        List<Program> programs = programDAO.get(programId);
-        if (programs.size() != 1) {
-            throw new InternalServerException("Program was not found for given key");
-        }
-        Program program = programs.get(0);
+    Optional<BrAPITrial> getTrialByDbId(String trialDbId, Program program) throws ApiException;
 
-        // Get the program experiments
-        BrAPITrialSearchRequest trialSearch = new BrAPITrialSearchRequest();
-        trialSearch.externalReferenceIDs(List.of(programId.toString()));
-        trialSearch.externalReferenceSources(
-                List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS))
-        );
-        List<BrAPITrial> programExperiments = brAPIDAOUtil.search(
-                api::searchTrialsPost,
-                api::searchTrialsSearchResultsDbIdGet,
-                trialSearch
-        );
+    List<BrAPITrial> getTrialsByDbIds(Collection<String> trialDbIds, Program program) throws ApiException;
 
-        return experimentById(processExperimentsForDisplay(programExperiments, program.getKey()));
-    }
-
-    private Map<String, BrAPITrial> experimentById(List<BrAPITrial> trials) {
-        Map<String, BrAPITrial> experimentById = new HashMap<>();
-        for (BrAPITrial experiment: trials) {
-            BrAPIExternalReference xref = experiment
-                    .getExternalReferences()
-                    .stream()
-                    .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.TRIALS).equalsIgnoreCase(reference.getReferenceSource()))
-                    .findFirst().orElseThrow(() -> new IllegalStateException("No BI external reference found"));
-            experimentById.put(xref.getReferenceID(), experiment);
-        }
-        return experimentById;
-    }
-
-    public List<BrAPITrial> getTrialsByName(List<String> trialNames, Program program) throws ApiException {
-        Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
-        List<BrAPITrial> trials = new ArrayList<>();
-        if (cache != null) {
-
-            // TODO: replace with more performant cache search, e.g. RediSearch
-            trials.addAll(cache
-                    .values()
-                    .stream()
-                    .filter(t -> trialNames.contains(t.getTrialName()))
-                    .collect(Collectors.toList()));
-        }
-
-        return trials;
-    }
-
-    private List<BrAPITrial> getTrialsByExRef(String referenceSource, String referenceId, Program program) throws ApiException {
-        Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
-        List<BrAPITrial> trials = new ArrayList<>();
-        if (cache != null) {
-            trials.addAll(cache
-                    .values()
-                    .stream()
-                    .filter(t -> {
-                        BrAPIExternalReference xref = t
-                                .getExternalReferences()
-                                .stream()
-                                .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.TRIALS)
-                                        .equalsIgnoreCase(reference.getReferenceSource()))
-                                .findFirst().orElseThrow(() -> new IllegalStateException("No BI trial external reference found"));
-                        return referenceId.equals(xref.getReferenceID());
-                    })
-                    .collect(Collectors.toList()));
-        }
-
-        return trials;
-    }
-
-    public List<BrAPITrial> createBrAPITrials(List<BrAPITrial> brAPITrialList, UUID programId, ImportUpload upload)
-            throws ApiException {
-        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
-        List<BrAPITrial> createdTrials = new ArrayList<>();
-        try {
-            if (!brAPITrialList.isEmpty()) {
-                Callable<Map<String, BrAPITrial>> postCallback = () -> {
-                    List<BrAPITrial> postedTrials = brAPIDAOUtil
-                            .post(brAPITrialList, upload, api::trialsPost, importDAO::update);
-                    return experimentById(postedTrials);
-                };
-                createdTrials.addAll(programExperimentCache.post(programId, postCallback));
-            }
-
-            return createdTrials;
-        } catch (Exception e) {
-            throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
-        }
-    }
-    public BrAPITrial updateBrAPITrial(String trialDbId, BrAPITrial trial, UUID programId) throws ApiException {
-        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
-        BrAPITrial updatedTrial = null;
-        try {
-            if (trial != null && !trialDbId.isBlank()) {
-                Callable<Map<String, BrAPITrial>> putCallback = () -> {
-                    BrAPITrial putTrial = brAPIDAOUtil.put(trialDbId, trial, api::trialsTrialDbIdPut);
-                    return experimentById(List.of(putTrial));
-                };
-                List<BrAPITrial> cachedUpdates = programExperimentCache.post(programId, putCallback);
-                if (cachedUpdates.isEmpty()) {
-                    throw new Exception();
-                }
-                updatedTrial = cachedUpdates.get(0);
-            }
-
-            return updatedTrial;
-        } catch (Exception e) {
-            throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
-        }
-    }
-
-    public List<BrAPITrial> getTrials(UUID programId) throws ApiException {
-        return new ArrayList<>(programExperimentCache.get(programId).values());
-    }
-
-    //Removes program key from trial name
-    private List<BrAPITrial> processExperimentsForDisplay(
-            List<BrAPITrial> trials,
-            String programKey) throws ApiException {
-        List<BrAPITrial> displayExperiments = new ArrayList<>();
-        for (BrAPITrial trial: trials) {
-            trial.setTrialName(Utilities.removeProgramKey(trial.getTrialName(), programKey, ""));
-            displayExperiments.add(trial);
-        }
-        return displayExperiments;
-    }
-
-    public Optional<BrAPITrial> getTrialById(UUID programId, UUID trialId) throws ApiException, DoesNotExistException {
-        Map<String, BrAPITrial> cache = programExperimentCache.get(programId);
-        BrAPITrial trial = null;
-        if (cache != null) {
-            trial = cache.get(trialId.toString());
-        }
-
-        return Optional.ofNullable(trial);
-    }
-
-    public Optional<BrAPITrial> getTrialByDbId(String trialDbId, Program program) throws ApiException {
-        List<BrAPITrial> trials = getTrialsByDbIds(List.of(trialDbId), program);
-        return Utilities.getSingleOptional(trials);
-    }
-
-    public List<BrAPITrial> getTrialsByDbIds(Collection<String> trialDbIds, Program program) throws ApiException {
-        Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
-        List<BrAPITrial> trials = new ArrayList<>();
-        if (cache != null) {
-            trials.addAll(cache
-                    .values()
-                    .stream()
-                    .filter(t -> trialDbIds.contains(t.getTrialDbId()))
-                    .collect(Collectors.toList()));
-        }
-
-        return trials;
-    }
-    public List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException {
-        if(experimentIds.isEmpty()) {
-            return Collections.emptyList();
-        }
-        BrAPITrialSearchRequest trialSearch = new BrAPITrialSearchRequest();
-        trialSearch.programDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
-        trialSearch.externalReferenceSources(List.of(referenceSource + "/" + ExternalReferenceSource.TRIALS.getName()));
-        trialSearch.externalReferenceIDs(experimentIds.stream().map(id -> id.toString()).collect(Collectors.toList()));
-        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), TrialsApi.class);
-        return brAPIDAOUtil.search(
-                api::searchTrialsPost,
-                api::searchTrialsSearchResultsDbIdGet,
-                trialSearch
-        );
-    }
+    List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException;
 }
-
-

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.core.TrialsApi;
 import org.brapi.v2.model.BrAPIExternalReference;
@@ -110,7 +111,7 @@ public class BrAPITrialDAO {
             BrAPIExternalReference xref = experiment
                     .getExternalReferences()
                     .stream()
-                    .filter(reference -> referenceSource.equals(reference.getReferenceSource()))
+                    .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.TRIALS).equalsIgnoreCase(reference.getReferenceSource()))
                     .findFirst().orElseThrow(() -> new IllegalStateException("No BI external reference found"));
             experimentById.put(xref.getReferenceID(), experiment);
         }

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
@@ -117,6 +117,7 @@ public class BrAPITrialDAO {
         return experimentById;
     }
 
+    /*
     public List<BrAPITrial> getTrialsByName(List<String> trialNames, Program program) throws ApiException {
         if(trialNames.isEmpty()) {
             return Collections.emptyList();
@@ -131,6 +132,19 @@ public class BrAPITrialDAO {
                 api::searchTrialsSearchResultsDbIdGet,
                 trialSearch
         );
+    }*/
+    public List<BrAPITrial> getTrialsByName(List<String> trialNames, Program program) throws ApiException {
+        Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
+        List<BrAPITrial> trials = new ArrayList<>();
+        if (cache != null) {
+            trials.addAll(cache
+                    .values()
+                    .stream()
+                    .filter(t -> trialNames.contains(t.getTrialName()))
+                    .collect(Collectors.toList()));
+        }
+
+        return trials;
     }
 
     private List<BrAPITrial> getTrialsByExRef(String referenceSource, String referenceId, Program program) throws ApiException {

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPITrialDAO.java
@@ -230,12 +230,33 @@ public class BrAPITrialDAO {
     }
 
     public Optional<BrAPITrial> getTrialById(UUID programId, UUID trialDbId) throws ApiException, DoesNotExistException {
+        Program program = programService
+                .getById(programId)
+                .orElseThrow(() -> new DoesNotExistException("Program id does not exist"));
+        Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
+        BrAPITrial trial = null;
+        if (cache != null) {
+            List<BrAPITrial> trials = cache
+                    .values()
+                    .stream()
+                    .filter(t -> t.getTrialDbId().equals(trialDbId))
+                    .collect(Collectors.toList());
+            if (trials.isEmpty()) {
+                throw new DoesNotExistException("trial does not exist for given dbId");
+            }
+            trial = trials.get(0);
+        }
+
+        return Optional.ofNullable(trial);
+    }
+    /*
+    public Optional<BrAPITrial> getTrialById(UUID programId, UUID trialDbId) throws ApiException, DoesNotExistException {
         Program program = programService.getById(programId).orElseThrow(() -> new DoesNotExistException("Program id does not exist"));
         String refSoure = Utilities.generateReferenceSource(BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS);
         List<BrAPITrial> trials = getTrialsByExRef(refSoure, trialDbId.toString(), program);
 
         return Utilities.getSingleOptional(trials);
-    }
+    }*/
 
     public Optional<BrAPITrial> getTrialByDbId(String trialDbId, Program program) throws ApiException {
         List<BrAPITrial> trials = getTrialsByDbIds(List.of(trialDbId), program);

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/impl/BrAPITrialDAOImpl.java
@@ -1,0 +1,282 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.breedinginsight.brapps.importer.daos.impl;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.server.exceptions.InternalServerException;
+import io.micronaut.scheduling.annotation.Scheduled;
+import lombok.extern.slf4j.Slf4j;
+import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.client.v2.modules.core.TrialsApi;
+import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.core.BrAPITrial;
+import org.brapi.v2.model.core.request.BrAPITrialSearchRequest;
+import org.breedinginsight.brapps.importer.daos.BrAPITrialDAO;
+import org.breedinginsight.brapps.importer.daos.ImportDAO;
+import org.breedinginsight.brapps.importer.model.ImportUpload;
+import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.daos.ProgramDAO;
+import org.breedinginsight.daos.cache.ProgramCache;
+import org.breedinginsight.daos.cache.ProgramCacheProvider;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.services.ProgramService;
+import org.breedinginsight.services.brapi.BrAPIEndpointProvider;
+import org.breedinginsight.services.exceptions.DoesNotExistException;
+import org.breedinginsight.utilities.BrAPIDAOUtil;
+import org.breedinginsight.utilities.Utilities;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Context
+@Singleton
+public class BrAPITrialDAOImpl implements BrAPITrialDAO {
+    private final ProgramCache<BrAPITrial> programExperimentCache;
+    private final ProgramDAO programDAO;
+    private final ImportDAO importDAO;
+    private final BrAPIDAOUtil brAPIDAOUtil;
+    private final ProgramService programService;
+    private final BrAPIEndpointProvider brAPIEndpointProvider;
+    private final String referenceSource;
+    private final boolean runScheduledTasks;
+
+    @Inject
+    public BrAPITrialDAOImpl(ProgramCacheProvider programCacheProvider,
+                             ProgramDAO programDAO,
+                             ImportDAO importDAO,
+                             BrAPIDAOUtil brAPIDAOUtil,
+                             ProgramService programService,
+                             @Property(name = "brapi.server.reference-source") String referenceSource,
+                             BrAPIEndpointProvider brAPIEndpointProvider,
+                             @Property(name = "micronaut.bi.api.run-scheduled-tasks") boolean runScheduledTasks) {
+        this.programExperimentCache = programCacheProvider.getProgramCache(this::fetchProgramExperiments, BrAPITrial.class);
+        this.programDAO = programDAO;
+        this.importDAO = importDAO;
+        this.brAPIDAOUtil = brAPIDAOUtil;
+        this.programService = programService;
+        this.referenceSource = referenceSource;
+        this.brAPIEndpointProvider = brAPIEndpointProvider;
+        this.runScheduledTasks = runScheduledTasks;
+    }
+
+
+    @Scheduled(initialDelay = "2s")
+    public void setup() {
+        if(!runScheduledTasks) {
+            return;
+        }
+
+        // Populate the experiment cache for all programs on startup
+        log.debug("populating experiment cache");
+        List<Program> programs = programDAO.getActive();
+        if (programs != null) {
+            programExperimentCache.populate(programs.stream().map(Program::getId).collect(Collectors.toList()));
+        }
+    }
+
+    private Map<String, BrAPITrial> fetchProgramExperiments(UUID programId) throws ApiException {
+        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
+
+        // Get the program
+        List<Program> programs = programDAO.get(programId);
+        if (programs.size() != 1) {
+            throw new InternalServerException("Program was not found for given key");
+        }
+        Program program = programs.get(0);
+
+        // Get the program experiments
+        BrAPITrialSearchRequest trialSearch = new BrAPITrialSearchRequest();
+        trialSearch.externalReferenceIDs(List.of(programId.toString()));
+        trialSearch.externalReferenceSources(
+                List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS))
+        );
+        List<BrAPITrial> programExperiments = brAPIDAOUtil.search(
+                api::searchTrialsPost,
+                api::searchTrialsSearchResultsDbIdGet,
+                trialSearch
+        );
+
+        return experimentById(processExperimentsForDisplay(programExperiments, program.getKey()));
+    }
+
+    private Map<String, BrAPITrial> experimentById(List<BrAPITrial> trials) {
+        Map<String, BrAPITrial> experimentById = new HashMap<>();
+        for (BrAPITrial experiment: trials) {
+            BrAPIExternalReference xref = experiment
+                    .getExternalReferences()
+                    .stream()
+                    .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.TRIALS).equalsIgnoreCase(reference.getReferenceSource()))
+                    .findFirst().orElseThrow(() -> new IllegalStateException("No BI external reference found"));
+            experimentById.put(xref.getReferenceID(), experiment);
+        }
+        return experimentById;
+    }
+
+    @Override
+    public List<BrAPITrial> getTrialsByName(List<String> trialNames, Program program) throws ApiException {
+        Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
+        List<BrAPITrial> trials = new ArrayList<>();
+        if (cache != null) {
+
+            // TODO: replace with more performant cache search, e.g. RediSearch
+            trials.addAll(cache
+                    .values()
+                    .stream()
+                    .filter(t -> trialNames.contains(t.getTrialName()))
+                    .collect(Collectors.toList()));
+        }
+
+        return trials;
+    }
+
+    private List<BrAPITrial> getTrialsByExRef(String referenceSource, String referenceId, Program program) throws ApiException {
+        Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
+        List<BrAPITrial> trials = new ArrayList<>();
+        if (cache != null) {
+            trials.addAll(cache
+                    .values()
+                    .stream()
+                    .filter(t -> {
+                        BrAPIExternalReference xref = t
+                                .getExternalReferences()
+                                .stream()
+                                .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.TRIALS)
+                                        .equalsIgnoreCase(reference.getReferenceSource()))
+                                .findFirst().orElseThrow(() -> new IllegalStateException("No BI trial external reference found"));
+                        return referenceId.equals(xref.getReferenceID());
+                    })
+                    .collect(Collectors.toList()));
+        }
+
+        return trials;
+    }
+
+    @Override
+    public List<BrAPITrial> createBrAPITrials(List<BrAPITrial> brAPITrialList, UUID programId, ImportUpload upload)
+            throws ApiException {
+        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
+        List<BrAPITrial> createdTrials = new ArrayList<>();
+        try {
+            if (!brAPITrialList.isEmpty()) {
+                Callable<Map<String, BrAPITrial>> postCallback = () -> {
+                    List<BrAPITrial> postedTrials = brAPIDAOUtil
+                            .post(brAPITrialList, upload, api::trialsPost, importDAO::update);
+                    return experimentById(postedTrials);
+                };
+                createdTrials.addAll(programExperimentCache.post(programId, postCallback));
+            }
+
+            return createdTrials;
+        } catch (Exception e) {
+            throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
+        }
+    }
+    @Override
+    public BrAPITrial updateBrAPITrial(String trialDbId, BrAPITrial trial, UUID programId) throws ApiException {
+        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
+        BrAPITrial updatedTrial = null;
+        try {
+            if (trial != null && !trialDbId.isBlank()) {
+                Callable<Map<String, BrAPITrial>> putCallback = () -> {
+                    BrAPITrial putTrial = brAPIDAOUtil.put(trialDbId, trial, api::trialsTrialDbIdPut);
+                    return experimentById(List.of(putTrial));
+                };
+                List<BrAPITrial> cachedUpdates = programExperimentCache.post(programId, putCallback);
+                if (cachedUpdates.isEmpty()) {
+                    throw new Exception();
+                }
+                updatedTrial = cachedUpdates.get(0);
+            }
+
+            return updatedTrial;
+        } catch (Exception e) {
+            throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<BrAPITrial> getTrials(UUID programId) throws ApiException {
+        return new ArrayList<>(programExperimentCache.get(programId).values());
+    }
+
+    //Removes program key from trial name
+    private List<BrAPITrial> processExperimentsForDisplay(
+            List<BrAPITrial> trials,
+            String programKey) throws ApiException {
+        List<BrAPITrial> displayExperiments = new ArrayList<>();
+        for (BrAPITrial trial: trials) {
+            trial.setTrialName(Utilities.removeProgramKey(trial.getTrialName(), programKey, ""));
+            displayExperiments.add(trial);
+        }
+        return displayExperiments;
+    }
+
+    @Override
+    public Optional<BrAPITrial> getTrialById(UUID programId, UUID trialId) throws ApiException, DoesNotExistException {
+        Map<String, BrAPITrial> cache = programExperimentCache.get(programId);
+        BrAPITrial trial = null;
+        if (cache != null) {
+            trial = cache.get(trialId.toString());
+        }
+
+        return Optional.ofNullable(trial);
+    }
+
+    @Override
+    public Optional<BrAPITrial> getTrialByDbId(String trialDbId, Program program) throws ApiException {
+        List<BrAPITrial> trials = getTrialsByDbIds(List.of(trialDbId), program);
+        return Utilities.getSingleOptional(trials);
+    }
+
+    @Override
+    public List<BrAPITrial> getTrialsByDbIds(Collection<String> trialDbIds, Program program) throws ApiException {
+        Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
+        List<BrAPITrial> trials = new ArrayList<>();
+        if (cache != null) {
+            trials.addAll(cache
+                    .values()
+                    .stream()
+                    .filter(t -> trialDbIds.contains(t.getTrialDbId()))
+                    .collect(Collectors.toList()));
+        }
+
+        return trials;
+    }
+    @Override
+    public List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException {
+        if(experimentIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        BrAPITrialSearchRequest trialSearch = new BrAPITrialSearchRequest();
+        trialSearch.programDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
+        trialSearch.externalReferenceSources(List.of(referenceSource + "/" + ExternalReferenceSource.TRIALS.getName()));
+        trialSearch.externalReferenceIDs(experimentIds.stream().map(id -> id.toString()).collect(Collectors.toList()));
+        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), TrialsApi.class);
+        return brAPIDAOUtil.search(
+                api::searchTrialsPost,
+                api::searchTrialsSearchResultsDbIdGet,
+                trialSearch
+        );
+    }
+}
+
+

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1141,7 +1141,7 @@ public class ExperimentProcessor implements Processor {
 
         List<String> uniqueTrialNames = experimentImportRows.stream()
                                                             .filter(row -> StringUtils.isBlank(row.getObsUnitID()))
-                                                            .map(experimentImport -> Utilities.appendProgramKey(experimentImport.getExpTitle(), programKey))
+                                                            .map(ExperimentObservation::getExpTitle)
                                                             .distinct()
                                                             .collect(Collectors.toList());
         try {

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -304,7 +304,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         newExp.put(Columns.ROW, "1");
         newExp.put(Columns.COLUMN, "1");
 
-        importTestUtils.uploadAndFetch(writeDataToFile(List.of(newExp), null), null, true, client, program, mappingId);
+        JsonObject expResult = importTestUtils.uploadAndFetch(writeDataToFile(List.of(newExp), null), null, true, client, program, mappingId);
 
         Map<String, Object> newEnv = new HashMap<>();
         newEnv.put(Columns.GERMPLASM_GID, "1");
@@ -634,7 +634,7 @@ public class ExperimentFileImportTest extends BrAPITest {
 
         importTestUtils.uploadAndFetch(writeDataToFile(List.of(newExp), null), null, true, client, program, mappingId);
 
-        BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of(Utilities.appendProgramKey((String)newExp.get(Columns.EXP_TITLE), program.getKey())), program).get(0);
+        BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
         BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceID()), program).get(0);
@@ -699,7 +699,7 @@ public class ExperimentFileImportTest extends BrAPITest {
 
         importTestUtils.uploadAndFetch(writeDataToFile(List.of(newExp), null), null, true, client, program, mappingId);
 
-        BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of(Utilities.appendProgramKey((String)newExp.get(Columns.EXP_TITLE), program.getKey())), program).get(0);
+        BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
         BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceID()), program).get(0);
@@ -766,7 +766,7 @@ public class ExperimentFileImportTest extends BrAPITest {
 
         importTestUtils.uploadAndFetch(writeDataToFile(List.of(newExp), traits), null, true, client, program, mappingId);
 
-        BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of(Utilities.appendProgramKey((String)newExp.get(Columns.EXP_TITLE), program.getKey())), program).get(0);
+        BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
         BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceID()), program).get(0);
@@ -866,7 +866,7 @@ public class ExperimentFileImportTest extends BrAPITest {
     private Map<String, Object> assertRowSaved(Map<String, Object> expected, Program program, List<Trait> traits) throws ApiException {
         Map<String, Object> ret = new HashMap<>();
 
-        List<BrAPITrial> trials = brAPITrialDAO.getTrialsByName(List.of(Utilities.appendProgramKey((String)expected.get(Columns.EXP_TITLE), program.getKey())), program);
+        List<BrAPITrial> trials = brAPITrialDAO.getTrialsByName(List.of((String)expected.get(Columns.EXP_TITLE)), program);
         assertFalse(trials.isEmpty());
         BrAPITrial trial = trials.get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(trial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));

--- a/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
@@ -43,9 +43,9 @@ import org.brapi.v2.model.pheno.response.BrAPIObservationUnitListResponse;
 import org.brapi.v2.model.pheno.response.BrAPIObservationUnitListResponseResult;
 import org.breedinginsight.DatabaseTest;
 import org.breedinginsight.brapps.importer.daos.BrAPITrialDAO;
-import org.breedinginsight.brapps.importer.daos.impl.BrAPITrialDAOImpl;
 import org.breedinginsight.brapps.importer.daos.ImportDAO;
 import org.breedinginsight.brapps.importer.daos.ImportMappingDAO;
+import org.breedinginsight.brapps.importer.daos.impl.BrAPITrialDAOImpl;
 import org.breedinginsight.brapps.importer.daos.impl.ImportMappingDAOImpl;
 import org.breedinginsight.brapps.importer.model.ImportProgress;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
@@ -55,7 +55,6 @@ import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.dao.db.tables.pojos.ImporterImportEntity;
 import org.breedinginsight.daos.ProgramDAO;
 import org.breedinginsight.daos.UserDAO;
-import org.breedinginsight.daos.cache.ProgramCacheProvider;
 import org.breedinginsight.daos.impl.ProgramDAOImpl;
 import org.breedinginsight.daos.impl.UserDAOImpl;
 import org.breedinginsight.model.BrAPIConstants;
@@ -152,8 +151,6 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
 
     @Inject
     private BrAPIEndpointProvider brAPIEndpointProvider;
-    @Inject
-    private ProgramCacheProvider cacheProvider;
 
     @Property(name = "gigwa.host")
     private String gigwaHost;
@@ -195,16 +192,6 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
     BrAPITrialDAO trialDAO() {
         return mock(BrAPITrialDAOImpl.class);
     }
-
-/*
-    @MockBean(BrAPITrialDAO.class)
-    BrAPITrialDAO trialDAO() {
-        return spy(new BrAPITrialDAO(cacheProvider, programDAO, importDAO, brAPIDAOUtil, mock(ProgramService.class),referenceSource , brAPIEndpointProvider, false));
-    }
-
- */
-
-
 
 
     @MockBean(BrAPIDAOUtil.class)
@@ -301,10 +288,7 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
 
         storageService = applicationContext.getBean(SimpleStorageService.class, Qualifiers.byName("genotype"));
         storageService.createBucket();
-        //cacheProvider = new ProgramCacheProvider(super.getRedisConnection());
-        //trialDAO = new BrAPITrialDAO(cacheProvider, programDAO, importDAO, brAPIDAOUtil, mock(ProgramService.class),System.getenv("BRAPI_REFERENCE_SOURCE") , new BrAPIEndpointProvider());
-        //trialDAO = Mockito.spy(new BrAPITrialDAO(cacheProvider, programDAO, importDAO, brAPIDAOUtil, mock(ProgramService.class),referenceSource , new BrAPIEndpointProvider()));
-    }
+     }
 
     @AfterAll
     public void teardown() {


### PR DESCRIPTION
# Description
**Story:** [BI-1294](https://breedinginsight.atlassian.net/browse/BI-1294)

An instance of `ProgramCache` was added as a field in `BrAPITrialDAO` for caching experiments on the redis server. Methods in the DAO were updated to create,update, and read experiemnts from the cache. The program key was stripped from the trial name before storing in the cache.



# Dependencies
none

# Testing
Verify that experiment importing, exporting, and displaying of experiments in both group table and individual table still works as expected with lower latency.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1294]: https://breedinginsight.atlassian.net/browse/BI-1294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ