### PR TITLE
BI-1880 - Error saving experiment import with Breedbase

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -26,6 +26,9 @@ API_INTERNAL_TEST_PORT=8082
 
 BRAPI_READ_TIMEOUT=60m
 
+# Max number of records to POST to the BrAPI service per request
+POST_CHUNK_SIZE=1000
+
 # BrAPI Server Variables
 BRAPI_SERVER_PORT=8083
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - AWS_SECRET_KEY=${AWS_SECRET_KEY}
       - AWS_GENO_BUCKET=${AWS_GENO_BUCKET}
       - AWS_S3_ENDPOINT=${AWS_S3_ENDPOINT:-https://s3.us-east-1.amazonaws.com}
+    restart: always
     ports:
       - ${API_INTERNAL_PORT}:${API_INTERNAL_PORT}
     networks:
@@ -75,6 +76,7 @@ services:
     environment:
       - POSTGRES_DB=${DB_NAME}
       - POSTGRES_PASSWORD=${DB_PASSWORD}
+    restart: always
     ports:
       - "5432:5432"
     volumes:
@@ -93,6 +95,7 @@ services:
       - BRAPI_DB=postgres
       - BRAPI_DB_USER=postgres
       - BRAPI_DB_PASSWORD=${DB_PASSWORD}
+    restart: always
     ports:
       - ${BRAPI_SERVER_PORT}:8080
     volumes:
@@ -161,6 +164,7 @@ services:
   localstack:
     container_name: "localstack"
     image: localstack/localstack
+    restart: always
     ports:
       - "4566:4566"
     networks:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -164,7 +164,7 @@ brapi:
   page-size: 1000
   search:
     wait-time: 1000
-  post-group-size: 100
+  post-group-size: ${POST_CHUNK_SIZE:1000}
 
 email:
   relay-server:


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1880

BreedBase refreshes materialized views after each POST request, so increasing the post-group-size from 100 to 1000 could reduce the number of refreshes and improve performance. I also added support for setting this value from a new environment variable `POST_CHUNK_SIZE` (added to .env.template).

I also snuck in some changes to docker-compose.yml which is helpful in development.

# Testing
Upload large files, see if the chunk size is increased. The default value will be 1000 now, but you can also set a value in your .env.

Ultimately, once this is deployed we'll re-run the workflow documented on the Jira card to see if it's able to complete successfully. 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
