### PR TITLE
BI-1340 - Allow system admin, memeber roles to fully read Ontology 

### DIFF
--- a/src/main/java/org/breedinginsight/api/v1/controller/OntologyController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/OntologyController.java
@@ -4,6 +4,8 @@ import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.*;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.rules.SecurityRule;
 import lombok.extern.slf4j.Slf4j;
 import org.breedinginsight.api.auth.ProgramSecured;
 import org.breedinginsight.api.auth.ProgramSecuredRole;
@@ -81,7 +83,7 @@ public class OntologyController {
     }
 
     /**
-     * Accepts a list of programs to shared the ontology with.
+     * Accepts a list of programs to share the ontology with.
      * @param programId
      * @return List of programs successfully shared to with acceptable status
      * {
@@ -210,7 +212,7 @@ public class OntologyController {
     @Get("/programs/{programId}/ontology/subscribe")
     @Produces(MediaType.APPLICATION_JSON)
     @AddMetadata
-    @ProgramSecured(roles = {ProgramSecuredRole.BREEDER})
+    @Secured(SecurityRule.IS_AUTHENTICATED)
     public HttpResponse<Response<DataResponse<SubscribedOntology>>> getSubscribedOntology(
             @PathVariable UUID programId) {
         try {


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1340

> Previously, a user logged in as a system admin or a member of a breeding program could not see the sharing status on the Ontology list view (see Jira comments for more background). 
- Updated `getSubscribedOntology` (GET) endpoint authorization to allow read access to any authenticated user.

# Dependencies
None

# Testing
1. Upload Ontology to program A.
2. [Regression Test] Go to the program A Ontology list view as (1) system admin, (2) breeder, (3) member and ensure only the breeder role can edit Ontology Terms (expand a Term's detail view to try to edit).
3. Share program A's Ontology Terms with program B.
4. Accept the shared Ontology Terms in program B.
5. Go to the program B Ontology list view as (1) system admin, (2) breeder, (3) member and ensure "This Ontology is shared from A" message is visible above the table. 


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/6313682866
