### PR TITLE
[BI-1647] View Experiments: Observation Dataset Table

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
@@ -43,4 +43,5 @@ public final class BrAPIAdditionalInfoFields {
     public static final String OBSERVATION_DATASET_ID = "observationDatasetId";
     public static final String FEMALE_PARENT_UNKNOWN = "femaleParentUnknown";
     public static final String MALE_PARENT_UNKNOWN = "maleParentUnknown";
+    public static final String GID = "gid";
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -283,7 +283,7 @@ public class BrAPITrialService {
 
         // TODO: Once BI-1831 is complete and OUs in a dataset can be identified using the datasetId stored as a xref
         // the expOUs needs to be replaced with datasetOUs, as was done with datasetObsVars
-        List<BrAPIObservationUnit> expOUs = ouDAO.getObservationUnitsForTrialDbId(program.getId(), experiment.getTrialDbId());
+        List<BrAPIObservationUnit> expOUs = ouDAO.getObservationUnitsForTrialDbId(program.getId(), experiment.getTrialDbId(), true);
         List<BrAPIObservationVariable> datasetObsVars = getDatasetObsVars(datsetId.toString(), program);
         List<String> ouDbIds = expOUs.stream().map(BrAPIObservationUnit::getObservationUnitDbId).collect(Collectors.toList());
         List<String> obsVarDbIds = datasetObsVars.stream().map(BrAPIObservationVariable::getObservationVariableDbId).collect(Collectors.toList());

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
@@ -23,6 +23,7 @@ import org.brapi.client.v2.modules.phenotype.ObservationUnitsApi;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
 import org.brapi.v2.model.pheno.request.BrAPIObservationUnitSearchRequest;
+import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapi.v2.services.BrAPIGermplasmService;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
@@ -127,10 +128,13 @@ public class BrAPIObservationUnitDAO {
                 api::searchObservationunitsSearchResultsDbIdGet,
                 observationUnitSearchRequest);
         if( withGID ){
+            // Load germplasm for program into map.
+            // TODO: if we use redis search, that may be more efficient than loading all germplasm for the program.
+            HashMap<String, BrAPIGermplasm> germplasmByDbId = new HashMap<>();
+            this.germplasmService.getGermplasm(programId).forEach((germplasm -> germplasmByDbId.put(germplasm.getGermplasmDbId(), germplasm)));
             for (BrAPIObservationUnit observationUnit: observationUnits) {
-                String germplasmDbId = observationUnit.getGermplasmDbId();
-                BrAPIGermplasm germplasm = this.germplasmService.getGermplasmByDBID(program.getId(), germplasmDbId).get() ;
-                observationUnit.putAdditionalInfoItem("gid", germplasm.getAccessionNumber());
+                BrAPIGermplasm germplasm = germplasmByDbId.get(observationUnit.getGermplasmDbId());
+                observationUnit.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GID, germplasm.getAccessionNumber());
             }
         }
         return observationUnits;

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
@@ -20,8 +20,10 @@ package org.breedinginsight.brapps.importer.daos;
 import io.micronaut.context.annotation.Property;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.phenotype.ObservationUnitsApi;
+import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
 import org.brapi.v2.model.pheno.request.BrAPIObservationUnitSearchRequest;
+import org.breedinginsight.brapi.v2.services.BrAPIGermplasmService;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.daos.ProgramDAO;
@@ -43,17 +45,19 @@ public class BrAPIObservationUnitDAO {
     private final BrAPIDAOUtil brAPIDAOUtil;
     private final BrAPIEndpointProvider brAPIEndpointProvider;
     private final ProgramService programService;
+    private final BrAPIGermplasmService germplasmService;
 
     private final String referenceSource;
 
     @Inject
-    public BrAPIObservationUnitDAO(ProgramDAO programDAO, ImportDAO importDAO, BrAPIDAOUtil brAPIDAOUtil, BrAPIEndpointProvider brAPIEndpointProvider, ProgramService programService, @Property(name = "brapi.server.reference-source") String referenceSource) {
+    public BrAPIObservationUnitDAO(ProgramDAO programDAO, ImportDAO importDAO, BrAPIDAOUtil brAPIDAOUtil, BrAPIEndpointProvider brAPIEndpointProvider, BrAPIGermplasmService germplasmService, ProgramService programService, @Property(name = "brapi.server.reference-source") String referenceSource) {
         this.programDAO = programDAO;
         this.importDAO = importDAO;
         this.brAPIDAOUtil = brAPIDAOUtil;
         this.brAPIEndpointProvider = brAPIEndpointProvider;
         this.referenceSource = referenceSource;
         this.programService = programService;
+        this.germplasmService = germplasmService;
     }
 
     public List<BrAPIObservationUnit> getObservationUnitByName(List<String> observationUnitNames, Program program) throws ApiException {
@@ -105,7 +109,12 @@ public class BrAPIObservationUnitDAO {
                 api::searchObservationunitsSearchResultsDbIdGet,
                 observationUnitSearchRequest);
     }
+
     public List<BrAPIObservationUnit> getObservationUnitsForTrialDbId(@NotNull UUID programId, @NotNull String trialDbId) throws ApiException, DoesNotExistException {
+        return getObservationUnitsForTrialDbId(programId, trialDbId, false);
+    }
+
+    public List<BrAPIObservationUnit> getObservationUnitsForTrialDbId(@NotNull UUID programId, @NotNull String trialDbId, boolean withGID) throws ApiException, DoesNotExistException {
         Program program = programService.getById(programId).orElseThrow(() -> new DoesNotExistException("Program id does not exist"));
 
         BrAPIObservationUnitSearchRequest observationUnitSearchRequest = new BrAPIObservationUnitSearchRequest();
@@ -114,8 +123,16 @@ public class BrAPIObservationUnitDAO {
         observationUnitSearchRequest.trialDbIds(List.of(trialDbId));
 
         ObservationUnitsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), ObservationUnitsApi.class);
-        return brAPIDAOUtil.search(api::searchObservationunitsPost,
+        List<BrAPIObservationUnit> observationUnits = brAPIDAOUtil.search(api::searchObservationunitsPost,
                 api::searchObservationunitsSearchResultsDbIdGet,
                 observationUnitSearchRequest);
+        if( withGID ){
+            for (BrAPIObservationUnit observationUnit: observationUnits) {
+                String germplasmDbId = observationUnit.getGermplasmDbId();
+                BrAPIGermplasm germplasm = this.germplasmService.getGermplasmByDBID(program.getId(), germplasmDbId).get() ;
+                observationUnit.putAdditionalInfoItem("gid", germplasm.getAccessionNumber());
+            }
+        }
+        return observationUnits;
     }
 }


### PR DESCRIPTION
# Description
[BI-1647](https://breedinginsight.atlassian.net/browse/BI-1647) (View Experiments: Observation Dataset Table)

Added the ability to retrieve the GID in the _additional information_ element of the Observation Unit.

# Dependencies
bi-web: branch _feature/BI-1647_

# Testing
see [bi-web PR](https://github.com/Breeding-Insight/bi-web/pull/322).

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: [_link to TAF run_](https://github.com/Breeding-Insight/taf/actions/runs/5786086405)



[BI-1647]: https://breedinginsight.atlassian.net/browse/BI-1647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ