### PR TITLE
[BI-1819] Experimental download file: phenotypes are out of order

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
@@ -17,26 +17,19 @@
 
 package org.breedinginsight.brapps.importer.services;
 
-import io.micronaut.http.server.exceptions.InternalServerException;
 import io.reactivex.functions.Function;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
-import org.breedinginsight.brapps.importer.daos.*;
-import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.config.MappedImportRelation;
-import org.breedinginsight.brapps.importer.model.mapping.ImportMapping;
-import org.breedinginsight.brapps.importer.model.mapping.MappingField;
-import org.breedinginsight.model.Trait;
-import org.jooq.DSLContext;
 import tech.tablesaw.api.Row;
 import tech.tablesaw.api.Table;
-import tech.tablesaw.columns.Column;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Singleton
 public class FileMappingUtil {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -207,8 +207,6 @@ public class ExperimentProcessor implements Processor {
         ValidationErrors validationErrors = new ValidationErrors();
 
         // Get dynamic phenotype columns for processing
-        //List<Column<?>> dynamicCols = fileMappingUtil.getDynamicColumns(upload, data);
-
         List<Column<?>> dynamicCols = data.columns(upload.getDynamicColumnNames());
         List<Column<?>> phenotypeCols = new ArrayList<>();
         List<Column<?>> timestampCols = new ArrayList<>();

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -195,6 +195,7 @@ public class ExperimentProcessor implements Processor {
      */
     @Override
     public Map<String, ImportPreviewStatistics> process(
+            ImportUpload upload,
             List<BrAPIImport> importRows,
             Map<Integer, PendingImport> mappedBrAPIImport,
             Table data,
@@ -206,7 +207,9 @@ public class ExperimentProcessor implements Processor {
         ValidationErrors validationErrors = new ValidationErrors();
 
         // Get dynamic phenotype columns for processing
-        List<Column<?>> dynamicCols = fileMappingUtil.getDynamicColumns(data, EXPERIMENT_TEMPLATE_NAME);
+        //List<Column<?>> dynamicCols = fileMappingUtil.getDynamicColumns(upload, data);
+
+        List<Column<?>> dynamicCols = data.columns(upload.getDynamicColumnNames());
         List<Column<?>> phenotypeCols = new ArrayList<>();
         List<Column<?>> timestampCols = new ArrayList<>();
         for (Column<?> dynamicCol : dynamicCols) {
@@ -436,7 +439,9 @@ public class ExperimentProcessor implements Processor {
                                           "Timestamp column(s) lack corresponding phenotype column(s): " + String.join(COMMA_DELIMITER, unmatchedTimestamps));
         }
 
-        return filteredTraits;
+        // sort the verified traits to match the order of the trait columns
+        List<String> phenotypeColNames = phenotypeCols.stream().map(Column::name).collect(Collectors.toList());
+        return fileMappingUtil.sortByField(phenotypeColNames, filteredTraits, TraitEntity::getObservationVariableName);
     }
 
     private List<Trait> fetchFileTraits(UUID programId, Collection<String> varNames) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -16,9 +16,6 @@
  */
 package org.breedinginsight.brapps.importer.services.processors;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.http.HttpStatus;
@@ -30,7 +27,6 @@ import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.core.BrAPIListSummary;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
-import org.brapi.v2.model.germ.BrAPIGermplasmSynonyms;
 import org.breedinginsight.api.model.v1.response.ValidationError;
 import org.breedinginsight.api.model.v1.response.ValidationErrors;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
@@ -221,7 +217,7 @@ public class GermplasmProcessor implements Processor {
     }
 
     @Override
-    public Map<String, ImportPreviewStatistics> process(List<BrAPIImport> importRows,
+    public Map<String, ImportPreviewStatistics> process(ImportUpload upload, List<BrAPIImport> importRows,
                                                         Map<Integer, PendingImport> mappedBrAPIImport, Table data,
                                                         Program program, User user, boolean commit) throws ValidatorException {
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/LocationProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/LocationProcessor.java
@@ -78,7 +78,7 @@ public class LocationProcessor implements Processor {
     }
 
     @Override
-    public Map<String, ImportPreviewStatistics> process(List<BrAPIImport> importRows,
+    public Map<String, ImportPreviewStatistics> process(ImportUpload upload, List<BrAPIImport> importRows,
                                                         Map<Integer, PendingImport> mappedBrAPIImport, Table data,
                                                         Program program, User user, boolean commit) throws ValidatorException {
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ObservationProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ObservationProcessor.java
@@ -142,7 +142,7 @@ public class ObservationProcessor implements Processor {
     }
 
     @Override
-    public Map<String, ImportPreviewStatistics> process(List<BrAPIImport> importRows,
+    public Map<String, ImportPreviewStatistics> process(ImportUpload upload, List<BrAPIImport> importRows,
                                                         Map<Integer,PendingImport> mappedBrAPIImport, Table data,
                                                         Program program, User user, boolean commit) throws ValidatorException {
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ObservationUnitProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ObservationUnitProcessor.java
@@ -88,7 +88,7 @@ public class ObservationUnitProcessor implements Processor {
     }
 
     @Override
-    public Map<String, ImportPreviewStatistics> process(List<BrAPIImport> importRows,
+    public Map<String, ImportPreviewStatistics> process(ImportUpload upload, List<BrAPIImport> importRows,
                                                         Map<Integer,PendingImport> mappedBrAPIImport, Table data,
                                                         Program program, User user, boolean commit) {
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/Processor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/Processor.java
@@ -43,6 +43,8 @@ public interface Processor {
     /**
      * Update mappedBrAPIImport mapping with PendingImport data for brapi object based on new and existing objects.
      * Return stats on number of new & existing objects
+     *
+     * @param upload
      * @param importRows
      * @param mappedBrAPIImport
      * @param data
@@ -50,7 +52,7 @@ public interface Processor {
      * @return
      * @throws ValidatorException
      */
-    Map<String, ImportPreviewStatistics> process(List<BrAPIImport> importRows,
+    Map<String, ImportPreviewStatistics> process(ImportUpload upload, List<BrAPIImport> importRows,
                                                  Map<Integer, PendingImport> mappedBrAPIImport, Table data,
                                                  Program program, User user, boolean commit)
             throws ValidatorException, MissingRequiredInfoException, ApiException;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
@@ -62,7 +62,7 @@ public class ProcessorManager {
             log.debug("Checking existing " + processor.getName().toLowerCase() + " objects in brapi service and mapping data");
             statusService.updateMessage(upload, "Checking existing " + processor.getName().toLowerCase() + " objects in brapi service and mapping data");
             processor.getExistingBrapiData(importRows, program);
-            Map<String, ImportPreviewStatistics> stats = processor.process(importRows, mappedBrAPIImport, data, program, user, commit);
+            Map<String, ImportPreviewStatistics> stats = processor.process(upload, importRows, mappedBrAPIImport, data, program, user, commit);
             statistics.putAll(stats);
         }
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/StudyProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/StudyProcessor.java
@@ -21,7 +21,6 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import org.brapi.client.v2.model.exceptions.ApiException;
-import org.brapi.v2.model.core.BrAPILocation;
 import org.brapi.v2.model.core.BrAPIStudy;
 import org.brapi.v2.model.core.BrAPITrial;
 import org.breedinginsight.brapps.importer.daos.BrAPIStudyDAO;
@@ -80,7 +79,7 @@ public class StudyProcessor implements Processor {
     }
 
     @Override
-    public Map<String, ImportPreviewStatistics> process(List<BrAPIImport> importRows,
+    public Map<String, ImportPreviewStatistics> process(ImportUpload upload, List<BrAPIImport> importRows,
                                                         Map<Integer, PendingImport> mappedBrAPIImport, Table data,
                                                         Program program, User user, boolean commit) {
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/TrialProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/TrialProcessor.java
@@ -74,7 +74,7 @@ public class TrialProcessor implements Processor {
     }
 
     @Override
-    public Map<String, ImportPreviewStatistics> process(List<BrAPIImport> importRows,
+    public Map<String, ImportPreviewStatistics> process(ImportUpload upload, List<BrAPIImport> importRows,
                                                         Map<Integer, PendingImport> mappedBrAPIImport, Table data,
                                                         Program program, User user, boolean commit) throws ValidatorException {
 


### PR DESCRIPTION
# Description
**Story:** [BI-1819](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1819)

A reference to the import upload was added to the signature of the interface method `Processor::process` so that the order of the dynamic columns in the import file can be used when creating a new observation dataset.

`TrialService::exportObservations` was updated to use the order of the names in the observation dataset obs var list returned from the brapi service when creating the dynamic columns for export.

# Dependencies
none
# Testing

1. using the deltabreed ui, upload an experiment containing multiple Observation Variable columns with or without observation data.
2. verify that the order of the obs var columns matches the order in the import file
3. import the experiment
4. go to the Experiment&Observations table and click Download for the new experiment
5. verify the order of the obs var columns in the downloaded file matches those in the original import file.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1819]: https://breedinginsight.atlassian.net/browse/BI-1819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ