### PR TITLE
BI-1842 - Append existing exp with observations isn't working

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/ExternalReferenceSource.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/ExternalReferenceSource.java
@@ -9,7 +9,8 @@ public enum ExternalReferenceSource {
     STUDIES("studies"),
     OBSERVATION_UNITS("observationunits"),
     DATASET("dataset"),
-    LISTS("lists");
+    LISTS("lists"),
+    OBSERVATIONS("observations");
 
     private String name;
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -618,7 +618,8 @@ public class ExperimentProcessor implements Processor {
 
     private void validateObservations(ValidationErrors validationErrors, int rowNum, ExperimentObservation importRow, List<Column<?>> phenotypeCols, Map<String, Trait> colVarMap, Map<String, BrAPIObservation> existingObservations) {
         phenotypeCols.forEach(phenoCol -> {
-            if(existingObservations.containsKey(getImportObservationHash(importRow, phenoCol.name()))) {
+            var importHash = getImportObservationHash(importRow, phenoCol.name());
+            if(existingObservations.containsKey(importHash) && StringUtils.isNotBlank(phenoCol.getString(rowNum)) && !existingObservations.get(importHash).getValue().equals(phenoCol.getString(rowNum))) {
                 addRowError(
                         phenoCol.name(),
                         String.format("Value already exists for ObsUnitId: %s, Phenotype: %s", importRow.getObsUnitID(), phenoCol.name()),


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1842

Loosened the validation of observations to only throw an error if a new upload will change the value of an existing observation.  If the incoming value is blank, then no validation error will be thrown.



# Dependencies
None

# Testing
1. Upload an experiment with observations
2. Upload a file to the same experiment with new observations to a different phenotype/trait.  Ensure that the observations from the first upload are blank in the second file
3. Ensure the file uploads successfully

1. Upload an experiment with observations
2. Upload a file to the same experiment with new observations to a different phenotype/trait.  Ensure that the observations from the first upload are copied from the first file to the second file
3. Ensure the file uploads successfully

1. Upload an experiment with observations
2. Upload a file to the same experiment with new observations to a different phenotype/trait.  Also put new values for the existing observations
3. Ensure the file upload throws a validation error for the existing observations attempting to be overwritten


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
