### PR TITLE
BI-1947 - fix non-deterministic test

### DIFF
--- a/src/test/java/org/breedinginsight/utilities/response/ResponseUtilsIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/utilities/response/ResponseUtilsIntegrationTest.java
@@ -108,10 +108,11 @@ public class ResponseUtilsIntegrationTest extends BrAPITest {
                                                .slope(new BigDecimal("1.1"))
                                                .build());
         for(int i = 2; i < 25; i++) {
+            // Ensure random slope values don't overlap with hardcoded value by adding 2 to the unsigned magnitude.
             newLocations.add(ProgramLocationRequest.builder()
                                                       .name("place"+i)
                                                       .abbreviation("abbrev"+i)
-                    .slope(new BigDecimal(((Math.random()*10)%2 == 0 ? "" : "-")+Math.random()*20.0))
+                    .slope(new BigDecimal(((Math.random()*10)%2 == 0 ? "" : "-")+(Math.random()*20.0 + 2.0)))
                                                       .build());
         }
         for(int i = 25; i < 31; i++) {

--- a/src/test/java/org/breedinginsight/utilities/response/ResponseUtilsIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/utilities/response/ResponseUtilsIntegrationTest.java
@@ -112,7 +112,7 @@ public class ResponseUtilsIntegrationTest extends BrAPITest {
             newLocations.add(ProgramLocationRequest.builder()
                                                       .name("place"+i)
                                                       .abbreviation("abbrev"+i)
-                    .slope(new BigDecimal(((Math.random()*10)%2 == 0 ? "" : "-")+(Math.random()*20.0 + 2.0)))
+                    .slope(new BigDecimal((Math.random() > 0.5 ? "" : "-")+(Math.random() + 2.0)))
                                                       .build());
         }
         for(int i = 25; i < 31; i++) {

--- a/src/test/java/org/breedinginsight/utilities/response/ResponseUtilsIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/utilities/response/ResponseUtilsIntegrationTest.java
@@ -112,7 +112,7 @@ public class ResponseUtilsIntegrationTest extends BrAPITest {
             newLocations.add(ProgramLocationRequest.builder()
                                                       .name("place"+i)
                                                       .abbreviation("abbrev"+i)
-                    .slope(new BigDecimal((Math.random() > 0.5 ? "" : "-")+(Math.random() + 2.0)))
+                    .slope(new BigDecimal((Math.random() > 0.5 ? "" : "-")+Math.random()))
                                                       .build());
         }
         for(int i = 25; i < 31; i++) {


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1943

The `ResponseUtilsIntegrationTest::postMultipleSearchSuccess` fails sporadically because the randomly seeded data could occasionally result in 2 records being returned from the search query instead of the expected 1.

The hardcoded value that is searched for is slope=1.1, so I changed the code to ensure that the randomly created slope values will never be 1.1 (`Math.random()` produces a number in the range [0,1)).

# Testing
Run the `ResponseUtilsIntegrationTest` suite.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
