### PR TITLE
BI-1911 fix QA findings

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
@@ -47,4 +47,5 @@ public final class BrAPIAdditionalInfoFields {
     public static final String MALE_PARENT_UNKNOWN = "maleParentUnknown";
 	public static final String TREATMENTS = "treatments";
     public static final String GID = "gid";
+    public static final String ENV_YEAR = "envYear";
 }


### PR DESCRIPTION
# D# Description
[BI-1911](https://breedinginsight.atlassian.net/browse/BI-1911) - in response to Shahana's [testing notes.](https://breedinginsight.atlassian.net/browse/BI-1911?focusedCommentId=14057)


# Dependencies
bi-api: bug/BI-1911-2 branch

# Testing
- Import an Experiment.
- Look at the confirmation page.

**Expected Results**
- The `Env Year`, `Env`, and  `Exp unit ID` columns should appear as they did in the import file.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: _\<link to TAF run>_


[BI-1911]: https://breedinginsight.atlassian.net/browse/BI-1911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQescription
[BI-1911](https://breedinginsight.atlassian.net/browse/BI-1911) - in response to Shahana's [testing notes.](https://breedinginsight.atlassian.net/browse/BI-1911?focusedCommentId=14057)


# Dependencies
bi-web: bug/BI-1911-2 branch

# Testing
- Import an Experiment.
- Look at the confirmation page.

**Expected Results**
- The `Env Year`, `Env`, and  `Exp unit ID` columns should appear as they did in the import file.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: _\<link to TAF run>_


[BI-1911]: https://breedinginsight.atlassian.net/browse/BI-1911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ