### PR TITLE
[BI-1825] add check for legacy trait names in ExperimentProcessor

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -841,6 +841,12 @@ public class ExperimentProcessor implements Processor {
         BrAPIListDetails details = pio.getBrAPIObject();
         referencedTraits.forEach(trait -> {
             String id = Utilities.appendProgramKey(trait.getObservationVariableName(), program.getKey());
+
+            // Don't append the key if connected to a brapi service operating with legacy data(no appended program key)
+            if (trait.getFullName() == null) {
+                id = trait.getObservationVariableName();
+            }
+
             if (!details.getData().contains(id) && ImportObjectState.EXISTING != pio.getState()) {
                 details.getData().add(id);
             }


### PR DESCRIPTION
# Description
**Story:** [BI-1825](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1825)

Update dExperimentProcessor::addObsVarsToDatasetDetails ([GitHub link](https://github.com/Breeding-Insight/bi-api/blob/3a3c7f21dd4f1deebb1989238c58739501f0b20b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java#L837)) to check if the Trait.fullName field is populated, and if so, then append the program key, otherwise don’t.

# Dependencies
testing needs to be done with a program connected to a brapi service using legacy trait names

# Testing
To test, upload an experiment with phenotypic data that uses Traits that are defined in BreedBase without program key namespacing.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1825]: https://breedinginsight.atlassian.net/browse/BI-1825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ