### PR TITLE
BI-1832 - Treatment factors not being stored in BreedBase

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
@@ -43,4 +43,6 @@ public final class BrAPIAdditionalInfoFields {
     public static final String OBSERVATION_DATASET_ID = "observationDatasetId";
     public static final String FEMALE_PARENT_UNKNOWN = "femaleParentUnknown";
     public static final String MALE_PARENT_UNKNOWN = "maleParentUnknown";
+
+    public static final String TREATMENTS = "treatments";
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
@@ -17,11 +17,19 @@
 
 package org.breedinginsight.brapps.importer.daos;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 import io.micronaut.context.annotation.Property;
+import org.brapi.client.v2.JSON;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.phenotype.ObservationUnitsApi;
+import org.brapi.v2.model.pheno.BrAPIObservation;
+import org.brapi.v2.model.pheno.BrAPIObservationTreatment;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
 import org.brapi.v2.model.pheno.request.BrAPIObservationUnitSearchRequest;
+import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.daos.ProgramDAO;
@@ -34,7 +42,9 @@ import org.breedinginsight.utilities.BrAPIDAOUtil;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.validation.constraints.NotNull;
+import java.lang.reflect.Type;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Singleton
 public class BrAPIObservationUnitDAO {
@@ -45,6 +55,9 @@ public class BrAPIObservationUnitDAO {
     private final ProgramService programService;
 
     private final String referenceSource;
+
+    private Gson gson = new JSON().getGson();
+    private Type treatmentlistType = new TypeToken<ArrayList<BrAPIObservationTreatment>>(){}.getType();
 
     @Inject
     public BrAPIObservationUnitDAO(ProgramDAO programDAO, ImportDAO importDAO, BrAPIDAOUtil brAPIDAOUtil, BrAPIEndpointProvider brAPIEndpointProvider, ProgramService programService, @Property(name = "brapi.server.reference-source") String referenceSource) {
@@ -64,17 +77,15 @@ public class BrAPIObservationUnitDAO {
         BrAPIObservationUnitSearchRequest observationUnitSearchRequest = new BrAPIObservationUnitSearchRequest();
         observationUnitSearchRequest.programDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
         observationUnitSearchRequest.observationUnitNames(observationUnitNames);
-        ObservationUnitsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), ObservationUnitsApi.class);
-        return brAPIDAOUtil.search(
-                api::searchObservationunitsPost,
-                api::searchObservationunitsSearchResultsDbIdGet,
-                observationUnitSearchRequest
-        );
+
+        return searchObservationUnitsAndProcess(observationUnitSearchRequest, program.getId());
     }
 
     public List<BrAPIObservationUnit> createBrAPIObservationUnits(List<BrAPIObservationUnit> brAPIObservationUnitList, UUID programId, ImportUpload upload) throws ApiException {
         ObservationUnitsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ObservationUnitsApi.class);
-        return brAPIDAOUtil.post(brAPIObservationUnitList, upload, api::observationunitsPost, importDAO::update);
+        List<BrAPIObservationUnit> ous = brAPIDAOUtil.post(brAPIObservationUnitList, upload, api::observationunitsPost, importDAO::update);
+        processObservationUnits(ous);
+        return ous;
     }
 
     public List<BrAPIObservationUnit> getObservationUnitsById(Collection<String> observationUnitExternalIds, Program program) throws ApiException {
@@ -88,10 +99,7 @@ public class BrAPIObservationUnitDAO {
         observationUnitSearchRequest.externalReferenceIDs(new ArrayList<>(observationUnitExternalIds));
         observationUnitSearchRequest.externalReferenceSources(List.of(String.format("%s/%s", referenceSource, ExternalReferenceSource.OBSERVATION_UNITS.getName())));
 
-        ObservationUnitsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), ObservationUnitsApi.class);
-        return brAPIDAOUtil.search(api::searchObservationunitsPost,
-                                   api::searchObservationunitsSearchResultsDbIdGet,
-                                   observationUnitSearchRequest);
+        return searchObservationUnitsAndProcess(observationUnitSearchRequest, program.getId());
     }
 
     public List<BrAPIObservationUnit> getObservationUnitsForStudyDbId(@NotNull String studyDbId, Program program) throws ApiException {
@@ -100,10 +108,7 @@ public class BrAPIObservationUnitDAO {
                 .getProgramDbId()));
         observationUnitSearchRequest.studyDbIds(List.of(studyDbId));
 
-        ObservationUnitsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), ObservationUnitsApi.class);
-        return brAPIDAOUtil.search(api::searchObservationunitsPost,
-                api::searchObservationunitsSearchResultsDbIdGet,
-                observationUnitSearchRequest);
+        return searchObservationUnitsAndProcess(observationUnitSearchRequest, program.getId());
     }
     public List<BrAPIObservationUnit> getObservationUnitsForTrialDbId(@NotNull UUID programId, @NotNull String trialDbId) throws ApiException, DoesNotExistException {
         Program program = programService.getById(programId).orElseThrow(() -> new DoesNotExistException("Program id does not exist"));
@@ -113,9 +118,37 @@ public class BrAPIObservationUnitDAO {
                 .getProgramDbId()));
         observationUnitSearchRequest.trialDbIds(List.of(trialDbId));
 
-        ObservationUnitsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), ObservationUnitsApi.class);
-        return brAPIDAOUtil.search(api::searchObservationunitsPost,
+        return searchObservationUnitsAndProcess(observationUnitSearchRequest, programId);
+    }
+
+
+    /**
+     * Perform observation unit search and process returned observation units to handle any modifications to the data
+     * to be returned by bi-api
+     */
+    private List<BrAPIObservationUnit> searchObservationUnitsAndProcess(BrAPIObservationUnitSearchRequest request, UUID programId) throws ApiException {
+
+        ObservationUnitsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ObservationUnitsApi.class);
+        List<BrAPIObservationUnit> brapiObservationUnits = brAPIDAOUtil.search(api::searchObservationunitsPost,
                 api::searchObservationunitsSearchResultsDbIdGet,
-                observationUnitSearchRequest);
+                request);
+
+        processObservationUnits(brapiObservationUnits);
+        return brapiObservationUnits;
+    }
+
+    private void processObservationUnits(List<BrAPIObservationUnit> brapiObservationUnits) {
+
+        // if has treatments in additionalInfo but not treatments property, copy to treatments property
+        for (BrAPIObservationUnit ou : brapiObservationUnits) {
+            JsonObject additionalInfo = ou.getAdditionalInfo();
+            if (additionalInfo != null) {
+                JsonElement treatmentsElement = additionalInfo.get(BrAPIAdditionalInfoFields.TREATMENTS);
+                if (treatmentsElement != null) {
+                    List<BrAPIObservationTreatment> treatments = gson.fromJson(treatmentsElement, treatmentlistType);
+                    ou.setTreatments(treatments);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
@@ -54,8 +54,8 @@ public class BrAPIObservationUnitDAO {
 
     private final String referenceSource;
 
-    private Gson gson = new JSON().getGson();
-    private Type treatmentlistType = new TypeToken<ArrayList<BrAPIObservationTreatment>>(){}.getType();
+    private final Gson gson = new JSON().getGson();
+    private final Type treatmentlistType = new TypeToken<ArrayList<BrAPIObservationTreatment>>(){}.getType();
 
     @Inject
     public BrAPIObservationUnitDAO(ProgramDAO programDAO, ImportDAO importDAO, BrAPIDAOUtil brAPIDAOUtil, BrAPIEndpointProvider brAPIEndpointProvider, ProgramService programService, @Property(name = "brapi.server.reference-source") String referenceSource) {

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
@@ -141,7 +141,7 @@ public class BrAPIObservationUnitDAO {
 
     private void processObservationUnits(List<BrAPIObservationUnit> brapiObservationUnits) {
 
-        // if has treatments in additionalInfo but not treatments property, copy to treatments property
+        // if has treatments in additionalInfo, copy to treatments property
         for (BrAPIObservationUnit ou : brapiObservationUnits) {
             JsonObject additionalInfo = ou.getAdditionalInfo();
             if (additionalInfo != null) {

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -290,6 +290,9 @@ public class ExperimentObservation implements BrAPIImport {
             BrAPIObservationTreatment treatment = new BrAPIObservationTreatment();
             treatment.setFactor(getTreatmentFactors());
             observationUnit.setTreatments(List.of(treatment));
+
+            // Store treatments in additionalinfo as well for temporary BreedBase workaround
+            observationUnit.putAdditionalInfoItem(BrAPIAdditionalInfoFields.TREATMENTS, List.of(treatment));
         }
 
         if (getObsUnitID() != null) {

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -290,9 +290,6 @@ public class ExperimentObservation implements BrAPIImport {
             BrAPIObservationTreatment treatment = new BrAPIObservationTreatment();
             treatment.setFactor(getTreatmentFactors());
             observationUnit.setTreatments(List.of(treatment));
-
-            // Store treatments in additionalinfo as well for temporary BreedBase workaround
-            observationUnit.putAdditionalInfoItem(BrAPIAdditionalInfoFields.TREATMENTS, List.of(treatment));
         }
 
         if (getObsUnitID() != null) {

--- a/src/test/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAOTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAOTest.java
@@ -1,0 +1,144 @@
+package org.breedinginsight.brapps.importer.daos;
+
+import com.google.gson.Gson;
+import io.kowalski.fannypack.FannyPack;
+import io.micronaut.http.client.RxHttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import lombok.SneakyThrows;
+import org.brapi.client.v2.JSON;
+import org.brapi.v2.model.pheno.BrAPIObservationTreatment;
+import org.brapi.v2.model.pheno.BrAPIObservationUnit;
+import org.breedinginsight.BrAPITest;
+import org.breedinginsight.api.model.v1.request.ProgramRequest;
+import org.breedinginsight.api.model.v1.request.SpeciesRequest;
+import org.breedinginsight.api.v1.controller.TestTokenValidator;
+import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
+import org.breedinginsight.brapps.importer.model.ImportProgress;
+import org.breedinginsight.brapps.importer.model.ImportUpload;
+import org.breedinginsight.dao.db.tables.pojos.SpeciesEntity;
+import org.breedinginsight.daos.SpeciesDAO;
+import org.breedinginsight.daos.UserDAO;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.model.User;
+import org.breedinginsight.services.ProgramService;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.*;
+
+import javax.inject.Inject;
+import java.util.List;
+
+import static org.breedinginsight.TestUtils.insertAndFetchTestProgram;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class BrAPIObservationUnitDAOTest extends BrAPITest {
+
+    private FannyPack fp;
+
+    @Inject
+    private DSLContext dsl;
+
+    @Inject
+    private SpeciesDAO speciesDAO;
+
+    @Inject
+    private UserDAO userDAO;
+
+    @Inject
+    private BrAPIObservationUnitDAO obsUnitDAO;
+
+    @Inject
+    private ProgramService programService;
+
+    private Program validProgram;
+
+    private Gson gson;
+    private ImportUpload upload;
+
+    private BrAPIObservationTreatment testTreatment;
+
+    @Inject
+    @Client("/${micronaut.bi.api.version}")
+    RxHttpClient biClient;
+
+    @BeforeAll
+    @SneakyThrows
+    public void setup() {
+
+        ImportProgress progress = ImportProgress.builder().build();
+
+        upload = ImportUpload.uploadBuilder()
+                .progress(progress)
+                .build();
+
+        gson = new JSON().getGson();
+
+        // Add species needed to create program
+        fp = FannyPack.fill("src/test/resources/sql/brapi/species.sql");
+        super.getBrapiDsl().execute(fp.get("InsertSpecies"));
+        SpeciesEntity validSpecies = speciesDAO.findAll().get(0);
+
+        // Insert system admin role so can create program
+        FannyPack securityFp = FannyPack.fill("src/test/resources/sql/ProgramSecuredAnnotationRuleIntegrationTest.sql");
+        User testUser = userDAO.getUserByOrcId(TestTokenValidator.TEST_USER_ORCID).get();
+        dsl.execute(securityFp.get("InsertSystemRoleAdmin"), testUser.getId().toString());
+
+        SpeciesRequest speciesRequest = SpeciesRequest.builder()
+                .commonName(validSpecies.getCommonName())
+                .id(validSpecies.getId())
+                .build();
+
+        ProgramRequest program = ProgramRequest.builder()
+                .name("Test Program")
+                .species(speciesRequest)
+                .key("TEST")
+                .build();
+
+        // create test program
+        validProgram = insertAndFetchTestProgram(gson, biClient, program);
+        // updated with brapi db id
+        validProgram = programService.getById(validProgram.getId()).get();
+
+        testTreatment = new BrAPIObservationTreatment();
+        testTreatment.setFactor("ou1 treatment");
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(1)
+    public void testCreateObservationUnitAdditionalInfoSingleTreatmentFactor() {
+        // create observation unit with treatments only in additional info to simulate breedbase not populating
+        // treatments field
+        BrAPIObservationUnit ou1 = new BrAPIObservationUnit();
+        ou1.setObservationUnitName("test1");
+        ou1.putAdditionalInfoItem(BrAPIAdditionalInfoFields.TREATMENTS, List.of(testTreatment));
+        ou1.setProgramDbId(validProgram.getBrapiProgram().getProgramDbId());
+
+        List<BrAPIObservationUnit> ous = List.of(ou1);
+        List<BrAPIObservationUnit> createdOus = obsUnitDAO.createBrAPIObservationUnits(ous, validProgram.getId(), upload);
+        singleTreatmentAsserts(createdOus, testTreatment);
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(2)
+    public void testGetObservationUnitAdditionalInfoSingleTreatmentFactor() {
+        List<BrAPIObservationUnit> createdOus = obsUnitDAO.getObservationUnitByName(List.of("test1"), validProgram);
+        singleTreatmentAsserts(createdOus, testTreatment);
+    }
+
+    private void singleTreatmentAsserts(List<BrAPIObservationUnit> obsUnits, BrAPIObservationTreatment expectedTreatment) {
+        assertEquals(1, obsUnits.size(), "Expected 1 observation unit");
+
+        BrAPIObservationUnit ou = obsUnits.get(0);
+        List<BrAPIObservationTreatment> treatments = ou.getTreatments();
+        assertEquals(1, treatments.size(), "Expected treatments property");
+
+        BrAPIObservationTreatment treatment = treatments.get(0);
+        assertEquals(expectedTreatment, treatment, "Expected treatments to be same");
+    }
+
+}


### PR DESCRIPTION
# Description
**Story:** [BI-1832](https://breedinginsight.atlassian.net/browse/BI-1832?atlOrigin=eyJpIjoiYjgyMDIwOGQxYTQxNDAyNzgzNmNmNDgxMDhmMTM1YmYiLCJwIjoiaiJ9)

- Storing treatments properly in Breedbase so that they are in the right spot to be reflected in the Breedbase UI was larger in scope than anticipated for this card so a new card was made to do that [BI-1850](https://breedinginsight.atlassian.net/browse/BI-1850?atlOrigin=eyJpIjoiZDY2NzFlNTYyNzg5NGJmMzg3MWU0ZjE3NmI5OWJmZWEiLCJwIjoiaiJ9)
- This card bi-api stores the treatments in additionalInfo and it will be saved in Breedbase through that mechanism and then bi-api populated the treatments property of the observation unit from the additional info data if the treatements property is empty

# Dependencies
- sgn bug/BI-1832-2

# Testing
- Import an experiment with treatments specified in the file to programs on the BrAPI test server and Breedbase and ensure the downloaded experiment data contains the specified treatments. An example file is available in the card.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1832]: https://breedinginsight.atlassian.net/browse/BI-1832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-1850]: https://breedinginsight.atlassian.net/browse/BI-1850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ