### PR TITLE
BI-1855 - Create germplasm list not working

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -28,6 +28,7 @@ import org.breedinginsight.api.model.v1.validators.QueryValid;
 import org.breedinginsight.api.model.v1.validators.SearchValid;
 import org.breedinginsight.brapi.v1.controller.BrapiVersion;
 import org.breedinginsight.brapi.v1.model.request.query.BrapiQuery;
+import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapi.v2.model.request.query.GermplasmQuery;
 import org.breedinginsight.utilities.Utilities;
@@ -223,14 +224,14 @@ public class GermplasmController {
                 response = pedigreeResponse.getBody();
 
                 //Add nodes for unknown parents if applicable
-                if (germplasm.getAdditionalInfo().has("femaleParentUnknown") && germplasm.getAdditionalInfo().get("femaleParentUnknown").getAsBoolean()) {
+                if (germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN) && germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN).getAsBoolean()) {
                     BrAPIPedigreeNodeParents unknownFemale = new BrAPIPedigreeNodeParents();
                     unknownFemale.setGermplasmDbId(germplasm.getGermplasmDbId()+"-F-Unknown");
                     unknownFemale.setGermplasmName("Unknown");
                     unknownFemale.setParentType(BrAPIParentType.FEMALE);
                     returnNode.addParentsItem(unknownFemale);
                 }
-                if (germplasm.getAdditionalInfo().has("maleParentUnknown") && germplasm.getAdditionalInfo().get("maleParentUnknown").getAsBoolean()) {
+                if (germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN) && germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN).getAsBoolean()) {
                     BrAPIPedigreeNodeParents unknownMale = new BrAPIPedigreeNodeParents();
                     unknownMale.setGermplasmDbId(germplasm.getGermplasmDbId()+"-M-Unknown");
                     unknownMale.setGermplasmName("Unknown");

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -205,7 +205,7 @@ public class BrAPIGermplasmDAO {
                                 stream().filter(ref -> ref.getReferenceSource().equals(referenceSource)).
                                 map(ref -> ref.getReferenceID()).findFirst().orElse("");
                         additionalInfo.addProperty(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID, femaleParentAccessionNumber);
-                    } else if (additionalInfo.has("femaleParentUnknown") && additionalInfo.get("femaleParentUnknown").getAsBoolean()) {
+                    } else if (additionalInfo.has(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN) && additionalInfo.get(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN).getAsBoolean()) {
                         namePedigreeString = "Unknown";
                     }
                 }
@@ -221,7 +221,7 @@ public class BrAPIGermplasmDAO {
                     }
                 }
                 //Add Unknown germplasm for display
-                if (additionalInfo.has("maleParentUnknown") && additionalInfo.get("maleParentUnknown").getAsBoolean()) {
+                if (additionalInfo.has(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN) && additionalInfo.get(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN).getAsBoolean()) {
                     namePedigreeString += "/Unknown";
                 }
                 //For use in individual germplasm display

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -291,8 +291,10 @@ public class BrAPIGermplasmDAO {
         try {
             if (!putBrAPIGermplasmList.isEmpty()) {
                 postFunction = () -> {
-                    List<BrAPIGermplasm> postResponse = putGermplasm(putBrAPIGermplasmList, api);
-                    return processGermplasmForDisplay(postResponse, program.getKey());
+                    putGermplasm(putBrAPIGermplasmList, api);
+                    // Need all program germplasm for processGermplasmForDisplay parents pedigree
+                    List<BrAPIGermplasm> germplasm = getRawGermplasm(programId);
+                    return processGermplasmForDisplay(germplasm, program.getKey());
                 };
             }
             return programGermplasmCache.post(programId, postFunction);

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -264,7 +264,7 @@ public class BrAPIGermplasmDAO {
                 return pedigree.substring(2);
             }
         }
-        return "";
+        return pedigree;
     }
 
     public List<BrAPIGermplasm> createBrAPIGermplasm(List<BrAPIGermplasm> postBrAPIGermplasmList, UUID programId, ImportUpload upload) {

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -188,6 +188,7 @@ public class BrAPIGermplasmDAO {
                     germplasm.setAdditionalInfo(additionalInfo);
                 }
 
+                // TODO: BI-1883 to cleanup this workaround for the pedigree string
                 String pedigree = processBreedbasePedigree(germplasm.getPedigree());
                 additionalInfo.addProperty(BrAPIAdditionalInfoFields.GERMPLASM_RAW_PEDIGREE, pedigree);
 
@@ -241,6 +242,7 @@ public class BrAPIGermplasmDAO {
     }
 
     // TODO: hack for now, probably should update breedbase
+    // Made a JIRA card BI-1883 for this
     // Breedbase will return NA/NA for no pedigree or NA/father, mother/NA
     // strip NAs before saving RAW_PEDIGREE, if there was a germplasm with name NA it would be in format NA [program key]
     // so that case should be ok if we just strip NA/NA, NA/, or /NA<\0>

--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -218,16 +218,6 @@ public class Germplasm implements BrAPIObject {
         }
     }
 
-    public boolean pedigreesEqualGidOnly(BrAPIGermplasm brAPIGermplasm) {
-        JsonElement femaleGid = brAPIGermplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID);
-        String brapiFemaleGid = femaleGid != null && !femaleGid.isJsonNull() ? femaleGid.getAsString() : null;
-        JsonElement maleGid = brAPIGermplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID);
-        String brapiMaleGid = maleGid != null && !maleGid.isJsonNull() ? maleGid.getAsString() : null;
-
-        return (StringUtils.isAllBlank(getFemaleParentDBID(), brapiFemaleGid) || StringUtils.equals(getFemaleParentDBID(), brapiFemaleGid))
-                && (StringUtils.isAllBlank(getMaleParentDBID(), brapiMaleGid) || StringUtils.equals(getMaleParentDBID(), brapiMaleGid));
-    }
-
     public boolean pedigreeExists() {
         return StringUtils.isNotBlank(getFemaleParentDBID()) ||
                 StringUtils.isNotBlank(getMaleParentDBID()) ||

--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonObject;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPIListTypes;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
@@ -156,12 +157,22 @@ public class Germplasm implements BrAPIObject {
         return String.format("%s [%s-germplasm]", listName, program.getKey());
     }
 
-    public void updateBrAPIGermplasm(BrAPIGermplasm germplasm, Program program, UUID listId, boolean commit) {
+    public void updateBrAPIGermplasm(BrAPIGermplasm germplasm, Program program, UUID listId, boolean commit, boolean updatePedigree) {
 
-        germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID, getFemaleParentDBID());
-        germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID, getMaleParentDBID());
-        germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_ENTRY_NO, getFemaleParentEntryNo());
-        germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_ENTRY_NO, getMaleParentEntryNo());
+        if (updatePedigree) {
+            if (!StringUtils.isBlank(getFemaleParentDBID())) {
+                germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID, getFemaleParentDBID());
+            }
+            if (!StringUtils.isBlank(getMaleParentDBID())) {
+                germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID, getMaleParentDBID());
+            }
+            if (!StringUtils.isBlank(getFemaleParentEntryNo())) {
+                germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_ENTRY_NO, getFemaleParentEntryNo());
+            }
+            if (!StringUtils.isBlank(getMaleParentEntryNo())) {
+                germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_ENTRY_NO, getMaleParentEntryNo());
+            }
+        }
 
         // Append synonyms to germplasm that don't already exist
         // Synonym comparison is based on name and type
@@ -208,15 +219,16 @@ public class Germplasm implements BrAPIObject {
         String brapiFemaleGid = femaleGid != null ? femaleGid.getAsString() : null;
         JsonElement maleGid = brAPIGermplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID);
         String brapiMaleGid = maleGid != null ? maleGid.getAsString() : null;
-        JsonElement femaleEntryNo = brAPIGermplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_ENTRY_NO);
-        String brapiFemaleEntryNo = femaleEntryNo != null ? femaleEntryNo.getAsString() : null;
-        JsonElement maleEntryNo = brAPIGermplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_ENTRY_NO);
-        String brapiMaleEntryNo = maleEntryNo != null ? maleEntryNo.getAsString() : null;
 
-        return ((getFemaleParentDBID() == null && brapiFemaleGid == null) || (getFemaleParentDBID() != null && getFemaleParentDBID().equals(brapiFemaleGid))) &&
-               ((getMaleParentDBID() == null && brapiMaleGid == null) || (getMaleParentDBID() != null && getMaleParentDBID().equals(brapiMaleGid))) &&
-               ((getFemaleParentEntryNo() == null && brapiFemaleEntryNo == null) || (getFemaleParentEntryNo() != null && getFemaleParentEntryNo().equals(brapiFemaleEntryNo))) &&
-               ((getMaleParentEntryNo() == null && brapiMaleEntryNo == null) || (getMaleParentEntryNo() != null && getMaleParentEntryNo().equals(brapiMaleEntryNo)));
+        return ((StringUtils.isBlank(getFemaleParentDBID()) && StringUtils.isBlank(brapiFemaleGid)) || (getFemaleParentDBID() != null && getFemaleParentDBID().equals(brapiFemaleGid))) &&
+               ((StringUtils.isBlank(getMaleParentDBID()) && StringUtils.isBlank(brapiMaleGid)) || (getMaleParentDBID() != null && getMaleParentDBID().equals(brapiMaleGid)));
+    }
+
+    public boolean pedigreeEmpty() {
+        return StringUtils.isBlank(getFemaleParentDBID()) &&
+               StringUtils.isBlank(getMaleParentDBID()) &&
+               StringUtils.isBlank(getFemaleParentEntryNo()) &&
+               StringUtils.isBlank(getMaleParentEntryNo());
     }
 
     public BrAPIGermplasm constructBrAPIGermplasm(ProgramBreedingMethodEntity breedingMethod, User user, UUID listId) {

--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -214,11 +214,11 @@ public class Germplasm implements BrAPIObject {
         }
     }
 
-    public boolean pedigreesEqual(BrAPIGermplasm brAPIGermplasm) {
+    public boolean pedigreesEqualGidOnly(BrAPIGermplasm brAPIGermplasm) {
         JsonElement femaleGid = brAPIGermplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID);
-        String brapiFemaleGid = femaleGid != null ? femaleGid.getAsString() : null;
+        String brapiFemaleGid = femaleGid != null && !femaleGid.isJsonNull() ? femaleGid.getAsString() : null;
         JsonElement maleGid = brAPIGermplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID);
-        String brapiMaleGid = maleGid != null ? maleGid.getAsString() : null;
+        String brapiMaleGid = maleGid != null && !maleGid.isJsonNull() ? maleGid.getAsString() : null;
 
         return ((StringUtils.isBlank(getFemaleParentDBID()) && StringUtils.isBlank(brapiFemaleGid)) || (getFemaleParentDBID() != null && getFemaleParentDBID().equals(brapiFemaleGid))) &&
                ((StringUtils.isBlank(getMaleParentDBID()) && StringUtils.isBlank(brapiMaleGid)) || (getMaleParentDBID() != null && getMaleParentDBID().equals(brapiMaleGid)));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -288,10 +288,6 @@ public class GermplasmProcessor implements Processor {
             // Have GID so updating an existing germplasm record
             if (germplasm.getAccessionNumber() != null) {
                 processExistingGermplasm(germplasm, validationErrors, importRows, program, importListId, commit, mappedImportRow, i);
-                //if(!processExistingGermplasm(germplasm, validationErrors, importRows, program, importListId, commit, mappedImportRow, i)) {
-                //    continue;
-                //}
-
             } else {
                 processNewGermplasm(germplasm, validationErrors, breedingMethods, badBreedingMethods, program, importListId, commit, mappedImportRow, i, user, nextVal);
             }
@@ -381,9 +377,6 @@ public class GermplasmProcessor implements Processor {
         // no existing pedigree and file different pedigree
         // existing pedigree and file pedigree same
         // existing pedigree and file pedigree empty
-//                    if (!StringUtils.isBlank(existingGermplasm.getPedigree()) &&
-//                        !germplasm.pedigreesEqualGidOnly(existingGermplasm) &&
-//                        !germplasm.pedigreeEmpty()) {
         if(hasPedigree(existingGermplasm) && germplasm.pedigreeExists()) {
             if(!arePedigreesEqual(existingGermplasm, germplasm, importRows)) {
                 ValidationError ve = new ValidationError("Pedigree", pedigreeAlreadyExists, HttpStatus.UNPROCESSABLE_ENTITY);
@@ -729,8 +722,6 @@ public class GermplasmProcessor implements Processor {
                     if (maleParent != null) {
                         brAPIGermplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID, maleParent.getAccessionNumber());
                     }
-
-                    //brAPIGermplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_RAW_PEDIGREE, pedigreeString);
                 }
             }
         }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -417,8 +417,10 @@ public class GermplasmProcessor implements Processor {
         return StringUtils.isNotBlank(germplasm.getPedigree())
                 || germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID)
                 || germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID)
-                || germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN)
-                || germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN);
+                || (germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN) &&
+                    germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN).getAsBoolean())
+                || (germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN) &&
+                    germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN).getAsBoolean());
     }
 
     /**

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -24,7 +24,6 @@ import io.micronaut.http.server.exceptions.InternalServerException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.model.exceptions.ApiException;
-import org.brapi.v2.model.BrAPIAcceptedSearchResponse;
 import org.brapi.v2.model.core.BrAPIListSummary;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.germ.BrAPIGermplasm;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -286,9 +286,10 @@ public class GermplasmProcessor implements Processor {
             //TODO maybe make separate method for cleanliness
             // Have GID so updating an existing germplasm record
             if (germplasm.getAccessionNumber() != null) {
-                if(!processExistingGermplasm(germplasm, validationErrors, importRows, program, importListId, commit, mappedImportRow, i)) {
-                    continue;
-                }
+                processExistingGermplasm(germplasm, validationErrors, importRows, program, importListId, commit, mappedImportRow, i);
+                //if(!processExistingGermplasm(germplasm, validationErrors, importRows, program, importListId, commit, mappedImportRow, i)) {
+                //    continue;
+                //}
 
             } else {
                 processNewGermplasm(germplasm, validationErrors, breedingMethods, badBreedingMethods, program, importListId, commit, mappedImportRow, i, user, nextVal);
@@ -388,17 +389,18 @@ public class GermplasmProcessor implements Processor {
                 validationErrors.addError(rowIndex + 2, ve);  // +2 instead of +1 to account for the column header row.
                 return false;
             }
-        } else {
-            if(germplasm.pedigreeExists()) {
-                validatePedigree(germplasm, rowIndex + 2, validationErrors);
-            }
-
-            germplasm.updateBrAPIGermplasm(existingGermplasm, program, importListId, commit, true);
-
-            updatedGermplasmList.add(existingGermplasm);
-            mappedImportRow.setGermplasm(new PendingImportObject<>(ImportObjectState.MUTATED, existingGermplasm));
-            importList.addDataItem(existingGermplasm.getGermplasmName());
         }
+
+        if(germplasm.pedigreeExists()) {
+            validatePedigree(germplasm, rowIndex + 2, validationErrors);
+        }
+
+        germplasm.updateBrAPIGermplasm(existingGermplasm, program, importListId, commit, true);
+
+        updatedGermplasmList.add(existingGermplasm);
+        mappedImportRow.setGermplasm(new PendingImportObject<>(ImportObjectState.MUTATED, existingGermplasm));
+        importList.addDataItem(existingGermplasm.getGermplasmName());
+
 
         return true;
     }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -363,11 +363,12 @@ public class GermplasmProcessor implements Processor {
 
     private boolean processExistingGermplasm(Germplasm germplasm, ValidationErrors validationErrors, List<BrAPIImport> importRows, Program program, UUID importListId, boolean commit, PendingImport mappedImportRow, int rowIndex) {
         BrAPIGermplasm existingGermplasm;
-        if (germplasmByAccessionNumber.containsKey(germplasm.getAccessionNumber())) {
-            existingGermplasm = germplasmByAccessionNumber.get(germplasm.getAccessionNumber()).getBrAPIObject();
+        String gid = germplasm.getAccessionNumber();
+        if (germplasmByAccessionNumber.containsKey(gid)) {
+            existingGermplasm = germplasmByAccessionNumber.get(gid).getBrAPIObject();
         } else {
             //should be caught in getExistingBrapiData
-            ValidationError ve = new ValidationError("GID", missingGID, HttpStatus.NOT_FOUND);
+            ValidationError ve = new ValidationError("GID", String.format(missingGID, gid), HttpStatus.NOT_FOUND);
             validationErrors.addError(rowIndex+2, ve );  // +2 instead of +1 to account for the column header row.
             return false;
         }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -702,7 +702,10 @@ public class GermplasmProcessor implements Processor {
 
             // only allow this when not committing so that display name version can be shown in preview
             if (!commit) {
-                brAPIGermplasm.setPedigree(brAPIGermplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_PEDIGREE_BY_NAME).getAsString());
+                if (brAPIGermplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_PEDIGREE_BY_NAME)) {
+                    brAPIGermplasm.setPedigree(brAPIGermplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_PEDIGREE_BY_NAME).getAsString());
+                }
+
             }
 
             // no existing pedigree and pedigree not empty

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -78,7 +78,6 @@ public class GermplasmProcessor implements Processor {
 
     List<BrAPIGermplasm> updatedGermplasmList;
     List<BrAPIGermplasm> existingGermplasms;
-    List<BrAPIGermplasm> existingParentGermplasms;
     List<List<BrAPIGermplasm>> postOrder = new ArrayList<>();
     BrAPIListNewRequest importList = new BrAPIListNewRequest();
 
@@ -142,7 +141,7 @@ public class GermplasmProcessor implements Processor {
         // If parental DBID, should also be in database
         existingGermplasms = new ArrayList<>();
         List<String> missingParentalDbIds = germplasmDBIDs.entrySet().stream().filter(Map.Entry::getValue).map(Map.Entry::getKey).collect(Collectors.toList());
-        List<String> missingDbIds = germplasmDBIDs.entrySet().stream().filter(Map.Entry::getValue).map(Map.Entry::getKey).collect(Collectors.toList());
+        List<String> missingDbIds = germplasmDBIDs.entrySet().stream().filter(entry -> !entry.getValue()).map(Map.Entry::getKey).collect(Collectors.toList());
         if (germplasmDBIDs.size() > 0) {
             try {
                 existingGermplasms = brAPIGermplasmService.getRawGermplasmByAccessionNumber(new ArrayList<>(germplasmDBIDs.keySet()), program.getId());
@@ -155,7 +154,6 @@ public class GermplasmProcessor implements Processor {
                 existingGermplasms.forEach(existingGermplasm -> {
                     germplasmByAccessionNumber.put(existingGermplasm.getAccessionNumber(), new PendingImportObject<>(ImportObjectState.EXISTING, existingGermplasm));
                 });
-                existingParentGermplasms = existingGermplasms.stream().filter(germplasm -> germplasmDBIDs.get(germplasm.getAccessionNumber())).collect(Collectors.toList());
             } catch (ApiException e) {
                 // We shouldn't get an error back from our services. If we do, nothing the user can do about it
                 throw new InternalServerException(e.toString(), e);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -16,9 +16,6 @@
  */
 package org.breedinginsight.brapps.importer.services.processors;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.http.HttpStatus;
@@ -30,7 +27,6 @@ import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.core.BrAPIListSummary;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
-import org.brapi.v2.model.germ.BrAPIGermplasmSynonyms;
 import org.breedinginsight.api.model.v1.response.ValidationError;
 import org.breedinginsight.api.model.v1.response.ValidationErrors;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
@@ -86,6 +82,7 @@ public class GermplasmProcessor implements Processor {
     List<List<BrAPIGermplasm>> postOrder = new ArrayList<>();
     BrAPIListNewRequest importList = new BrAPIListNewRequest();
 
+    public static String missingDbIdsMsg = "The following GIDs were not found in the database: %s.";
     public static String missingParentalDbIdsMsg = "The following parental GIDs were not found in the database: %s.";
     public static String missingParentalEntryNoMsg = "The following parental entry numbers were not found in the database: %s.";
     public static String badBreedMethodsMsg = "Invalid breeding method";
@@ -116,17 +113,20 @@ public class GermplasmProcessor implements Processor {
     public void getExistingBrapiData(List<BrAPIImport> importRows, Program program) throws ApiException {
 
         // Get all of our objects specified in the data file by their unique attributes
-        Set<String> germplasmDBIDs = new HashSet<>();
+        Map<String, Boolean> germplasmDBIDs = new HashMap<>();
         for (int i = 0; i < importRows.size(); i++) {
             BrAPIImport germplasmImport = importRows.get(i);
             if (germplasmImport.getGermplasm() != null) {
 
                 // Retrieve parent dbids to assess if already in db
                 if (germplasmImport.getGermplasm().getFemaleParentDBID() != null) {
-                    germplasmDBIDs.add(germplasmImport.getGermplasm().getFemaleParentDBID());
+                    germplasmDBIDs.put(germplasmImport.getGermplasm().getFemaleParentDBID(), true);
                 }
                 if (germplasmImport.getGermplasm().getMaleParentDBID() != null) {
-                    germplasmDBIDs.add(germplasmImport.getGermplasm().getMaleParentDBID());
+                    germplasmDBIDs.put(germplasmImport.getGermplasm().getMaleParentDBID(), true);
+                }
+                if (germplasmImport.getGermplasm().getAccessionNumber() != null) {
+                    germplasmDBIDs.put(germplasmImport.getGermplasm().getAccessionNumber(), false);
                 }
 
                 //Retrieve entry numbers of file for comparison with parent entry numbers
@@ -141,20 +141,21 @@ public class GermplasmProcessor implements Processor {
 
         // If parental DBID, should also be in database
         existingGermplasms = new ArrayList<>();
-        List<String> missingDbIds = new ArrayList<>(germplasmDBIDs);
+        List<String> missingParentalDbIds = germplasmDBIDs.entrySet().stream().filter(Map.Entry::getValue).map(Map.Entry::getKey).collect(Collectors.toList());
+        List<String> missingDbIds = germplasmDBIDs.entrySet().stream().filter(Map.Entry::getValue).map(Map.Entry::getKey).collect(Collectors.toList());
         if (germplasmDBIDs.size() > 0) {
             try {
-                existingParentGermplasms = brAPIGermplasmService.getRawGermplasmByAccessionNumber(new ArrayList<>(germplasmDBIDs), program.getId());
-                List<String> existingDbIds = existingParentGermplasms.stream()
+                existingGermplasms = brAPIGermplasmService.getRawGermplasmByAccessionNumber(new ArrayList<>(germplasmDBIDs.keySet()), program.getId());
+                List<String> existingDbIds = existingGermplasms.stream()
                                                                      .map(germplasm -> germplasm.getAccessionNumber())
                                                                      .collect(Collectors.toList());
+                missingParentalDbIds.removeAll(existingDbIds);
                 missingDbIds.removeAll(existingDbIds);
 
-                existingParentGermplasms.forEach(existingGermplasm -> {
+                existingGermplasms.forEach(existingGermplasm -> {
                     germplasmByAccessionNumber.put(existingGermplasm.getAccessionNumber(), new PendingImportObject<>(ImportObjectState.EXISTING, existingGermplasm));
                 });
-                //Since parent germplasms need to be present for check re circular dependencies
-                existingGermplasms.addAll(existingParentGermplasms);
+                existingParentGermplasms = existingGermplasms.stream().filter(germplasm -> germplasmDBIDs.get(germplasm.getAccessionNumber())).collect(Collectors.toList());
             } catch (ApiException e) {
                 // We shouldn't get an error back from our services. If we do, nothing the user can do about it
                 throw new InternalServerException(e.toString(), e);
@@ -163,8 +164,10 @@ public class GermplasmProcessor implements Processor {
 
         // Get existing germplasm names
         List<BrAPIGermplasm> dbGermplasm = brAPIGermplasmService.getGermplasmByDisplayName(new ArrayList<>(fileGermplasmByName.keySet()), program.getId());
-        dbGermplasm.stream().forEach(germplasm -> dbGermplasmByName.put(germplasm.getDefaultDisplayName(), germplasm));
-        dbGermplasm.stream().forEach(germplasm -> dbGermplasmByAccessionNo.put(germplasm.getAccessionNumber(), germplasm));
+        dbGermplasm.forEach(germplasm -> {
+            dbGermplasmByName.put(germplasm.getDefaultDisplayName(), germplasm);
+            dbGermplasmByAccessionNo.put(germplasm.getAccessionNumber(), germplasm);
+        });
 
         // Check for existing germplasm lists
         Boolean listNameDup = false;
@@ -184,12 +187,20 @@ public class GermplasmProcessor implements Processor {
         }
 
         //Remove id indicating unknown parent
+        missingParentalDbIds.remove("0");
         missingDbIds.remove("0");
 
         // Parent reference checks
-        if (missingDbIds.size() > 0) {
+        if (missingParentalDbIds.size() > 0) {
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
                                           String.format(missingParentalDbIdsMsg,
+                                                        arrayOfStringFormatter.apply(missingParentalDbIds)));
+        }
+
+        //GID existence check
+        if (missingDbIds.size() > 0) {
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                                          String.format(missingDbIdsMsg,
                                                         arrayOfStringFormatter.apply(missingDbIds)));
         }
 
@@ -273,85 +284,14 @@ public class GermplasmProcessor implements Processor {
 
             //todo double check what dbgermplasmbyaccessionNo actually getting
             //TODO maybe make separate method for cleanliness
-            if (germplasm != null) {
-                //Fetch and update existing germplasm
-                BrAPIGermplasm existingGermplasm;
-
-                // Have GID so updating an existing germplasm record
-                if (germplasm.getAccessionNumber() != null) {
-                    if (dbGermplasmByAccessionNo.containsKey(germplasm.getAccessionNumber())) {
-                        existingGermplasm = dbGermplasmByAccessionNo.get(germplasm.getAccessionNumber());
-                    } else {
-                        ValidationError ve = new ValidationError("GID", missingGID, HttpStatus.NOT_FOUND);
-                        validationErrors.addError(i+2, ve );  // +2 instead of +1 to account for the column header row.
-                        continue;
-                    }
-
-                    // Update conditions:
-                    // no existing pedigree and file has different pedigree and not empty
-                    boolean updatePedigree = updatePedigree(existingGermplasm, germplasm);
-
-                    // Error conditions:
-                    // has existing pedigree and file pedigree is different and not empty
-                    // Valid conditions:
-                    // no existing pedigree and file different pedigree
-                    // existing pedigree and file pedigree same
-                    // existing pedigree and file pedigree empty
-                    if (!StringUtils.isBlank(existingGermplasm.getPedigree()) &&
-                        !germplasm.pedigreesEqualGidOnly(existingGermplasm) &&
-                        !germplasm.pedigreeEmpty()) {
-                        ValidationError ve = new ValidationError("Pedigree", pedigreeAlreadyExists, HttpStatus.UNPROCESSABLE_ENTITY);
-                        validationErrors.addError(i+2, ve );  // +2 instead of +1 to account for the column header row.
-                        continue;
-                    }
-
-                    // only validate if updating pedigree
-                    if (updatePedigree) {
-                        validatePedigree(germplasm, i+2, validationErrors);
-                    }
-
-                    germplasm.updateBrAPIGermplasm(existingGermplasm, program, importListId, commit, updatePedigree);
-
-                    updatedGermplasmList.add(existingGermplasm);
-                    mappedImportRow.setGermplasm(new PendingImportObject<>(ImportObjectState.EXISTING, existingGermplasm));
-                    importList.addDataItem(existingGermplasm.getGermplasmName());
-
-                } else {
-                    // Get the breeding method database object
-                    ProgramBreedingMethodEntity breedingMethod = null;
-                    if (germplasm.getBreedingMethod() != null) {
-                        if (breedingMethods.containsKey(germplasm.getBreedingMethod())) {
-                            breedingMethod = breedingMethods.get(germplasm.getBreedingMethod());
-                        } else {
-                            List<ProgramBreedingMethodEntity> breedingMethodResults = breedingMethodDAO.findByNameOrAbbreviation(germplasm.getBreedingMethod(), program.getId());
-                            if (breedingMethodResults.size() > 0) {
-                                breedingMethods.put(germplasm.getBreedingMethod(), breedingMethodResults.get(0));
-                                breedingMethod = breedingMethods.get(germplasm.getBreedingMethod());
-                            } else {
-                                ValidationError ve = new ValidationError("Breeding Method", badBreedMethodsMsg, HttpStatus.UNPROCESSABLE_ENTITY);
-                                validationErrors.addError(i + 2, ve);  // +2 instead of +1 to account for the column header row.
-                                badBreedingMethods.add(germplasm.getBreedingMethod());
-                                breedingMethod = null;
-                            }
-                        }
-                    }
-
-                    validatePedigree(germplasm, i + 2, validationErrors);
-
-                    BrAPIGermplasm newGermplasm = germplasm.constructBrAPIGermplasm(program, breedingMethod, user, commit, BRAPI_REFERENCE_SOURCE, nextVal, importListId);
-
-                    newGermplasmList.add(newGermplasm);
-                    // Assign status of the germplasm
-                    if (fileGermplasmByName.get(newGermplasm.getDefaultDisplayName()) > 1 || dbGermplasmByName.containsKey(newGermplasm.getDefaultDisplayName())) {
-                        mappedImportRow.setGermplasm(new PendingImportObject<>(ImportObjectState.EXISTING, newGermplasm));
-                    } else {
-                        mappedImportRow.setGermplasm(new PendingImportObject<>(ImportObjectState.NEW, newGermplasm));
-                    }
-
-                    importList.addDataItem(newGermplasm.getGermplasmName());
+            // Have GID so updating an existing germplasm record
+            if (germplasm.getAccessionNumber() != null) {
+                if(!processExistingGermplasm(germplasm, validationErrors, importRows, program, importListId, commit, mappedImportRow, i)) {
+                    continue;
                 }
+
             } else {
-                mappedImportRow.setGermplasm(null);
+                processNewGermplasm(germplasm, validationErrors, breedingMethods, badBreedingMethods, program, importListId, commit, mappedImportRow, i, user, nextVal);
             }
             mappedBrAPIImport.put(i, mappedImportRow);
         }
@@ -385,19 +325,180 @@ public class GermplasmProcessor implements Processor {
         return getStatisticsMap(importRows);
     }
 
-    private boolean updatePedigree(BrAPIGermplasm existingGermplasm, Germplasm germplasm) {
-        // Update conditions:
-        // no existing pedigree and file has different pedigree and not empty
-        return StringUtils.isBlank(existingGermplasm.getPedigree()) &&
-               !germplasm.pedigreesEqualGidOnly(existingGermplasm) &&
-               !germplasm.pedigreeEmpty();
+    private void processNewGermplasm(Germplasm germplasm, ValidationErrors validationErrors, Map<String, ProgramBreedingMethodEntity> breedingMethods,
+                                     List<String> badBreedingMethods,
+                                     Program program, UUID importListId, boolean commit, PendingImport mappedImportRow, int i, User user, Supplier<BigInteger> nextVal) {
+        // Get the breeding method database object
+        ProgramBreedingMethodEntity breedingMethod = null;
+        if (germplasm.getBreedingMethod() != null) {
+            if (breedingMethods.containsKey(germplasm.getBreedingMethod())) {
+                breedingMethod = breedingMethods.get(germplasm.getBreedingMethod());
+            } else {
+                List<ProgramBreedingMethodEntity> breedingMethodResults = breedingMethodDAO.findByNameOrAbbreviation(germplasm.getBreedingMethod(), program.getId());
+                if (breedingMethodResults.size() > 0) {
+                    breedingMethods.put(germplasm.getBreedingMethod(), breedingMethodResults.get(0));
+                    breedingMethod = breedingMethods.get(germplasm.getBreedingMethod());
+                } else {
+                    ValidationError ve = new ValidationError("Breeding Method", badBreedMethodsMsg, HttpStatus.UNPROCESSABLE_ENTITY);
+                    validationErrors.addError(i + 2, ve);  // +2 instead of +1 to account for the column header row.
+                    badBreedingMethods.add(germplasm.getBreedingMethod());
+                }
+            }
+        }
+
+        validatePedigree(germplasm, i + 2, validationErrors);
+
+        BrAPIGermplasm newGermplasm = germplasm.constructBrAPIGermplasm(program, breedingMethod, user, commit, BRAPI_REFERENCE_SOURCE, nextVal, importListId);
+
+        newGermplasmList.add(newGermplasm);
+        // Assign status of the germplasm
+        if (fileGermplasmByName.get(newGermplasm.getDefaultDisplayName()) > 1 || dbGermplasmByName.containsKey(newGermplasm.getDefaultDisplayName())) {
+            mappedImportRow.setGermplasm(new PendingImportObject<>(ImportObjectState.EXISTING, newGermplasm));
+        } else {
+            mappedImportRow.setGermplasm(new PendingImportObject<>(ImportObjectState.NEW, newGermplasm));
+        }
+
+        importList.addDataItem(newGermplasm.getGermplasmName());
     }
 
-    private boolean updatePedigreeNoEqualsCheck(BrAPIGermplasm existingGermplasm, Germplasm germplasm) {
+    private boolean processExistingGermplasm(Germplasm germplasm, ValidationErrors validationErrors, List<BrAPIImport> importRows, Program program, UUID importListId, boolean commit, PendingImport mappedImportRow, int rowIndex) {
+        BrAPIGermplasm existingGermplasm;
+        if (germplasmByAccessionNumber.containsKey(germplasm.getAccessionNumber())) {
+            existingGermplasm = germplasmByAccessionNumber.get(germplasm.getAccessionNumber()).getBrAPIObject();
+        } else {
+            //should be caught in getExistingBrapiData
+            ValidationError ve = new ValidationError("GID", missingGID, HttpStatus.NOT_FOUND);
+            validationErrors.addError(rowIndex+2, ve );  // +2 instead of +1 to account for the column header row.
+            return false;
+        }
+
+        // Error conditions:
+        // has existing pedigree and file pedigree is different and not empty
+        // Valid conditions:
+        // no existing pedigree and file different pedigree
+        // existing pedigree and file pedigree same
+        // existing pedigree and file pedigree empty
+//                    if (!StringUtils.isBlank(existingGermplasm.getPedigree()) &&
+//                        !germplasm.pedigreesEqualGidOnly(existingGermplasm) &&
+//                        !germplasm.pedigreeEmpty()) {
+        if(hasPedigree(existingGermplasm) && germplasm.pedigreeExists()) {
+            if(!arePedigreesEqual(existingGermplasm, germplasm, importRows)) {
+                ValidationError ve = new ValidationError("Pedigree", pedigreeAlreadyExists, HttpStatus.UNPROCESSABLE_ENTITY);
+                validationErrors.addError(rowIndex + 2, ve);  // +2 instead of +1 to account for the column header row.
+                return false;
+            }
+        } else {
+            if(germplasm.pedigreeExists()) {
+                validatePedigree(germplasm, rowIndex + 2, validationErrors);
+            }
+
+            germplasm.updateBrAPIGermplasm(existingGermplasm, program, importListId, commit, true);
+
+            updatedGermplasmList.add(existingGermplasm);
+            mappedImportRow.setGermplasm(new PendingImportObject<>(ImportObjectState.MUTATED, existingGermplasm));
+            importList.addDataItem(existingGermplasm.getGermplasmName());
+        }
+
+        return true;
+    }
+
+    private boolean canUpdatePedigree(BrAPIGermplasm existingGermplasm, Germplasm germplasm) {
+        // Update conditions:
+        // no existing pedigree and file has different pedigree and not empty
+//        return StringUtils.isBlank(existingGermplasm.getPedigree()) &&
+//                !germplasm.pedigreeEmpty() &&
+//                !germplasm.pedigreesEqualGidOnly(existingGermplasm); //seems unnecessary
+
+        return !hasPedigree(existingGermplasm) && germplasm.pedigreeExists();
+    }
+
+    private boolean hasPedigree(BrAPIGermplasm germplasm) {
+        return StringUtils.isNotBlank(germplasm.getPedigree())
+                || germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID)
+                || germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID)
+                || germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN)
+                || germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN);
+    }
+
+    /**
+     * Compare an existing germplasm's pedigree to the incoming germplasm's pedigree to ensure they are the same.<br><br>
+     * Assumes that an empty value for a given parent in the incoming germplasm is equal to the existing germplasm.<br><br>
+     * Assumes that the existing germplasm has pedigree
+     * @param existingGermplasm the existing germplasm with pedigree
+     * @param germplasm the germplasm record coming in the file
+     * @param importRows all records coming in the file.  Needed to look up GID of a parent referenced by entry number in the file
+     * @return true if the two germplasm pedigrees are effectively equal, false otherwise
+     */
+    private boolean arePedigreesEqual(BrAPIGermplasm existingGermplasm, Germplasm germplasm, List<BrAPIImport> importRows) {
+        if(germplasm.pedigreeExists()) {
+            StringBuilder existingPedigreeGIDString = new StringBuilder();
+            String existingFemalePedigree = getParentId(existingGermplasm, existingPedigreeGIDString, BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID, BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN);
+            existingPedigreeGIDString.append("/");
+            String existingMalePedigree = getParentId(existingGermplasm, existingPedigreeGIDString, BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID, BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN);
+
+            StringBuilder germplasmPedigreeGIDString = new StringBuilder();
+            if (StringUtils.isNotBlank(germplasm.getFemaleParentDBID())) {
+                germplasmPedigreeGIDString.append(germplasm.getFemaleParentDBID());
+            } else if (StringUtils.isNotBlank(germplasm.getFemaleParentEntryNo())) {
+                Integer femaleParentIdx = germplasmIndexByEntryNo.get(germplasm.getFemaleParentEntryNo());
+                BrAPIImport femaleParentRow = importRows.get(femaleParentIdx);
+                BrAPIGermplasm femaleGerm = dbGermplasmByName.get(femaleParentRow.getGermplasm()
+                                                                                 .getGermplasmName());
+                if (femaleGerm != null) {
+                    germplasmPedigreeGIDString.append(femaleGerm.getAccessionNumber());
+                } else {
+                    germplasmPedigreeGIDString.append("-1");
+                }
+            } else {
+                germplasmPedigreeGIDString.append(existingFemalePedigree);
+            }
+            germplasmPedigreeGIDString.append("/");
+            if (StringUtils.isNotBlank(germplasm.getMaleParentDBID())) {
+                germplasmPedigreeGIDString.append(germplasm.getMaleParentDBID());
+            } else if (StringUtils.isNotBlank(germplasm.getMaleParentEntryNo())) {
+                Integer maleParentIdx = germplasmIndexByEntryNo.get(germplasm.getMaleParentEntryNo());
+                BrAPIImport maleParentRow = importRows.get(maleParentIdx);
+                BrAPIGermplasm maleGerm = dbGermplasmByName.get(maleParentRow.getGermplasm()
+                                                                             .getGermplasmName());
+                if (maleGerm != null) {
+                    germplasmPedigreeGIDString.append(maleGerm.getAccessionNumber());
+                } else {
+                    germplasmPedigreeGIDString.append("-1");
+                }
+            } else {
+                germplasmPedigreeGIDString.append(existingMalePedigree);
+            }
+
+            return existingPedigreeGIDString.toString().equals(germplasmPedigreeGIDString.toString());
+        } else {
+            return true;
+        }
+    }
+
+    private String getParentId(BrAPIGermplasm existingGermplasm, StringBuilder pedigreeGIDString, String gidAdditionaInfoField, String unknownAdditionalInfoField) {
+        if (existingGermplasm.getAdditionalInfo()
+                             .has(gidAdditionaInfoField)) {
+            pedigreeGIDString.append(existingGermplasm.getAdditionalInfo()
+                                                              .get(gidAdditionaInfoField)
+                                                              .getAsString());
+            return existingGermplasm.getAdditionalInfo()
+                                                      .get(gidAdditionaInfoField)
+                                                      .getAsString();
+        } else if (existingGermplasm.getAdditionalInfo()
+                                    .has(unknownAdditionalInfoField) && existingGermplasm.getAdditionalInfo()
+                                                                                                              .get(unknownAdditionalInfoField)
+                                                                                                              .getAsBoolean()) {
+            pedigreeGIDString.append("0");
+            return "0";
+        }
+        return "";
+    }
+
+    private boolean canUpdatePedigreeNoEqualsCheck(BrAPIGermplasm existingGermplasm, Germplasm germplasm) {
 
 
         return StringUtils.isBlank(existingGermplasm.getPedigree()) &&
-               !germplasm.pedigreeEmpty();
+                germplasm.pedigreeExists();
     }
 
     private Map<String, ImportPreviewStatistics> getStatisticsMap(List<BrAPIImport> importRows) {
@@ -462,8 +563,8 @@ public class GermplasmProcessor implements Processor {
                 List<String> pedigreeArray = List.of(germplasm.getPedigree().split("/"));
                 String femaleParent = pedigreeArray.get(0);
                 String maleParent = pedigreeArray.size() > 1 ? pedigreeArray.get(1) : null;
-                if (created.contains(femaleParent) || germplasm.getAdditionalInfo().get("femaleParentUnknown").getAsBoolean()) {
-                    if (maleParent == null || created.contains(maleParent) || germplasm.getAdditionalInfo().get("maleParentUnknown").getAsBoolean()) {
+                if (created.contains(femaleParent) || germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN).getAsBoolean()) {
+                    if (maleParent == null || created.contains(maleParent) || germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN).getAsBoolean()) {
                         createList.add(germplasm);
                     }
                 }
@@ -471,7 +572,7 @@ public class GermplasmProcessor implements Processor {
 
             totalRecorded += createList.size();
             if (createList.size() > 0) {
-                created.addAll(createList.stream().map(brAPIGermplasm -> brAPIGermplasm.getGermplasmName()).collect(Collectors.toList()));
+                created.addAll(createList.stream().map(BrAPIGermplasm::getGermplasmName).collect(Collectors.toList()));
                 postOrder.add(createList);
             } else if (totalRecorded < newGermplasmList.size()) {
                 // We ran into circular dependencies, throw an error
@@ -554,13 +655,16 @@ public class GermplasmProcessor implements Processor {
             boolean femaleParentUnknown = false;
             boolean maleParentUnknown = false;
 
+            BrAPIGermplasm femaleParent = null;
+            BrAPIGermplasm maleParent = null;
+
             boolean femaleParentFound = false;
             StringBuilder pedigreeString = new StringBuilder();
             if (femaleParentDB != null) {
                 if (femaleParentDB.equals("0")) {
                     femaleParentUnknown = true;
                 } else if (germplasmByAccessionNumber.containsKey(femaleParentDB)) {
-                    BrAPIGermplasm femaleParent = germplasmByAccessionNumber.get(femaleParentDB).getBrAPIObject();
+                    femaleParent = germplasmByAccessionNumber.get(femaleParentDB).getBrAPIObject();
                     pedigreeString.append(commit ? femaleParent.getGermplasmName() : femaleParent.getDefaultDisplayName());
                     femaleParentFound = true;
                 }
@@ -570,7 +674,7 @@ public class GermplasmProcessor implements Processor {
                 }
                 else if (germplasmIndexByEntryNo.containsKey(germplasm.getFemaleParentEntryNo())) {
                     Integer femaleParentInd = germplasmIndexByEntryNo.get(femaleParentFile);
-                    BrAPIGermplasm femaleParent = mappedBrAPIImport.get(femaleParentInd).getGermplasm().getBrAPIObject();
+                    femaleParent = mappedBrAPIImport.get(femaleParentInd).getGermplasm().getBrAPIObject();
                     pedigreeString.append(commit ? femaleParent.getGermplasmName() : femaleParent.getDefaultDisplayName());
                     femaleParentFound = true;
                 }
@@ -582,7 +686,7 @@ public class GermplasmProcessor implements Processor {
                         maleParentUnknown = true;
                     }
                     if ((germplasmByAccessionNumber.containsKey(germplasm.getMaleParentDBID()))) {
-                        BrAPIGermplasm maleParent = germplasmByAccessionNumber.get(maleParentDB).getBrAPIObject();
+                        maleParent = germplasmByAccessionNumber.get(maleParentDB).getBrAPIObject();
                         pedigreeString.append(String.format("/%s", commit ? maleParent.getGermplasmName() : maleParent.getDefaultDisplayName()));
                     }
                 } else if (maleParentFile != null){
@@ -591,26 +695,27 @@ public class GermplasmProcessor implements Processor {
                     }
                     if (germplasmIndexByEntryNo.containsKey(germplasm.getMaleParentEntryNo())) {
                         Integer maleParentInd = germplasmIndexByEntryNo.get(maleParentFile);
-                        BrAPIGermplasm maleParent = mappedBrAPIImport.get(maleParentInd).getGermplasm().getBrAPIObject();
+                        maleParent = mappedBrAPIImport.get(maleParentInd).getGermplasm().getBrAPIObject();
                         pedigreeString.append(String.format("/%s", commit ? maleParent.getGermplasmName() : maleParent.getDefaultDisplayName()));
                     }
                 }
             }
 
-            // only update pedigree with the following conditions:
-            // - new germplasm & pedigree is not empty
-            // - existing pedigree & existing pedigree is blank & new pedigree is different & not empty
-            BrAPIGermplasm brapiGermplasm = mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject();
+            mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().setPedigree(pedigreeString.length() > 0 ? pedigreeString.toString() : null);
+            //Simpler to just always add boolean, but consider for logic that previous imported values won't have that additional info value
+            mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN, femaleParentUnknown);
+            mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN, maleParentUnknown);
 
-            // no existing pedigree and pedigree not empty
-            // pedigrees will be equal at this point from prior processing code if being updated so don't check that
-            boolean updatePedigree = updatePedigreeNoEqualsCheck(brapiGermplasm, germplasm);
+            if(commit) {
+                if (femaleParentFound) {
+                    mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID, femaleParent.getAccessionNumber());
+                }
 
-            if (updatePedigree) {
-                mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().setPedigree(pedigreeString.length() > 0 ? pedigreeString.toString() : null);
-                //Simpler to just always add boolean, but consider for logic that previous imported values won't have that additional info value
-                mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN, femaleParentUnknown);
-                mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN, maleParentUnknown);
+                if (maleParent != null) {
+                    mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID, maleParent.getAccessionNumber());
+                }
+
+                mappedBrAPIImport.get(i).getGermplasm().getBrAPIObject().putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_RAW_PEDIGREE, pedigreeString);
             }
         }
     }


### PR DESCRIPTION
# Description
**Story:** [BI-1855](https://breedinginsight.atlassian.net/browse/BI-1855?atlOrigin=eyJpIjoiMmMzMzdmMjMyOGYzNDY4OGI5NjhjMDljNDc3MzAxMjEiLCJwIjoiaiJ9)

- Germplasm update logic changed:
- Allow empty pedigree values to enable creating a new germplasm list without requiring the original pedigree values
- Only require parent gids to be entered when updating a germplasm pedigree rather than gid and entry number
- Various bug fixes found when testing against Breedbase

# Dependencies
- release/0.8 bi-web

# Testing
- Test different combinations of updating pedigrees, synonyms, and not allowed pedigree changes
- Test files used in development, number indicates order ascending: [1855-tep46-np398.zip](https://github.com/Breeding-Insight/bi-api/files/12315658/1855-tep46-np398.zip)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1855]: https://breedinginsight.atlassian.net/browse/BI-1855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ