### PR TITLE
BI-1872 - Generate Access Token for using BrAPI with DeltaBreed

### DIFF
--- a/src/main/java/org/breedinginsight/api/v1/controller/TokenController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/TokenController.java
@@ -24,14 +24,17 @@ import io.micronaut.http.uri.UriBuilder;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.breedinginsight.api.auth.AuthenticatedUser;
 import org.breedinginsight.api.auth.SecurityService;
 import org.breedinginsight.model.ApiToken;
 import org.breedinginsight.services.TokenService;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.validation.constraints.NotBlank;
 import java.net.URI;
+import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -47,9 +50,9 @@ public class TokenController {
         this.tokenService = tokenService;
     }
 
-    @Get("/api-token")
+    @Get("/api-token{?returnUrl}")
     @Secured(SecurityRule.IS_AUTHENTICATED)
-    public HttpResponse apiToken(@QueryValue @NotBlank String returnUrl) {
+    public HttpResponse apiToken(@QueryValue @Nullable String returnUrl) {
 
         AuthenticatedUser actingUser = securityService.getUser();
         Optional<ApiToken> token = tokenService.generateApiToken(actingUser);
@@ -57,18 +60,21 @@ public class TokenController {
         if(token.isPresent()) {
             ApiToken apiToken = token.get();
 
-            URI location = UriBuilder.of(returnUrl)
-                    .queryParam("status", 200)
-                    .queryParam("token", apiToken.getAccessToken())
-                    .build();
+            if(StringUtils.isNotBlank(returnUrl)) {
+                URI location = UriBuilder.of(returnUrl)
+                                         .queryParam("status", 200)
+                                         .queryParam("token", apiToken.getAccessToken())
+                                         .build();
 
-            return HttpResponse.seeOther(location)
-                    .header("Cache-Control","no-store")
-                    .header("Pragma", "no-cache");
+                return HttpResponse.seeOther(location)
+                                   .header("Cache-Control", "no-store")
+                                   .header("Pragma", "no-cache");
+            } else {
+                return HttpResponse.ok(Map.of("token", apiToken.getAccessToken()));
+            }
         } else {
             return HttpResponse.serverError();
         }
-
     }
     
 }

--- a/src/main/java/org/breedinginsight/api/v1/controller/TokenController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/TokenController.java
@@ -60,7 +60,10 @@ public class TokenController {
         if(token.isPresent()) {
             ApiToken apiToken = token.get();
 
-            if(StringUtils.isNotBlank(returnUrl)) {
+            if(returnUrl != null) {
+                if(StringUtils.trim(returnUrl).isEmpty()) {
+                    return HttpResponse.badRequest("returnUrl cannot be blank");
+                }
                 URI location = UriBuilder.of(returnUrl)
                                          .queryParam("status", 200)
                                          .queryParam("token", apiToken.getAccessToken())

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIV2Controller.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIV2Controller.java
@@ -63,10 +63,11 @@ public class BrAPIV2Controller {
     @Secured(SecurityRule.IS_ANONYMOUS)
     public BrAPIServerInfoResponse serverinfo() {
         BrAPIServerInfo serverInfo = new BrAPIServerInfo();
-        serverInfo.setOrganizationName("Breeding Insight Platform");
-        serverInfo.setServerName("bi-api");
+        serverInfo.setOrganizationName("Breeding Insight");
+        serverInfo.setServerName("DeltaBreed");
         serverInfo.setContactEmail("bidevteam@cornell.edu");
         serverInfo.setOrganizationURL("breedinginsight.org");
+        serverInfo.setServerDescription("BrAPI endpoints are not implemented at the root of this domain.  Please make BrAPI calls in the context of a program (ex: https://app.breedinginsight.net/v1/programs/<programId>/brapi/v2)");
 
         return new BrAPIServerInfoResponse().result(serverInfo);
     }

--- a/src/test/java/org/breedinginsight/api/v1/controller/TokenControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/TokenControllerIntegrationTest.java
@@ -42,19 +42,6 @@ public class TokenControllerIntegrationTest extends DatabaseTest {
     RxHttpClient client;
 
     @Test
-    void getApiTokenMissingRequiredParameter() {
-        Flowable<HttpResponse<String>> call = client.exchange(
-                GET("/api-token")
-                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
-        );
-
-        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> {
-            HttpResponse<String> response = call.blockingFirst();
-        });
-        assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
-    }
-
-    @Test
     void getApiTokenRequiredParameterBlank() {
         Flowable<HttpResponse<String>> call = client.exchange(
                 GET("/api-token?returnUrl=")

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ControllerIntegrationTest.java
@@ -142,8 +142,8 @@ public class BrAPIV2ControllerIntegrationTest extends BrAPITest {
                                       .getAsJsonObject("result");
         BrAPIServerInfo serverInfo = GSON.fromJson(result, BrAPIServerInfo.class);
 
-        assertEquals("Breeding Insight Platform", serverInfo.getOrganizationName());
-        assertEquals("bi-api", serverInfo.getServerName());
+        assertEquals("Breeding Insight", serverInfo.getOrganizationName());
+        assertEquals("DeltaBreed", serverInfo.getServerName());
         assertEquals("bidevteam@cornell.edu", serverInfo.getContactEmail());
         assertEquals("breedinginsight.org", serverInfo.getOrganizationURL());
     }


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1872

expanded the `TokenController#apiToken` method to allow the generation of a token to be triggered from the UI (previously this method was only used for generating a token for Field Book)

# Dependencies
none

# Testing
See https://github.com/Breeding-Insight/bi-web/pull/327


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] ~I have tested that my code works with both the brapi-java-server and BreedBase~
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/6027686471
