### PR TITLE
BI-1932 - GIDs missing from Exp & Obs dataset

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIObservationUnitDAO.java
@@ -152,10 +152,7 @@ public class BrAPIObservationUnitDAO {
         ouSearchRequest.programDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
         ouSearchRequest.externalReferenceSources(List.of(datasetReferenceSource));
         ouSearchRequest.externalReferenceIDs(List.of(datasetId));
-        ObservationUnitsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), ObservationUnitsApi.class);
-        return brAPIDAOUtil.search(api::searchObservationunitsPost,
-                api::searchObservationunitsSearchResultsDbIdGet,
-                ouSearchRequest);
+        return searchObservationUnitsAndProcess(ouSearchRequest, program.getId(), true);
     }
 
     public List<BrAPIObservationUnit> getObservationUnitsForTrialDbId(@NotNull UUID programId, @NotNull String trialDbId, boolean withGID) throws ApiException, DoesNotExistException {


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1932

When dataset OUs the code was not fetching the GIDs.  Updated the `getObservationUnitsForDataset` method to fetch GIDs.

# Dependencies
none

# Testing
1. Import an experiment
2. Navigate to the experiment details page
3. Ensure that the GID column is populated for each row


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [ ] I have run TAF: 
