### PR TITLE
BI-1914 - Improve exp dataset sort

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -229,7 +229,7 @@ public class BrAPITrialService {
                 // Initialize key with empty list if it is not present.
                 if (!rowsByStudyId.containsKey(studyId))
                 {
-                    rowsByStudyId.put(studyId, new ArrayList<Map<String, Object>>());
+                    rowsByStudyId.put(studyId, new ArrayList<>());
                 }
                 // Add row to appropriate list in rowsByStudyId.
                 rowsByStudyId.get(studyId).add(row);
@@ -240,8 +240,7 @@ public class BrAPITrialService {
 
                 List<Map<String, Object>> rows = entry.getValue();
                 sortExportRows(rows);
-                //TODO the sheetName should be "Data".  It should no longer be "Experiment Data"
-                StreamedFile streamedFile = writeToStreamedFile(columns, rows, fileType, "Experiment Data");
+                StreamedFile streamedFile = writeToStreamedFile(columns, rows, fileType, "Data");
                 String name = makeFileName(experiment, program, studyByDbId.get(entry.getKey()).getStudyName()) + fileType.getExtension();
                 // Add to file list.
                 files.add(new DownloadFile(name, streamedFile));
@@ -260,8 +259,7 @@ public class BrAPITrialService {
             List<Map<String, Object>> exportRows = new ArrayList<>(rowByOUId.values());
             sortExportRows(exportRows);
             // write export data to requested file format
-            //TODO the sheetName should be "Data".  It should no longer be "Experiment Data"
-            StreamedFile streamedFile = writeToStreamedFile(columns, exportRows, fileType, "Experiment Data");
+            StreamedFile streamedFile = writeToStreamedFile(columns, exportRows, fileType, "Data");
             // Set filename.
             String envFilenameFragment = params.getEnvironments() == null ? "All Environments" : params.getEnvironments();
             String fileName = makeFileName(experiment, program, envFilenameFragment) + fileType.getExtension();


### PR DESCRIPTION
# Description
[BI-1914](https://breedinginsight.atlassian.net/browse/BI-1914) - Improve exp dataset sort

Added two methods to sort the dataset:
- `sortDefaultForObservationUnit()` - called by _getDatasetData()_ to sort the datset as displayed on the Experiment detail page.
- `sortDefaultForExportRows()` - called by _exportObservations()_ to sort the dataset for the Experiment download.

ALSO
The sheet-name of an downloaded Excel experiment is now "Data" instead of "Experiment Data" see [BI-1583](https://breedinginsight.atlassian.net/browse/BI-1583)


# Dependencies
bi-web:  feature/BI-1914 branch

# Testing
- go to the Experiment detail page
- **the default order should be by `Env` and then `Exp Unit Id`**

- Download an experiment
- **the order of the downloaded file(s) should be by `Env` and then `Exp Unit Id`**


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
