### PR TITLE
[BI-1831] Add DatasetID to ObservationUnits

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -296,18 +296,14 @@ public class BrAPITrialService {
     }
 
     public Dataset getDatasetData(Program program, UUID experimentId, UUID datsetId, Boolean stats) throws ApiException, DoesNotExistException {
-        BrAPITrial experiment = this.getExperiment(program, experimentId);
-
-        // TODO: Once BI-1831 is complete and OUs in a dataset can be identified using the datasetId stored as a xref
-        // the expOUs needs to be replaced with datasetOUs, as was done with datasetObsVars
-        List<BrAPIObservationUnit> expOUs = ouDAO.getObservationUnitsForTrialDbId(program.getId(), experiment.getTrialDbId(), true);
+        List<BrAPIObservationUnit> datasetOUs = ouDAO.getObservationUnitsForDataset(datsetId.toString(), program);
         List<BrAPIObservationVariable> datasetObsVars = getDatasetObsVars(datsetId.toString(), program);
-        List<String> ouDbIds = expOUs.stream().map(BrAPIObservationUnit::getObservationUnitDbId).collect(Collectors.toList());
+        List<String> ouDbIds = datasetOUs.stream().map(BrAPIObservationUnit::getObservationUnitDbId).collect(Collectors.toList());
         List<String> obsVarDbIds = datasetObsVars.stream().map(BrAPIObservationVariable::getObservationVariableDbId).collect(Collectors.toList());
         List<BrAPIObservation> data = observationDAO.getObservationsByObservationUnitsAndVariables(ouDbIds, obsVarDbIds, program);
-        Dataset dataset = new Dataset(experimentId.toString(), data, expOUs, datasetObsVars);
+        Dataset dataset = new Dataset(experimentId.toString(), data, datasetOUs, datasetObsVars);
         if (stats) {
-            Integer ouCount = expOUs.size();
+            Integer ouCount = datasetOUs.size();
             Integer obsVarCount = datasetObsVars.size();
             Integer obsCount = ouCount * obsVarCount;
             Integer obsDataCount = data.size();

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import io.micronaut.context.annotation.Property;
 import org.brapi.client.v2.JSON;
+import io.micronaut.http.server.exceptions.InternalServerException;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.phenotype.ObservationUnitsApi;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
@@ -95,6 +96,19 @@ public class BrAPIObservationUnitDAO {
         List<BrAPIObservationUnit> ous = brAPIDAOUtil.post(brAPIObservationUnitList, upload, api::observationunitsPost, importDAO::update);
         processObservationUnits(programId, ous, false);
         return ous;
+    }
+
+    public BrAPIObservationUnit updateBrAPIObservationUnit(String ouDbId, BrAPIObservationUnit ou, UUID programId) {
+        ObservationUnitsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ObservationUnitsApi.class);
+        BrAPIObservationUnit updatedOu = null;
+        try {
+            if (ou != null && !ouDbId.isBlank()) {
+                updatedOu = brAPIDAOUtil.put(ouDbId, ou, api::observationunitsObservationUnitDbIdPut);
+            }
+            return updatedOu;
+        } catch (Exception e) {
+            throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
+        }
     }
 
     public List<BrAPIObservationUnit> getObservationUnitsById(Collection<String> observationUnitExternalIds, Program program) throws ApiException {

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
@@ -26,6 +26,7 @@ import org.brapi.client.v2.JSON;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.phenotype.ObservationUnitsApi;
+import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
 import org.brapi.v2.model.pheno.request.BrAPIObservationUnitSearchRequest;
@@ -43,6 +44,7 @@ import org.breedinginsight.services.ProgramService;
 import org.breedinginsight.services.brapi.BrAPIEndpointProvider;
 import org.breedinginsight.services.exceptions.DoesNotExistException;
 import org.breedinginsight.utilities.BrAPIDAOUtil;
+import org.breedinginsight.utilities.Utilities;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -65,7 +67,13 @@ public class BrAPIObservationUnitDAO {
     private final Type treatmentlistType = new TypeToken<ArrayList<BrAPIObservationTreatment>>(){}.getType();
 
     @Inject
-    public BrAPIObservationUnitDAO(ProgramDAO programDAO, ImportDAO importDAO, BrAPIDAOUtil brAPIDAOUtil, BrAPIEndpointProvider brAPIEndpointProvider, BrAPIGermplasmService germplasmService, ProgramService programService, @Property(name = "brapi.server.reference-source") String referenceSource) {
+    public BrAPIObservationUnitDAO(ProgramDAO programDAO,
+                                   ImportDAO importDAO,
+                                   BrAPIDAOUtil brAPIDAOUtil,
+                                   BrAPIEndpointProvider brAPIEndpointProvider,
+                                   BrAPIGermplasmService germplasmService,
+                                   ProgramService programService,
+                                   @Property(name = "brapi.server.reference-source") String referenceSource) {
         this.programDAO = programDAO;
         this.importDAO = importDAO;
         this.brAPIDAOUtil = brAPIDAOUtil;
@@ -136,6 +144,18 @@ public class BrAPIObservationUnitDAO {
 
     public List<BrAPIObservationUnit> getObservationUnitsForTrialDbId(@NotNull UUID programId, @NotNull String trialDbId) throws ApiException, DoesNotExistException {
         return getObservationUnitsForTrialDbId(programId, trialDbId, false);
+    }
+
+    public List<BrAPIObservationUnit> getObservationUnitsForDataset(@NotNull String datasetId, @NotNull Program program) throws ApiException {
+        String datasetReferenceSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.DATASET);
+        BrAPIObservationUnitSearchRequest ouSearchRequest = new BrAPIObservationUnitSearchRequest();
+        ouSearchRequest.programDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
+        ouSearchRequest.externalReferenceSources(List.of(datasetReferenceSource));
+        ouSearchRequest.externalReferenceIDs(List.of(datasetId));
+        ObservationUnitsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), ObservationUnitsApi.class);
+        return brAPIDAOUtil.search(api::searchObservationunitsPost,
+                api::searchObservationunitsSearchResultsDbIdGet,
+                ouSearchRequest);
     }
 
     public List<BrAPIObservationUnit> getObservationUnitsForTrialDbId(@NotNull UUID programId, @NotNull String trialDbId, boolean withGID) throws ApiException, DoesNotExistException {

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -223,6 +223,7 @@ public class ExperimentObservation implements BrAPIImport {
             String germplasmName,
             String referenceSource,
             UUID trialID,
+            UUID datasetId,
             UUID studyID,
             UUID id
     ) {
@@ -232,7 +233,7 @@ public class ExperimentObservation implements BrAPIImport {
             observationUnit.setObservationUnitName(Utilities.appendProgramKey(getExpUnitId(), program.getKey(), seqVal));
 
             // Set external reference
-            observationUnit.setExternalReferences(getObsUnitExternalReferences(program, referenceSource, trialID, studyID, id));
+            observationUnit.setExternalReferences(getObsUnitExternalReferences(program, referenceSource, trialID, datasetId, studyID, id));
         } else {
             observationUnit.setObservationUnitName(getExpUnitId());
         }
@@ -345,12 +346,15 @@ public class ExperimentObservation implements BrAPIImport {
     }
 
     private List<BrAPIExternalReference> getBrAPIExternalReferences(
-            Program program, String referenceSourceBaseName, UUID trialId, UUID studyId, UUID obsUnitId, UUID observationId) {
+            Program program, String referenceSourceBaseName, UUID trialId, UUID datasetId, UUID studyId, UUID obsUnitId, UUID observationId) {
         List<BrAPIExternalReference> refs = new ArrayList<>();
 
         addReference(refs, program.getId(), referenceSourceBaseName, ExternalReferenceSource.PROGRAMS);
         if (trialId != null) {
             addReference(refs, trialId, referenceSourceBaseName, ExternalReferenceSource.TRIALS);
+        }
+        if (datasetId != null) {
+            addReference(refs, datasetId, referenceSourceBaseName, ExternalReferenceSource.DATASET);
         }
         if (studyId != null) {
             addReference(refs, studyId, referenceSourceBaseName, ExternalReferenceSource.STUDIES);
@@ -367,22 +371,22 @@ public class ExperimentObservation implements BrAPIImport {
 
     private List<BrAPIExternalReference> getTrialExternalReferences(
             Program program, String referenceSourceBaseName, UUID trialId) {
-        return getBrAPIExternalReferences(program, referenceSourceBaseName, trialId, null, null, null);
+        return getBrAPIExternalReferences(program, referenceSourceBaseName, trialId, null, null, null, null);
     }
 
     private List<BrAPIExternalReference> getStudyExternalReferences(
             Program program, String referenceSourceBaseName, UUID trialId, UUID studyId) {
-        return getBrAPIExternalReferences(program, referenceSourceBaseName, trialId, studyId, null, null);
+        return getBrAPIExternalReferences(program, referenceSourceBaseName, trialId, null, studyId, null, null);
     }
 
     private List<BrAPIExternalReference> getObsUnitExternalReferences(
-            Program program, String referenceSourceBaseName, UUID trialId, UUID studyId, UUID obsUnitId) {
-        return getBrAPIExternalReferences(program, referenceSourceBaseName, trialId, studyId, obsUnitId, null);
+            Program program, String referenceSourceBaseName, UUID trialId, UUID datasetId, UUID studyId, UUID obsUnitId) {
+        return getBrAPIExternalReferences(program, referenceSourceBaseName, trialId, datasetId, null, obsUnitId, null);
     }
 
     private List<BrAPIExternalReference> getObservationExternalReferences(
             Program program, String referenceSourceBaseName, UUID trialId, UUID studyId, UUID obsUnitId, UUID observationId) {
-        return getBrAPIExternalReferences(program, referenceSourceBaseName, trialId, studyId, obsUnitId, observationId);
+        return getBrAPIExternalReferences(program, referenceSourceBaseName, trialId, null, studyId, obsUnitId, observationId);
     }
 
 

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -381,7 +381,7 @@ public class ExperimentObservation implements BrAPIImport {
 
     private List<BrAPIExternalReference> getObsUnitExternalReferences(
             Program program, String referenceSourceBaseName, UUID trialId, UUID datasetId, UUID studyId, UUID obsUnitId) {
-        return getBrAPIExternalReferences(program, referenceSourceBaseName, trialId, datasetId, null, obsUnitId, null);
+        return getBrAPIExternalReferences(program, referenceSourceBaseName, trialId, datasetId, studyId, obsUnitId, null);
     }
 
     private List<BrAPIExternalReference> getObservationExternalReferences(

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -806,9 +806,12 @@ public class ExperimentProcessor implements Processor {
             }
             PendingImportObject<BrAPITrial> trialPIO = this.trialByNameNoScope.get(importRow.getExpTitle());
             UUID trialID = trialPIO.getId();
-            UUID datasetId = UUID.fromString(trialPIO.getBrAPIObject()
-                    .getAdditionalInfo().getAsJsonObject()
-                    .get(BrAPIAdditionalInfoFields.OBSERVATION_DATASET_ID).getAsString());
+            UUID datasetId = null;
+            if (commit) {
+                datasetId = UUID.fromString(trialPIO.getBrAPIObject()
+                        .getAdditionalInfo().getAsJsonObject()
+                        .get(BrAPIAdditionalInfoFields.OBSERVATION_DATASET_ID).getAsString());
+            }
             PendingImportObject<BrAPIStudy> studyPIO = this.studyByNameNoScope.get(importRow.getEnv());
             UUID studyID = studyPIO.getId();
             UUID id = UUID.randomUUID();

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -41,6 +41,7 @@ import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapps.importer.daos.*;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
+import org.breedinginsight.brapps.importer.model.base.AdditionalInfo;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
 import org.breedinginsight.brapps.importer.model.imports.PendingImport;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
@@ -805,10 +806,13 @@ public class ExperimentProcessor implements Processor {
             }
             PendingImportObject<BrAPITrial> trialPIO = this.trialByNameNoScope.get(importRow.getExpTitle());
             UUID trialID = trialPIO.getId();
+            UUID datasetId = UUID.fromString(trialPIO.getBrAPIObject()
+                    .getAdditionalInfo().getAsJsonObject()
+                    .get(BrAPIAdditionalInfoFields.OBSERVATION_DATASET_ID).getAsString());
             PendingImportObject<BrAPIStudy> studyPIO = this.studyByNameNoScope.get(importRow.getEnv());
             UUID studyID = studyPIO.getId();
             UUID id = UUID.randomUUID();
-            BrAPIObservationUnit newObservationUnit = importRow.constructBrAPIObservationUnit(program, envSeqValue, commit, germplasmName, BRAPI_REFERENCE_SOURCE, trialID, studyID, id);
+            BrAPIObservationUnit newObservationUnit = importRow.constructBrAPIObservationUnit(program, envSeqValue, commit, germplasmName, BRAPI_REFERENCE_SOURCE, trialID, datasetId, studyID, id);
             pio = new PendingImportObject<>(ImportObjectState.NEW, newObservationUnit, id);
             this.observationUnitByNameNoScope.put(key, pio);
         }

--- a/src/main/java/org/breedinginsight/db/migration/V1_0_13__Update_BrAPI_Locations_XRefs.java
+++ b/src/main/java/org/breedinginsight/db/migration/V1_0_13__Update_BrAPI_Locations_XRefs.java
@@ -49,7 +49,7 @@ public class V1_0_13__Update_BrAPI_Locations_XRefs extends BaseJavaMigration {
         String referenceSource = placeholders.get(BRAPI_REFERENCE_SOURCE_KEY);
 
         // Get all the programs
-        List<Program> programs = getAllPrograms(context, defaultUrl);
+        List<Program> programs = Utilities.getAllProgramsFlyway(context, defaultUrl);
         Map<UUID, LocationsApi> locationsApiForProgram = new HashMap<>();
         for (Program program : programs) {
             BrAPIClient client = new BrAPIClient(program.getBrapiUrl(), 240000);
@@ -102,23 +102,5 @@ public class V1_0_13__Update_BrAPI_Locations_XRefs extends BaseJavaMigration {
             }
         }
         return locations;
-    }
-
-    private List<Program> getAllPrograms(Context context, String defaultUrl) throws Exception {
-        List<Program> programs = new ArrayList<>();
-        try (Statement select = context.getConnection().createStatement()) {
-            try (ResultSet rows = select.executeQuery("SELECT id, brapi_url, key FROM program where active = true ORDER BY id")) {
-                while (rows.next()) {
-                    Program program = new Program();
-                    program.setId(UUID.fromString(rows.getString(1)));
-                    String brapi_url = rows.getString(2);
-                    if (brapi_url == null) brapi_url = defaultUrl;
-                    program.setBrapiUrl(brapi_url);
-                    program.setKey(rows.getString(3));
-                    programs.add(program);
-                }
-            }
-        }
-        return programs;
     }
 }

--- a/src/main/java/org/breedinginsight/db/migration/V1_0_15__Add_OU_Dataset_Xrefs.java
+++ b/src/main/java/org/breedinginsight/db/migration/V1_0_15__Add_OU_Dataset_Xrefs.java
@@ -1,0 +1,115 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.db.migration;
+
+import io.micronaut.context.annotation.ConfigurationInject;
+import lombok.extern.slf4j.Slf4j;
+import org.brapi.client.v2.ApiResponse;
+import org.brapi.client.v2.BrAPIClient;
+import org.brapi.client.v2.model.queryParams.core.TrialQueryParams;
+import org.brapi.client.v2.model.queryParams.phenotype.ObservationUnitQueryParams;
+import org.brapi.client.v2.modules.core.TrialsApi;
+import org.brapi.client.v2.modules.phenotype.ObservationUnitsApi;
+import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.core.BrAPITrial;
+import org.brapi.v2.model.core.response.BrAPITrialListResponse;
+import org.brapi.v2.model.pheno.BrAPIObservationUnit;
+import org.brapi.v2.model.pheno.response.BrAPIObservationUnitListResponse;
+import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
+import org.breedinginsight.brapps.importer.daos.BrAPIObservationUnitDAO;
+import org.breedinginsight.brapps.importer.daos.BrAPITrialDAO;
+import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.utilities.Utilities;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import javax.inject.Inject;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class V1_0_15__Add_OU_Dataset_Xrefs extends BaseJavaMigration {
+    final private String DEFAULT_URL_KEY = "default-url";
+    final private String BRAPI_REFERENCE_SOURCE_KEY = "brapi-reference-source";
+    private final BrAPITrialDAO trialDAO;
+    private final BrAPIObservationUnitDAO ouDAO;
+
+    @Inject
+    V1_0_15__Add_OU_Dataset_Xrefs(BrAPITrialDAO trialDAO, BrAPIObservationUnitDAO ouDAO) {
+        this.trialDAO = trialDAO;
+        this.ouDAO = ouDAO;
+    }
+
+    public void migrate(Context context) throws Exception {
+        Map<String, String> placeholders = context.getConfiguration().getPlaceholders();
+        String defaultUrl = placeholders.get(DEFAULT_URL_KEY);
+        String referenceSource = placeholders.get(BRAPI_REFERENCE_SOURCE_KEY);
+        String programReferenceSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS);
+        String trialReferenceSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.TRIALS);
+        String datasetReferenceSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.DATASET);
+
+
+        // Get all the programs
+        List<Program> programs = Utilities.getAllProgramsFlyway(context, defaultUrl);
+
+        // For each program, update any observation units created via Deltabreed
+        for (Program program : programs) {
+
+            // Get the Deltabreed-generated experiments for the program
+            List<BrAPITrial> experiments = trialDAO.getTrials(program.getId()).stream().filter(trial -> {
+                List<BrAPIExternalReference> xrefs = trial.getExternalReferences();
+                Optional<BrAPIExternalReference> programRef = Utilities.getExternalReference(xrefs,programReferenceSource);
+                return trial.getAdditionalInfo().getAsJsonObject().has(BrAPIAdditionalInfoFields.OBSERVATION_DATASET_ID) &&
+                        programRef.isPresent() &&
+                        program.getId().equals(UUID.fromString(programRef.get().getReferenceID()));
+            }).collect(Collectors.toList());
+
+            Map<String, String> ExpIdByDbId = new HashMap<>();
+            experiments.stream().forEach(exp -> {
+                Optional<BrAPIExternalReference> expRef = Utilities.getExternalReference(exp.getExternalReferences(), trialReferenceSource);
+                if (expRef.isPresent()) {
+                    ExpIdByDbId.put(expRef.get().getReferenceID(), exp.getTrialDbId());
+                }
+            });
+
+            for (BrAPITrial exp : experiments) {
+
+                ouDAO.getObservationUnitsForTrialDbId(program.getId(), exp.getTrialDbId())
+                        .stream().filter(ou -> {
+
+                            // For each experiment, fetch the observation units that need a dataset reference
+                            List<BrAPIExternalReference> xrefs = ou.getExternalReferences();
+                            Optional<BrAPIExternalReference> expRef = Utilities.getExternalReference(xrefs, trialReferenceSource);
+                            Optional<BrAPIExternalReference> datasetRef = Utilities.getExternalReference(xrefs, datasetReferenceSource);
+                           return datasetRef.isEmpty() &&
+                                   expRef.isPresent() &&
+                                   ExpIdByDbId.get(exp.getTrialDbId()).equals(expRef.get().getReferenceID());
+                        }).forEach(ou -> {
+
+                            // Assign the experiment Observation Dataset id to the observation units
+                            BrAPIExternalReference datasetRef = new BrAPIExternalReference()
+                                    .referenceSource(datasetReferenceSource)
+                                    .referenceID(exp.getAdditionalInfo().getAsJsonObject().get(BrAPIAdditionalInfoFields.OBSERVATION_DATASET_ID).getAsString());
+                            ou.getExternalReferences().add(datasetRef);
+                            ouDAO.updateBrAPIObservationUnit(ou.getObservationUnitDbId(), ou, program.getId());
+                        });
+            }
+        }
+    }
+}

--- a/src/main/java/org/breedinginsight/db/migration/V1_0_15__Add_OU_Dataset_Xrefs.java
+++ b/src/main/java/org/breedinginsight/db/migration/V1_0_15__Add_OU_Dataset_Xrefs.java
@@ -30,18 +30,13 @@ import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.core.response.BrAPITrialListResponse;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
 import org.brapi.v2.model.pheno.response.BrAPIObservationUnitListResponse;
-import org.brapi.v2.model.pheno.response.BrAPIObservationUnitListResponseResult;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
-import org.breedinginsight.brapps.importer.daos.BrAPIObservationUnitDAO;
-import org.breedinginsight.brapps.importer.daos.BrAPITrialDAO;
-import org.breedinginsight.brapps.importer.daos.impl.BrAPITrialDAOImpl;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.utilities.Utilities;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
 
-import javax.inject.Inject;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -114,7 +109,6 @@ public class V1_0_15__Add_OU_Dataset_Xrefs extends BaseJavaMigration {
                                 ousResponse.getBody().getMetadata().getPagination().getCurrentPage()+1,
                                 ousResponse.getBody().getMetadata().getPagination().getTotalPages(),
                                 exp.getTrialName()));
-                        Map<String, BrAPIObservationUnit> mutatedOuByDbId = new HashMap<>();
                         ousResponse.getBody().getResult().getData()
                                 .stream().filter(ou -> {
 
@@ -142,14 +136,20 @@ public class V1_0_15__Add_OU_Dataset_Xrefs extends BaseJavaMigration {
                                         BrAPIObservationUnit updatedOu = ousApi.observationunitsObservationUnitDbIdPut(ou.getObservationUnitDbId(), ou).getBody().getResult();
 
                                         // Verify that the observation unit was updated at the server
+                                        // TODO: Breedbase does not return the updated unit in the successful response, and fetching a single unit via GET returns a an error
+                                        // parsing the date time. Once these bugs are fixed in Breedbase, uncomment the verification step below.
+                                        /*
                                         boolean isUpdated = updatedOu.getExternalReferences().stream().anyMatch(xref -> {
                                             return xref.getReferenceSource().equals(datasetReferenceSource) &&
                                                     xref.getReferenceID().equals(exp.getAdditionalInfo().getAsJsonObject().get(BrAPIAdditionalInfoFields.OBSERVATION_DATASET_ID).getAsString());
                                         });
+
                                         log.debug("Updating observation unit successful: " + String.valueOf(isUpdated));
                                         if (!isUpdated) {
                                             throw new Exception("Observation unit returned from brapi server was not updated. Check your brapi server.");
                                         }
+
+                                         */
                                     } catch(Exception e) {
                                         log.error(e.getMessage(), e);
                                         throw new InternalServerException(e.toString(), e);

--- a/src/main/java/org/breedinginsight/db/migration/V1_0_15__Add_OU_Dataset_Xrefs.java
+++ b/src/main/java/org/breedinginsight/db/migration/V1_0_15__Add_OU_Dataset_Xrefs.java
@@ -76,14 +76,14 @@ public class V1_0_15__Add_OU_Dataset_Xrefs extends BaseJavaMigration {
             ApiResponse<BrAPITrialListResponse> trialsResponse = trialsApi.trialsGet(trialQueryParams);
 
             boolean trialsDone = trialsResponse.getBody() == null || trialsResponse.getBody().getMetadata().getPagination().getTotalCount() == 0 || trialsResponse.getBody().getResult() == null;
-            while(!trialsDone) {
+            while (!trialsDone) {
                 log.debug(String.format("processing page %d of %d of experiments for programId: %s",
-                        trialsResponse.getBody().getMetadata().getPagination().getCurrentPage()+1,
+                        trialsResponse.getBody().getMetadata().getPagination().getCurrentPage() + 1,
                         trialsResponse.getBody().getMetadata().getPagination().getTotalPages(),
                         program.getId()));
                 List<BrAPITrial> experiments = trialsResponse.getBody().getResult().getData().stream().filter(trial -> {
                     List<BrAPIExternalReference> xrefs = trial.getExternalReferences();
-                    Optional<BrAPIExternalReference> programRef = Utilities.getExternalReference(xrefs,programReferenceSource);
+                    Optional<BrAPIExternalReference> programRef = Utilities.getExternalReference(xrefs, programReferenceSource);
                     return trial.getAdditionalInfo().getAsJsonObject().has(BrAPIAdditionalInfoFields.OBSERVATION_DATASET_ID) &&
                             programRef.isPresent() &&
                             program.getId().equals(UUID.fromString(programRef.get().getReferenceID()));
@@ -107,9 +107,9 @@ public class V1_0_15__Add_OU_Dataset_Xrefs extends BaseJavaMigration {
                     ApiResponse<BrAPIObservationUnitListResponse> ousResponse = ousApi.observationunitsGet(ouQueryParams);
 
                     boolean ousDone = ousResponse.getBody() == null || ousResponse.getBody().getMetadata().getPagination().getTotalCount() == 0 || ousResponse.getBody().getResult() == null;
-                    while(!ousDone) {
+                    while (!ousDone) {
                         log.debug(String.format("processing page %d of %d of observation units for experiment: %s",
-                                ousResponse.getBody().getMetadata().getPagination().getCurrentPage()+1,
+                                ousResponse.getBody().getMetadata().getPagination().getCurrentPage() + 1,
                                 ousResponse.getBody().getMetadata().getPagination().getTotalPages(),
                                 exp.getTrialName()));
                         ousResponse.getBody().getResult().getData()
@@ -130,13 +130,13 @@ public class V1_0_15__Add_OU_Dataset_Xrefs extends BaseJavaMigration {
                                             .referenceID(exp.getAdditionalInfo().getAsJsonObject().get(BrAPIAdditionalInfoFields.OBSERVATION_DATASET_ID).getAsString());
                                     ou.getExternalReferences().add(datasetRef);
                                     log.debug(String.format("Adding observation unit (id: %s) with observation dataset (id: %s) to update list",
-                                        Utilities.getExternalReference(ou.getExternalReferences(), observationUnitReferenceSource),
-                                        datasetRef.getReferenceID()));
+                                            Utilities.getExternalReference(ou.getExternalReferences(), observationUnitReferenceSource),
+                                            datasetRef.getReferenceID()));
                                     ousToUpdate.put(ou.getObservationUnitDbId(), ou);
                                 });
-                        
+
                         // Fetch the next page of observation units for this experiment
-                        if(ousResponse.getBody().getMetadata().getPagination().getCurrentPage() + 1 == ousResponse.getBody().getMetadata().getPagination().getTotalPages()) {
+                        if (ousResponse.getBody().getMetadata().getPagination().getCurrentPage() + 1 == ousResponse.getBody().getMetadata().getPagination().getTotalPages()) {
                             ousDone = true;
                         } else {
                             ouQueryParams.page(ouQueryParams.page() + 1);
@@ -146,7 +146,7 @@ public class V1_0_15__Add_OU_Dataset_Xrefs extends BaseJavaMigration {
                 }
 
                 // Fetch the next page of experiments for this program
-                if(trialsResponse.getBody().getMetadata().getPagination().getCurrentPage() + 1 == trialsResponse.getBody().getMetadata().getPagination().getTotalPages()) {
+                if (trialsResponse.getBody().getMetadata().getPagination().getCurrentPage() + 1 == trialsResponse.getBody().getMetadata().getPagination().getTotalPages()) {
                     trialsDone = true;
                 } else {
                     trialQueryParams.page(trialQueryParams.page() + 1);
@@ -157,11 +157,11 @@ public class V1_0_15__Add_OU_Dataset_Xrefs extends BaseJavaMigration {
             try {
                 log.debug(String.format("Update OUs for program: %s at url: %s", program.getId(), program.getBrapiUrl()));
                 ousApi.observationunitsPut(ousToUpdate);
-            } catch(Exception e) {
+            } catch (Exception e) {
                 log.error(e.getMessage(), e);
                 throw new InternalServerException(e.toString(), e);
             }
-            }
+
         }
     }
 }

--- a/src/main/java/org/breedinginsight/db/migration/V1_0_15__Add_OU_Dataset_Xrefs.java
+++ b/src/main/java/org/breedinginsight/db/migration/V1_0_15__Add_OU_Dataset_Xrefs.java
@@ -141,11 +141,11 @@ public class V1_0_15__Add_OU_Dataset_Xrefs extends BaseJavaMigration {
                                         BrAPIObservationUnit updatedOu = ousApi.observationunitsObservationUnitDbIdPut(ou.getObservationUnitDbId(), ou).getBody().getResult();
 
                                         // Verify that the observation unit was updated at the server
-                                        log.debug(updatedOu.getExternalReferences().toString());
                                         boolean isUpdated = updatedOu.getExternalReferences().stream().anyMatch(xref -> {
                                             return xref.getReferenceSource().equals(datasetReferenceSource) &&
                                                     xref.getReferenceID().equals(exp.getAdditionalInfo().getAsJsonObject().get(BrAPIAdditionalInfoFields.OBSERVATION_DATASET_ID).getAsString());
                                         });
+                                        log.debug("Updating observation unit successful: " + String.valueOf(isUpdated));
                                         if (!isUpdated) {
                                             throw new Exception("Observation unit returned from brapi server was not updated. Check your brapi server.");
                                         }

--- a/src/main/java/org/breedinginsight/utilities/Utilities.java
+++ b/src/main/java/org/breedinginsight/utilities/Utilities.java
@@ -186,6 +186,12 @@ public class Utilities {
         return sb.toString();
     }
 
+    /**
+     * For only the context of a specific flyway migration, return a list of all Deltabreed programs.
+     * @param context the context relevant to a Java-based migration
+     * @param defaultUrl the url for the default BrAPI service
+     * @return a list of all Deltabreed programs
+     */
     public static List<Program> getAllProgramsFlyway(Context context, String defaultUrl) throws Exception {
         List<Program> programs = new ArrayList<>();
         try (Statement select = context.getConnection().createStatement()) {

--- a/src/main/java/org/breedinginsight/utilities/Utilities.java
+++ b/src/main/java/org/breedinginsight/utilities/Utilities.java
@@ -21,7 +21,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.model.Program;
+import org.flywaydb.core.api.migration.Context;
 
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -179,6 +184,24 @@ public class Utilities {
         }
 
         return sb.toString();
+    }
+
+    public static List<Program> getAllProgramsFlyway(Context context, String defaultUrl) throws Exception {
+        List<Program> programs = new ArrayList<>();
+        try (Statement select = context.getConnection().createStatement()) {
+            try (ResultSet rows = select.executeQuery("SELECT id, brapi_url, key FROM program where active = true ORDER BY id")) {
+                while (rows.next()) {
+                    Program program = new Program();
+                    program.setId(UUID.fromString(rows.getString(1)));
+                    String brapi_url = rows.getString(2);
+                    if (brapi_url == null) brapi_url = defaultUrl;
+                    program.setBrapiUrl(brapi_url);
+                    program.setKey(rows.getString(3));
+                    programs.add(program);
+                }
+            }
+        }
+        return programs;
     }
 
     private static boolean isSafeChar(char c) {


### PR DESCRIPTION
# Description
**Story:** [BI-1831](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-1831)
The Experiment processor was changed so that new observation units created during experiment import have a dataset external ref assigned with the experiment observation dataset id set as the reference id.

A previous TODO was fulfilled by updating the BrAPITrialService::getDatasetData to use only OUs that have the corresponding dataset id as an exref.

A flyway migration was created to add dataset xrefs to existing observation units belonging to BI experiemnts.

NOTE: further bug fixes in breedbase are required in order to verify the migration occurred without error, so the verification is left commented out unilt that TODO is done in a separate card: [BI-1898](https://breedinginsight.atlassian.net/browse/BI-1898)

# Dependencies
A bug in the ObservationUnits.pm update method was fixed and is needed for the migration to work with Breedbase.
Run the SGN branch `feature/BI-1831`.

# Testing
1. create two test programs: connect one to the brapi-java-server, the other to breedbase
2. switch to the `develop` branch for bi-api 
3. for both programs, import an experiment with observation variable headers but no observations
4. switch to the `feature/BI-1831` branch
5. verify that the observation units created in step 3 now have the dataset xref
6. import the same experiment with a new experiment name
7. verify that the observation units created during the import in step 6 have dataset xrefs assigned
8. download the experiment
9. verify fidelity between the export and import data


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1831]: https://breedinginsight.atlassian.net/browse/BI-1831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BI-1898]: https://breedinginsight.atlassian.net/browse/BI-1898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ