### PR TITLE
BI-1900 - Exp error message improvement: unrecognized column header

### DIFF
--- a/src/main/java/org/breedinginsight/utilities/FileUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/FileUtil.java
@@ -18,6 +18,9 @@
 package org.breedinginsight.utilities;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.io.input.BOMInputStream;
 import org.apache.poi.EncryptedDocumentException;
 import org.apache.poi.ss.usermodel.*;
 import org.breedinginsight.services.parsers.ParsingException;
@@ -31,6 +34,7 @@ import tech.tablesaw.io.json.JsonReadOptions;
 
 import java.io.*;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 
@@ -70,7 +74,14 @@ public class FileUtil {
         try {
             columns = new HashMap<>();
             headerRow = sheet.getRow(headerRowIndex);
-            headerRow.forEach(cell -> columns.put(formatter.formatCellValue(cell), new ArrayList<>()));
+            // Throw an exception if duplicate header values are found.
+            for (Cell cell: headerRow) {
+                if (columns.containsKey(formatter.formatCellValue(cell))) {
+                    // Duplicate column header.
+                    throw new ParsingException(ParsingExceptionType.DUPLICATE_COLUMN_NAMES);
+                }
+                columns.put(formatter.formatCellValue(cell), new ArrayList<>());
+            }
             for (int i = headerRowIndex + 1; i <= sheet.getLastRowNum(); i++) {
                 Row row = sheet.getRow(i);
                 Iterator<Cell> cellIterator = row.cellIterator();
@@ -94,7 +105,12 @@ public class FileUtil {
                     }
                 }
             }
-        } catch (Exception e) {
+        }
+        catch (ParsingException e) {
+            log.error(e.toString());
+            throw e;
+        }
+        catch (Exception e) {
             log.error(e.toString());
             throw new ParsingException(ParsingExceptionType.ERROR_READING_FILE);
         }
@@ -131,6 +147,17 @@ public class FileUtil {
     public static Table parseTableFromCsv(InputStream inputStream) throws ParsingException {
         //TODO: See if this has the windows BOM issue
         try {
+            Reader reader = new InputStreamReader(new BOMInputStream(inputStream), StandardCharsets.UTF_8);
+            CSVParser parser = new CSVParser(reader, CSVFormat.EXCEL);
+            HashSet<String> columnNames = new HashSet<>();
+            for (String columnName: parser.getRecords().get(0)) {
+                log.debug(columnName);
+                if (columnNames.contains(columnName)) {
+                    log.debug("Duplicate column header name: " + columnName);
+                    throw new ParsingException(ParsingExceptionType.DUPLICATE_COLUMN_NAMES);
+                }
+                columnNames.add(columnName);
+            }
             //Jackson used downstream messily converts LOCAL_DATE/LOCAL_DATETIME, so need to interpret date input as strings
             //Note that if another type is needed later this is what needs to be updated
             ArrayList<ColumnType> acceptedTypes = new ArrayList<>(Arrays.asList(ColumnType.STRING, ColumnType.INTEGER, ColumnType.DOUBLE, ColumnType.FLOAT));
@@ -141,7 +168,7 @@ public class FileUtil {
                             .separator(',')
             );
             return removeNullColumns(removeNullRows(df));
-        } catch (IOException e) {
+        } catch (Exception e) {
             log.error(e.getMessage());
             throw new ParsingException(ParsingExceptionType.ERROR_READING_FILE);
         }

--- a/src/main/java/org/breedinginsight/utilities/FileUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/FileUtil.java
@@ -74,10 +74,10 @@ public class FileUtil {
         try {
             columns = new HashMap<>();
             headerRow = sheet.getRow(headerRowIndex);
-            // Throw an exception if duplicate header values are found.
+            // Build column map, throw if duplicate (non-blank) column header values are found.
             for (Cell cell: headerRow) {
-                if (columns.containsKey(formatter.formatCellValue(cell))) {
-                    // Duplicate column header.
+                if (columns.containsKey(formatter.formatCellValue(cell)) && !formatter.formatCellValue(cell).isBlank()) {
+                    // Duplicate (non-blank) column header.
                     throw new ParsingException(ParsingExceptionType.DUPLICATE_COLUMN_NAMES);
                 }
                 columns.put(formatter.formatCellValue(cell), new ArrayList<>());
@@ -148,7 +148,7 @@ public class FileUtil {
         //TODO: See if this has the windows BOM issue
         try {
             // Read inputStream into a String.
-            String input = new String(inputStream.readAllBytes());
+            String input = new String(new BOMInputStream(inputStream).readAllBytes());
 
             // Check for duplicate (non-blank) column names, could also do other validations.
             try (CSVParser parser = CSVParser.parse(input, CSVFormat.EXCEL);) {

--- a/src/main/java/org/breedinginsight/utilities/FileUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/FileUtil.java
@@ -147,8 +147,8 @@ public class FileUtil {
     public static Table parseTableFromCsv(InputStream inputStream) throws ParsingException {
         //TODO: See if this has the windows BOM issue
         try {
-            // Read inputStream into a String.
-            String input = new String(new BOMInputStream(inputStream).readAllBytes());
+            // Read inputStream into a String, exclude any Byte Order Marks.
+            String input = new String(new BOMInputStream(inputStream, false).readAllBytes());
 
             // Check for duplicate (non-blank) column names, could also do other validations.
             try (CSVParser parser = CSVParser.parse(input, CSVFormat.EXCEL);) {

--- a/src/main/java/org/breedinginsight/utilities/FileUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/FileUtil.java
@@ -77,7 +77,7 @@ public class FileUtil {
             // Build column map, throw if duplicate (non-blank) column header values are found.
             for (Cell cell: headerRow) {
                 if (columns.containsKey(formatter.formatCellValue(cell)) && !formatter.formatCellValue(cell).isBlank()) {
-                    // Duplicate (non-blank) column header.
+                    // Duplicate (non-blank) column header found.
                     throw new ParsingException(ParsingExceptionType.DUPLICATE_COLUMN_NAMES);
                 }
                 columns.put(formatter.formatCellValue(cell), new ArrayList<>());
@@ -145,7 +145,6 @@ public class FileUtil {
     }
 
     public static Table parseTableFromCsv(InputStream inputStream) throws ParsingException {
-        //TODO: See if this has the windows BOM issue
         try {
             // Read inputStream into a String, exclude any Byte Order Marks.
             String input = new String(new BOMInputStream(inputStream, false).readAllBytes());


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1900

We parse Excel and CSV files into tablesaw `Table`s. For Excel files, we use Apache POI to parse, do some validation, and then build a `Table`. For CSV files, we were using tablesaw to read the CSV into a `Table` directly. While tablesaw does return descriptive error messages, it doesn't give us as fine-grained control over parsing and exception handling as we want. To solve this, I made changes to `FileUtil::parseTableFromCsv` to
- read the `InputStream` into a `String`, 
- parse the string with `apache.commons.CSVParser` and do validation, which enables us to return descriptive error messages *that we control* to the user, and
- finally build a `Table` from the `String`.

# Testing
> Note: this only applies to Germplasm and Experiment & Observation uploads, Ontology uses a different code path (for now).
#### New feature:
Try uploading Excel and CSV files with duplicate column names, make sure the error message shown to the user is descriptive.
#### Regression
Try uploading Excel and CSV files with required column names missing, any other data issues you can think of, and make sure the error message shown to the user is descriptive.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/6422962193
