### PR TITLE
BI-1909 - Unable to open observation dataset. 

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -92,7 +92,9 @@ public class BrAPITrialService {
             //Remove the [program key] from the trial name
             trial.setTrialName( Utilities.removeUnknownProgramKey( trial.getTrialName()) );
             if( stats ){
+                log.debug("fetching experiment: " + trialId + " stats");
                 int environmentsCount = 1; // For now this is hardcoded to 1, because we are only supporting one environment per experiment
+                log.debug("fetching observation units for experiment: " + trialId);
                 long germplasmCount = countGermplasm(programId, trial.getTrialDbId());
                 trial.putAdditionalInfoItem("environmentsCount", environmentsCount);
                 trial.putAdditionalInfoItem("germplasmCount", germplasmCount);
@@ -296,11 +298,16 @@ public class BrAPITrialService {
     }
 
     public Dataset getDatasetData(Program program, UUID experimentId, UUID datsetId, Boolean stats) throws ApiException, DoesNotExistException {
+        log.debug("fetching dataset: " + datsetId + " for experiment: " + experimentId + ".  including stats: " + stats);
+        log.debug("fetching observationUnits for dataset: " + datsetId);
         List<BrAPIObservationUnit> datasetOUs = ouDAO.getObservationUnitsForDataset(datsetId.toString(), program);
+        log.debug("fetching dataset variables dataset: " + datsetId);
         List<BrAPIObservationVariable> datasetObsVars = getDatasetObsVars(datsetId.toString(), program);
         List<String> ouDbIds = datasetOUs.stream().map(BrAPIObservationUnit::getObservationUnitDbId).collect(Collectors.toList());
         List<String> obsVarDbIds = datasetObsVars.stream().map(BrAPIObservationVariable::getObservationVariableDbId).collect(Collectors.toList());
+        log.debug("fetching observations for dataset: " + datsetId);
         List<BrAPIObservation> data = observationDAO.getObservationsByObservationUnitsAndVariables(ouDbIds, obsVarDbIds, program);
+        log.debug("building dataset object for dataset: " + datsetId);
         Dataset dataset = new Dataset(experimentId.toString(), data, datasetOUs, datasetObsVars);
         if (stats) {
             Integer ouCount = datasetOUs.size();

--- a/src/test/java/org/breedinginsight/DatabaseTest.java
+++ b/src/test/java/org/breedinginsight/DatabaseTest.java
@@ -56,7 +56,6 @@ public class DatabaseTest implements TestPropertyProvider {
     @Getter
     private RedissonClient redisConnection;
 
-//    @SneakyThrows
     public DatabaseTest() {
         if(network == null) {
             network = Network.newNetwork();
@@ -119,7 +118,7 @@ public class DatabaseTest implements TestPropertyProvider {
 
     @SneakyThrows
     @AfterAll
-    public void stopContainers() {
+    public void resetContainers() {
         if(redisContainer != null) {
             redisConnection.getKeys()
                            .flushall();

--- a/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
@@ -1104,7 +1104,9 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         assertEquals(trait.getScale().getDataType().toString(), scaleJson.get("dataType").getAsString(), "Scale data types don't match");
 
         List<JsonObject> jsonCategories = new ArrayList<>();
-        scaleJson.get("categories").getAsJsonArray().iterator().forEachRemaining(element -> jsonCategories.add(element.getAsJsonObject()));
+        if(scaleJson.has("categories")) {
+            scaleJson.get("categories").getAsJsonArray().iterator().forEachRemaining(element -> jsonCategories.add(element.getAsJsonObject()));
+        }
         Collections.sort(jsonCategories, Comparator.comparing((x) -> x.get("label").getAsString()));
         List<BrAPIScaleValidValuesCategories> brApiScaleCategories = new ArrayList<>(trait.getScale().getCategories());
         Collections.sort(brApiScaleCategories, Comparator.comparing(BrAPIScaleValidValuesCategories::getLabel));


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1909

- Updated a unit test to check to prevent an NPE
- Updated unit tests so that the database and redis containers live between test suites
- Added some logging messages for fetching datasets



# Dependencies
brapi-java-testserver/bug/BI-1909

# Testing
Regression testing:
- experiment upload
- experiment view
- germplasm upload
- germplasm view


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
