### PR TITLE
BI-1881 (Remove Need to Provide Parents to processGermplasmForDisplay)

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -296,7 +296,15 @@ public class BrAPIGermplasmDAO {
                     putGermplasm(putBrAPIGermplasmList, api);
                     // Need all program germplasm for processGermplasmForDisplay parents pedigree
                     List<BrAPIGermplasm> germplasm = getRawGermplasm(programId);
-                    return processGermplasmForDisplay(germplasm, program.getKey());
+                    Map<String,BrAPIGermplasm> allDisplayGermplasm = processGermplasmForDisplay(germplasm, program.getKey());
+                    Map<String,BrAPIGermplasm> updatedBrAPIGermplasmForDisplay = new HashMap<>();
+                    for (BrAPIGermplasm updatedGermplasm: putBrAPIGermplasmList) {
+                        BrAPIExternalReference extRef = updatedGermplasm.getExternalReferences().stream().filter(reference -> referenceSource.equals(reference.getReferenceSource())).findFirst().orElseThrow(() -> new IllegalStateException("No BI external reference found"));
+                        String germplasmId = extRef.getReferenceID();
+                        BrAPIGermplasm displayGerm = allDisplayGermplasm.get(germplasmId);
+                        updatedBrAPIGermplasmForDisplay.put(germplasmId, displayGerm);
+                    }
+                    return updatedBrAPIGermplasmForDisplay;
                 };
             }
             return programGermplasmCache.post(programId, postFunction);


### PR DESCRIPTION
# Description
[BI-1881](https://breedinginsight.atlassian.net/browse/BI-1881) Remove Need to Provide Parents to processGermplasmForDisplay

- Any call to processGermplasmForDisplay() now will only need to pass in a list of the modified germplasm, not the entire list of germplasm for the program
- if a parent of a gerplasm is not referenced on the passed-in list of germplasm, then, and only then will the code fetch the entire list of germplasm for the program.



# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [X] I have run TAF: [please include a link to TAF run](https://github.com/Breeding-Insight/taf/actions/runs/5978812089)


[BI-1881]: https://breedinginsight.atlassian.net/browse/BI-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ