### PR TITLE
[BI-1930] trait names are case sensitive

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
@@ -18,6 +18,7 @@
 package org.breedinginsight.brapps.importer.services;
 
 import io.reactivex.functions.Function;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.breedinginsight.brapps.importer.model.config.MappedImportRelation;
@@ -76,7 +77,7 @@ public class FileMappingUtil {
     }
 
     public <T> List<T> sortByField(List<String> sortedFields, List<T> unsortedItems, Function<T, String> fieldGetter) {
-        HashMap<String, Integer> sortOrder = new HashMap<>();
+        CaseInsensitiveMap<String, Integer> sortOrder = new CaseInsensitiveMap<>();
         for (int i = 0; i < sortedFields.size(); i++) {
             sortOrder.put(sortedFields.get(i), i);
         }


### PR DESCRIPTION
[BI-1930](https://breedinginsight.atlassian.net/browse/BI-1930) - trait names are case sensitive

# Description

When importing an experiment in the current system, the observation-variable must match an ontology in a case-sensitive way.  If not it will fail validation.  The purpose of this story is to allow the matching between the observation-variable and the ontology to be case-insensitive, while still allowing the observation-variable and the observation data to be saved correctly.  

# Dependencies
bi-web: develop branch

# Testing
WHEN An experiment is imported with observations.  
AND At least one observation-variable (i.e. the observation column header) differs from an ontology by case (for example: if the ontology is "Color" the observation-variable could be "cOLoR").  
**THEN The experiment should pass validation.**

WHEN Viewing the experiment summary.
**THEN the observation-variable should be displayed with the same cases as the ontology (in the above example: "Color")**


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [X] I have run TAF: _\<please include a link to TAF run>_


[BI-1930]: https://breedinginsight.atlassian.net/browse/BI-1930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ