### PR TITLE
BI-1881 - Store Parent UUIDs in Germplasm AdditionalInfo

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
@@ -23,6 +23,8 @@ public final class BrAPIAdditionalInfoFields {
     public static final String GERMPLASM_RAW_PEDIGREE = "rawPedigree";
     public static final String GERMPLASM_PEDIGREE_BY_NAME = "pedigreeByName";
     public static final String GERMPLASM_PEDIGREE_BY_UUID = "pedigreeByUUID";
+    public static final String GERMPLASM_FEMALE_PARENT_UUID = "femaleParentUUID";
+    public static final String GERMPLASM_MALE_PARENT_UUID = "maleParentUUID";
     public static final String GERMPLASM_IMPORT_ENTRY_NUMBER = "importEntryNumber";
     public static final String GERMPLASM_FEMALE_PARENT_GID = "femaleParentGid";
     public static final String GERMPLASM_MALE_PARENT_GID = "maleParentGid";

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -31,7 +31,7 @@ import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.germ.BrAPIGermplasmSynonyms;
 import org.brapi.v2.model.germ.request.BrAPIGermplasmSearchRequest;
 import org.brapi.v2.model.germ.response.BrAPIGermplasmSingleResponse;
-import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
+import static org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields.*;
 import org.breedinginsight.brapps.importer.daos.ImportDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
@@ -112,9 +112,9 @@ public class BrAPIGermplasmDAO {
         List<BrAPIGermplasm> cacheList = new ArrayList<>(programGermplasmCache.get(programId).values());
         return cacheList.stream().map(germplasm -> {
             germplasm.setGermplasmName(Utilities.appendProgramKey(germplasm.getDefaultDisplayName(), program.getKey(), germplasm.getAccessionNumber()));
-            if(germplasm.getAdditionalInfo() != null && germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_RAW_PEDIGREE)
-                    && !(germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_RAW_PEDIGREE).isJsonNull())) {
-                germplasm.setPedigree(germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_RAW_PEDIGREE).getAsString());
+            if(germplasm.getAdditionalInfo() != null && germplasm.getAdditionalInfo().has(GERMPLASM_RAW_PEDIGREE)
+                    && !(germplasm.getAdditionalInfo().get(GERMPLASM_RAW_PEDIGREE).isJsonNull())) {
+                germplasm.setPedigree(germplasm.getAdditionalInfo().get(GERMPLASM_RAW_PEDIGREE).getAsString());
             }
 
             return germplasm;
@@ -161,8 +161,8 @@ public class BrAPIGermplasmDAO {
         for (BrAPIGermplasm germplasm: programGermplasm) {
 
             JsonObject additionalInfo = germplasm.getAdditionalInfo();
-            if (additionalInfo != null && additionalInfo.has(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD_ID)) {
-                germplasm.setBreedingMethodDbId(additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD_ID).getAsString());
+            if (additionalInfo != null && additionalInfo.has(GERMPLASM_BREEDING_METHOD_ID)) {
+                germplasm.setBreedingMethodDbId(additionalInfo.get(GERMPLASM_BREEDING_METHOD_ID).getAsString());
             }
 
             if (germplasm.getDefaultDisplayName() != null) {
@@ -188,7 +188,7 @@ public class BrAPIGermplasmDAO {
 
                 // TODO: BI-1883 to cleanup this workaround for the pedigree string
                 String pedigree = processBreedbasePedigree(germplasm.getPedigree());
-                additionalInfo.addProperty(BrAPIAdditionalInfoFields.GERMPLASM_RAW_PEDIGREE, pedigree);
+                additionalInfo.addProperty(GERMPLASM_RAW_PEDIGREE, pedigree);
 
                 String gidPedigreeString = "";
                 String namePedigreeString = "";
@@ -214,34 +214,34 @@ public class BrAPIGermplasmDAO {
             // Update pedigree info for female parent.
             if (parentNames.size() >= 1 && !parentNames.get(0).isEmpty())
             {
-                gidPedigreeString = additionalInfo.has(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID) ? additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID).getAsString() : "";
+                gidPedigreeString = additionalInfo.has(GERMPLASM_FEMALE_PARENT_GID) ? additionalInfo.get(GERMPLASM_FEMALE_PARENT_GID).getAsString() : "";
                 namePedigreeString = parentNames.get(0);
-                uuidPedigreeString = additionalInfo.has(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_UUID) ? additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_UUID).getAsString() : "";
+                uuidPedigreeString = additionalInfo.has(GERMPLASM_FEMALE_PARENT_UUID) ? additionalInfo.get(GERMPLASM_FEMALE_PARENT_UUID).getAsString() : "";
                 // Throw a descriptive error if femaleParentUUID is absent.
-                if (!additionalInfo.has(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_UUID)) {
+                if (!additionalInfo.has(GERMPLASM_FEMALE_PARENT_UUID)) {
                     log.debug("The germplasm data in your backing BrAPI service needs to be updated: https://github.com/Breeding-Insight/bi-api/pull/290");
                     throw new InternalServerException("Germplasm (" + germplasm.getGermplasmName() + ") has a female parent but femaleParentUUID is missing (Pedigree: " + germplasm.getPedigree() + ").");
                 }
-            } else if (additionalInfo.has(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN) && additionalInfo.get(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN).getAsBoolean()) {
+            } else if (additionalInfo.has(FEMALE_PARENT_UNKNOWN) && additionalInfo.get(FEMALE_PARENT_UNKNOWN).getAsBoolean()) {
                 namePedigreeString = "Unknown";
             }
             // Update pedigree info for male parent.
             if (parentNames.size() == 2 && !parentNames.get(1).isEmpty())
             {
-                gidPedigreeString += "/" + (additionalInfo.has(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID) ? additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID).getAsString() : "");
+                gidPedigreeString += "/" + (additionalInfo.has(GERMPLASM_MALE_PARENT_GID) ? additionalInfo.get(GERMPLASM_MALE_PARENT_GID).getAsString() : "");
                 namePedigreeString += "/" + parentNames.get(1);
-                uuidPedigreeString += "/" + (additionalInfo.has(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_UUID) ? additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_UUID).getAsString() : "");
+                uuidPedigreeString += "/" + (additionalInfo.has(GERMPLASM_MALE_PARENT_UUID) ? additionalInfo.get(GERMPLASM_MALE_PARENT_UUID).getAsString() : "");
                 // Throw a descriptive error if maleParentUUID is absent.
-                if (!additionalInfo.has(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_UUID)) {
+                if (!additionalInfo.has(GERMPLASM_MALE_PARENT_UUID)) {
                     log.debug("The germplasm data in your backing BrAPI service needs to be updated: https://github.com/Breeding-Insight/bi-api/pull/290");
                     throw new InternalServerException("Germplasm (" + germplasm.getGermplasmName() + ") has a male parent but maleParentUUID is missing (Pedigree: " + germplasm.getPedigree() + ").");
                 }
-            } else if (additionalInfo.has(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN) && additionalInfo.get(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN).getAsBoolean()) {
+            } else if (additionalInfo.has(MALE_PARENT_UNKNOWN) && additionalInfo.get(MALE_PARENT_UNKNOWN).getAsBoolean()) {
                 namePedigreeString += "/Unknown";
             }
             //For use in individual germplasm display
-            additionalInfo.addProperty(BrAPIAdditionalInfoFields.GERMPLASM_PEDIGREE_BY_NAME, namePedigreeString);
-            additionalInfo.addProperty(BrAPIAdditionalInfoFields.GERMPLASM_PEDIGREE_BY_UUID, uuidPedigreeString);
+            additionalInfo.addProperty(GERMPLASM_PEDIGREE_BY_NAME, namePedigreeString);
+            additionalInfo.addProperty(GERMPLASM_PEDIGREE_BY_UUID, uuidPedigreeString);
 
                 germplasm.setPedigree(gidPedigreeString);
 

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -305,8 +305,8 @@ public class BrAPIGermplasmDAO {
         try {
             if (!putBrAPIGermplasmList.isEmpty()) {
                 postFunction = () -> {
-                    putGermplasm(putBrAPIGermplasmList, api);
-                    return processGermplasmForDisplay(putBrAPIGermplasmList, program.getKey());
+                    List<BrAPIGermplasm> putResponse = putGermplasm(putBrAPIGermplasmList, api);
+                    return processGermplasmForDisplay(putResponse, program.getKey());
                 };
             }
             return programGermplasmCache.post(programId, postFunction);

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -216,6 +216,8 @@ public class BrAPIGermplasmDAO {
                     // Throw a descriptive error if femaleParentUUID is absent.
                     if (!additionalInfo.has(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_UUID)) {
                         // TODO: link to BI-1881.
+                        log.debug("Germplasm: " + germplasm.getGermplasmName());
+                        log.debug("Germplasm Pedigree: " + germplasm.getPedigree());
                         throw new InternalServerException("Germplasm has a female parent but femaleParentUUID is missing.");
                     }
                 } else if (additionalInfo.has(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN) && additionalInfo.get(BrAPIAdditionalInfoFields.FEMALE_PARENT_UNKNOWN).getAsBoolean()) {
@@ -230,6 +232,8 @@ public class BrAPIGermplasmDAO {
                     // Throw a descriptive error if maleParentUUID is absent.
                     if (!additionalInfo.has(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_UUID)) {
                         // TODO: link to BI-1881.
+                        log.debug("Germplasm: " + germplasm.getGermplasmName());
+                        log.debug("Germplasm Pedigree: " + germplasm.getPedigree());
                         throw new InternalServerException("Germplasm has a male parent but maleParentUUID is missing.");
                     }
                 } else if (additionalInfo.has(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN) && additionalInfo.get(BrAPIAdditionalInfoFields.MALE_PARENT_UNKNOWN).getAsBoolean()) {

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -306,9 +306,7 @@ public class BrAPIGermplasmDAO {
             if (!putBrAPIGermplasmList.isEmpty()) {
                 postFunction = () -> {
                     putGermplasm(putBrAPIGermplasmList, api);
-                    // Need all program germplasm for processGermplasmForDisplay parents pedigree
-                    List<BrAPIGermplasm> germplasm = getRawGermplasm(programId);
-                    return processGermplasmForDisplay(germplasm, program.getKey());
+                    return processGermplasmForDisplay(putBrAPIGermplasmList, program.getKey());
                 };
             }
             return programGermplasmCache.post(programId, postFunction);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -24,6 +24,7 @@ import io.micronaut.http.server.exceptions.InternalServerException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPIListSummary;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
@@ -45,6 +46,7 @@ import org.breedinginsight.daos.BreedingMethodDAO;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
 import org.breedinginsight.services.exceptions.ValidatorException;
+import org.breedinginsight.utilities.Utilities;
 import org.jooq.DSLContext;
 import tech.tablesaw.api.Table;
 
@@ -717,11 +719,20 @@ public class GermplasmProcessor implements Processor {
                 if (commit) {
                     if (femaleParentFound) {
                         brAPIGermplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_GID, femaleParent.getAccessionNumber());
+                        // Add femaleParentUUID to additionalInfo.
+                        Optional<BrAPIExternalReference> femaleParentUUID = Utilities.getExternalReference(femaleParent.getExternalReferences(), BRAPI_REFERENCE_SOURCE);
+                        if (femaleParentUUID.isPresent()) {
+                            brAPIGermplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_FEMALE_PARENT_UUID, femaleParentUUID.get().getReferenceID());
+                        }
                     }
 
                     if (maleParent != null) {
                         brAPIGermplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID, maleParent.getAccessionNumber());
-                    }
+                        // Add maleParentUUID to additionalInfo.
+                        Optional<BrAPIExternalReference> maleParentUUID = Utilities.getExternalReference(maleParent.getExternalReferences(), BRAPI_REFERENCE_SOURCE);
+                        if (maleParentUUID.isPresent()) {
+                            brAPIGermplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_UUID, maleParentUUID.get().getReferenceID());
+                        }                    }
                 }
             }
         }

--- a/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
@@ -36,6 +36,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
@@ -92,6 +93,7 @@ public class BrAPIGermplasmServiceUnitTest extends DatabaseTest {
         listResponse.setResult(listDetails);
 
         //Create Germplasm
+        String parentUuid = UUID.randomUUID().toString();
         List<BrAPIGermplasm> germplasm = new ArrayList();
         BrAPIGermplasm testGermplasm = new BrAPIGermplasm();
         testGermplasm.setGermplasmName("Germplasm A [TEST-1]");
@@ -99,13 +101,13 @@ public class BrAPIGermplasmServiceUnitTest extends DatabaseTest {
         testGermplasm.setAccessionNumber("1");
         testGermplasm.setDefaultDisplayName("Germplasm A");
         JsonObject additionalInfo = new JsonObject();
-        additionalInfo.addProperty("importEntryNumber", "2");
-        additionalInfo.addProperty("breedingMethod", "Allopolyploid");
+        additionalInfo.addProperty(GERMPLASM_IMPORT_ENTRY_NUMBER, "2");
+        additionalInfo.addProperty(GERMPLASM_BREEDING_METHOD, "Allopolyploid");
         testGermplasm.setAdditionalInfo(additionalInfo);
         List<BrAPIExternalReference> externalRef = new ArrayList<>();
         BrAPIExternalReference testReference = new BrAPIExternalReference();
         testReference.setReferenceSource(referenceSource);
-        testReference.setReferenceID(UUID.randomUUID().toString());
+        testReference.setReferenceID(parentUuid);
         externalRef.add(testReference);
         testGermplasm.setExternalReferences(externalRef);
         germplasm.add(testGermplasm);
@@ -117,8 +119,9 @@ public class BrAPIGermplasmServiceUnitTest extends DatabaseTest {
         testGermplasm.setDefaultDisplayName("Germplasm B");
         testGermplasm.setPedigree("Germplasm A [TEST-1]");
         additionalInfo = new JsonObject();
-        additionalInfo.addProperty("importEntryNumber", "3");
-        additionalInfo.addProperty("breedingMethod", "Autopolyploid");
+        additionalInfo.addProperty(GERMPLASM_IMPORT_ENTRY_NUMBER, "3");
+        additionalInfo.addProperty(GERMPLASM_BREEDING_METHOD, "Autopolyploid");
+        additionalInfo.addProperty(GERMPLASM_FEMALE_PARENT_UUID, parentUuid);
         testGermplasm.setAdditionalInfo(additionalInfo);
         testReference = new BrAPIExternalReference();
         testReference.setReferenceSource(referenceSource);


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1881

Previously, `BrAPIGermplasmDAO::processGermplasmForDisplay` required parent `BrAPIGermplasm` objects to be available in order to add the `pedigreeByUUID` and `pedigreeByName` keys to `additionalInfo` on each `BrAPIGermplasm`. This required some hacks, [passing all germplasm in the program for example](https://github.com/Breeding-Insight/bi-api/blob/09ccfd5fa20dd199d7b00cd8f45516e3d2fa0b14/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java#L295).

To make the code more efficient and avoid having to pass all program germplasm into `processGermplasmForDisplay`, I made changes to
- store male/female parent UUIDs on each `BrAPIGermplasm` in `additionalInfo` on create,
- read the parent UUIDs in `processGermplasmForDisplay` to build the required pedigree string ("<femaleParentUUID>/<maleParentUUID>"),
- wrote a SQL script to update Germplasm records in BreedBase to store the parental UUIDs in `additionalInfo`, that's in [this PR on breedbase_configs](https://github.com/Breeding-Insight/breedbase_configs/pull/32).

>Note: because the BrAPI Java TestServer (BJTS) stores additional info as byte arrays of serialized Java objects, it was deemed impractical to make the change in SQL. For the 1 program using the BJTS in production, there are no germplasm records so there is no data to be upgraded. The non-production BJTS instances will be wiped out, it's on [the v0.8.1 deploy checklist](https://breedinginsight.atlassian.net/l/cp/9KQLE3Np).


# Dependencies
If you checkout this branch and run it against BJTS or BreedBase with existing germplasm records, it will break. In the case of BJTS, the only option currently is to wipe out the database. For BreedBase, germplasm records can be upgraded in place by running `breedbase-deploy.sh` from the `bug/BI-1881-mlm483` branch. [See this PR for details](https://github.com/Breeding-Insight/breedbase_configs/pull/32).

# Testing

Steps 1-10 focus on BreedBase, step 11 is for BJTS.

<details>
<summary><strong>germplasm_with_additional_info</strong> (click to expand)</summary>

```sql
-- Germplasm with additional info.
SELECT 
    germ.stock_id, germ.uniquename AS "stock.uniquename", cvterm.name AS "cvterm.name", stockprop.stockprop_id, stockprop.value, stockprop.rank
FROM 
    public.stock germ
    LEFT JOIN public.stockprop ON stockprop.stock_id = germ.stock_id
    LEFT JOIN cvterm ON cvterm.cvterm_id = stockprop.type_id
WHERE 
    germ.stock_id IN
    (
        SELECT
            stock.stock_id
        FROM 
            stock
            JOIN
            cvterm cvt ON cvt.cvterm_id = stock.type_id AND cvt.name::text = 'accession'::text
    )
    AND cvterm.name = 'stock_additional_info'
    -- Uncomment if you only want to see germplasm from the attached file.
    -- AND germ.uniquename LIKE '1881-%'
ORDER BY germ.uniquename, cvterm.name, stockprop.rank
```

</details>

1. Checkout the `develop` branch for both `bi-api` and `breedbase_configs`.
2. Wipe out BJTS and BreedBase (optional, but makes testing cleaner). I like to delete all local containers and volumes.
3. Start up BreedBase (with `breedbase_deploy.sh`) and start up all the services needed for DeltaBreed, then run `bi-api` and `bi-web`.
4. Create a new program stored in BreedBase and upload germplasm with various pedigree permutations (example file attached).
5. Check the additionalInfo doesn't contain "maleParentUUID" or "femaleParentUUID" fields with the germplasm_with_additional_info SQL query above. If those keys are present, you are probably running the `bug/BI-1881-mlm483` branch of `bi-api`. Oops, start over!
6. Stop `bi-api` and checkout `bug/BI-1881-mlm483`. If you restart before performing the next step, you'll see some exceptions saying "Germplasm has a female parent but femaleParentUUID is missing.".
7. Checkout the `bug/BI-1881-mlm483` branch of `breedbase_configs` and run `breedbase_deploy.sh` (without the `--reinstall` flag). The flyway docker container will be pulled, start up, wait for the breedbase_db container to be healthy and then run the migrations in the ./flyway/sql directory.
8. You can confirm that the data has been updated with the germplasm_with_additional_info SQL above.
9. Start `bi-api` and ensure it runs without the exception and germplasm list, detail and pedigree views work as expected.
10. Upload more germplasm, and use steps 8. and 9. to ensure the running code stores new germplasm with the parental UUIDs correctly.
11. Create a program in the BJTS and upload germplasm and ensure the upload and list, detail and pedigree views work as expected. You can use the `brapi/v2/germplasm` endpoint as well to see that the "femaleParentUUID" and/or "maleParentUUID" fields are present in `additionalInfo`.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/6253277974
