### PR TITLE
bug fix - added null check and log

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -254,8 +254,17 @@ public class BrAPITrialService {
             BrAPIObservationVariable var,
             Program program) {
         String varName = Utilities.removeProgramKey(obs.getObservationVariableName(), program.getKey());
-        if (var.getScale().getDataType().equals(BrAPITraitDataType.NUMERICAL) ||
-                var.getScale().getDataType().equals(BrAPITraitDataType.DURATION)) {
+
+        //  Non-null Scale DataType expected, in case of exceptions: log and treat value as string.
+        boolean isScaleOrDataTypeNull = var.getScale() == null || var.getScale().getDataType() == null;
+        if (isScaleOrDataTypeNull)
+        {
+            log.warn("Observation Variable Scale DataType is null for programId:" + program.getId() + " variable:" + varName);
+        }
+
+        if (!isScaleOrDataTypeNull &&
+                (var.getScale().getDataType().equals(BrAPITraitDataType.NUMERICAL) ||
+                    var.getScale().getDataType().equals(BrAPITraitDataType.DURATION))) {
             row.put(varName, Double.parseDouble(obs.getValue()));
         } else {
             row.put(varName, obs.getValue());


### PR DESCRIPTION
# Description
**Story:** No story, to reproduce, try downloading [this experiment on rel-test](https://rel-test.breedinginsight.net/programs/aac84a58-27f9-4fb0-900e-39eb0f3bed13/experiment/610dcddb-10a9-432c-9641-6e3dd174f57c). Excerpt from biapi logs below.
```
java.lang.NullPointerException: null
    at org.breedinginsight.brapi.v2.services.BrAPITrialService.addObsVarDataToRow(BrAPITrialService.java:253)
```

ObservationVariables should always have a Scale and Scale DataType, but I added code to handle the null case that will:
1. log a warning and
2. default to treating the value as a string.

If approved I'll merge into release/0.8 as well.

# Testing
_Please include any details needed for reviewers to test this code_


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
