### PR TITLE
[BI-1830] Overwrite entity dataset

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
@@ -47,6 +47,7 @@ public final class BrAPIAdditionalInfoFields {
     public static final String MALE_PARENT_UNKNOWN = "maleParentUnknown";
 	public static final String TREATMENTS = "treatments";
     public static final String GID = "gid";
+    public static final String CHANGELOG = "changeLog";
     public static final String ENV_YEAR = "envYear";
     public static final String GERMPLASM_UUID = "germplasmId";
     public static final String SAMPLE_ORGANISM = "organism";

--- a/src/main/java/org/breedinginsight/brapps/importer/model/config/ImportFieldTypeEnum.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/config/ImportFieldTypeEnum.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 
 @Getter
 public enum ImportFieldTypeEnum {
+    BOOLEAN("BOOLEAN"),
     TEXT("TEXT"),
     NUMERICAL("NUMERICAL"),
     INTEGER("INTEGER"),

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
@@ -17,10 +17,15 @@
 
 package org.breedinginsight.brapps.importer.model.imports;
 
+import org.brapi.client.v2.model.exceptions.ApiException;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.response.ImportPreviewResponse;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
+import org.breedinginsight.services.exceptions.DoesNotExistException;
+import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
+import org.breedinginsight.services.exceptions.UnprocessableEntityException;
+import org.breedinginsight.services.exceptions.ValidatorException;
 import tech.tablesaw.api.Table;
 
 import java.util.List;

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
@@ -17,15 +17,10 @@
 
 package org.breedinginsight.brapps.importer.model.imports;
 
-import org.brapi.client.v2.model.exceptions.ApiException;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.response.ImportPreviewResponse;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
-import org.breedinginsight.services.exceptions.DoesNotExistException;
-import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
-import org.breedinginsight.services.exceptions.UnprocessableEntityException;
-import org.breedinginsight.services.exceptions.ValidatorException;
 import tech.tablesaw.api.Table;
 
 import java.util.List;

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
@@ -49,5 +49,5 @@ public interface BrAPIImportService {
         return String.format("User input, \"%s\" must be an %s", fieldName, typeName);
     }
     ImportPreviewResponse process(List<BrAPIImport> brAPIImports, Table data, Program program, ImportUpload upload, User user, Boolean commit)
-            throws UnprocessableEntityException, DoesNotExistException, ValidatorException, ApiException, MissingRequiredInfoException;
+            throws Exception;
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/ChangeLogEntry.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/ChangeLogEntry.java
@@ -1,0 +1,39 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapps.importer.model.imports;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+public class ChangeLogEntry {
+    private String originalValue;
+    private String reasonForChange;
+    private UUID changedBy;
+    private String dateOfChange;
+
+    public ChangeLogEntry(String originalValue, String reasonForChange, UUID changedBy, String dateOfChange) {
+        this.originalValue = originalValue;
+        this.reasonForChange = reasonForChange;
+        this.changedBy = changedBy;
+        this.dateOfChange = dateOfChange;
+    }
+}

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentImportService.java
@@ -70,7 +70,7 @@ public class ExperimentImportService implements BrAPIImportService {
 
     @Override
     public ImportPreviewResponse process(List<BrAPIImport> brAPIImports, Table data, Program program, ImportUpload upload, User user, Boolean commit)
-            throws UnprocessableEntityException, ValidatorException, ApiException, MissingRequiredInfoException {
+            throws Exception {
 
         ImportPreviewResponse response = null;
         List<Processor> processors = List.of(experimentProcessorProvider.get());

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentImportService.java
@@ -18,18 +18,15 @@
 package org.breedinginsight.brapps.importer.model.imports.experimentObservation;
 
 import lombok.extern.slf4j.Slf4j;
-import org.brapi.client.v2.model.exceptions.ApiException;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImportService;
-import org.breedinginsight.brapps.importer.model.imports.germplasm.GermplasmImport;
 import org.breedinginsight.brapps.importer.model.response.ImportPreviewResponse;
-import org.breedinginsight.brapps.importer.services.processors.*;
+import org.breedinginsight.brapps.importer.services.processors.ExperimentProcessor;
+import org.breedinginsight.brapps.importer.services.processors.Processor;
+import org.breedinginsight.brapps.importer.services.processors.ProcessorManager;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
-import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
-import org.breedinginsight.services.exceptions.UnprocessableEntityException;
-import org.breedinginsight.services.exceptions.ValidatorException;
 import tech.tablesaw.api.Table;
 
 import javax.inject.Inject;

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -47,9 +47,9 @@ import java.util.function.Supplier;
 @ImportConfigMetadata(id = "ExperimentImport", name = "Experiment Import",
         description = "This import is used to create Observation Unit and Experiment data")
 public class ExperimentObservation implements BrAPIImport {
-    @ImportFieldType(type = ImportFieldTypeEnum.BOOLEAN)
+    @ImportFieldType(type = ImportFieldTypeEnum.BOOLEAN, collectTime = ImportCollectTimeEnum.UPLOAD)
     @ImportFieldMetadata(id = "overwrite", name = "Overwrite", description = "Boolean flag to overwrite existing observation")
-    private boolean overwrite;
+    private String overwrite;
 
     @ImportFieldType(type = ImportFieldTypeEnum.TEXT, collectTime = ImportCollectTimeEnum.UPLOAD)
     @ImportFieldMetadata(id="overwriteReason", name="Overwrite Reason", description="Description of the reason for overwriting existing observations")

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -47,6 +47,13 @@ import java.util.function.Supplier;
 @ImportConfigMetadata(id = "ExperimentImport", name = "Experiment Import",
         description = "This import is used to create Observation Unit and Experiment data")
 public class ExperimentObservation implements BrAPIImport {
+    @ImportFieldType(type = ImportFieldTypeEnum.BOOLEAN)
+    @ImportFieldMetadata(id = "overwrite", name = "Overwrite", description = "Boolean flag to overwrite existing observation")
+    private boolean overwrite;
+
+    @ImportFieldType(type = ImportFieldTypeEnum.TEXT, collectTime = ImportCollectTimeEnum.UPLOAD)
+    @ImportFieldMetadata(id="overwriteReason", name="Overwrite Reason", description="Description of the reason for overwriting existing observations")
+    private String overwriteReason;
 
     @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
     @ImportFieldMetadata(id = "germplasmName", name = Columns.GERMPLASM_NAME, description = "Name of germplasm")

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/germplasm/GermplasmImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/germplasm/GermplasmImportService.java
@@ -66,7 +66,7 @@ public class GermplasmImportService implements BrAPIImportService {
 
     @Override
     public ImportPreviewResponse process(List<BrAPIImport> brAPIImports, Table data, Program program, ImportUpload upload, User user, Boolean commit)
-            throws UnprocessableEntityException, DoesNotExistException, ValidatorException, ApiException, MissingRequiredInfoException {
+            throws Exception {
 
         ImportPreviewResponse response = null;
         List<Processor> processors = List.of(germplasmProcessorProvider.get());

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/germplasm/GermplasmImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/germplasm/GermplasmImportService.java
@@ -18,24 +18,21 @@
 package org.breedinginsight.brapps.importer.model.imports.germplasm;
 
 import lombok.extern.slf4j.Slf4j;
-import org.brapi.client.v2.model.exceptions.ApiException;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImportService;
 import org.breedinginsight.brapps.importer.model.response.ImportPreviewResponse;
-import org.breedinginsight.brapps.importer.services.processors.*;
+import org.breedinginsight.brapps.importer.services.processors.GermplasmProcessor;
+import org.breedinginsight.brapps.importer.services.processors.Processor;
+import org.breedinginsight.brapps.importer.services.processors.ProcessorManager;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
-import org.breedinginsight.services.exceptions.DoesNotExistException;
-import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
-import org.breedinginsight.services.exceptions.UnprocessableEntityException;
-import org.breedinginsight.services.exceptions.ValidatorException;
 import tech.tablesaw.api.Table;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-import java.util.*;
+import java.util.List;
 
 @Singleton
 @Slf4j

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/sample/SampleSubmissionImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/sample/SampleSubmissionImportService.java
@@ -18,7 +18,6 @@
 package org.breedinginsight.brapps.importer.model.imports.sample;
 
 import lombok.extern.slf4j.Slf4j;
-import org.brapi.client.v2.model.exceptions.ApiException;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImportService;
@@ -28,10 +27,6 @@ import org.breedinginsight.brapps.importer.services.processors.ProcessorManager;
 import org.breedinginsight.brapps.importer.services.processors.SampleSubmissionProcessor;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
-import org.breedinginsight.services.exceptions.DoesNotExistException;
-import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
-import org.breedinginsight.services.exceptions.UnprocessableEntityException;
-import org.breedinginsight.services.exceptions.ValidatorException;
 import tech.tablesaw.api.Table;
 
 import javax.inject.Inject;

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/sample/SampleSubmissionImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/sample/SampleSubmissionImportService.java
@@ -69,7 +69,7 @@ public class SampleSubmissionImportService implements BrAPIImportService {
                                          Program program,
                                          ImportUpload upload,
                                          User user,
-                                         Boolean commit) throws UnprocessableEntityException, DoesNotExistException, ValidatorException, ApiException, MissingRequiredInfoException {
+                                         Boolean commit) throws Exception {
         List<Processor> processors = List.of(sampleProcessorProvider.get());
         return processorManagerProvider.get().process(brAPIImports, processors, data, program, upload, user, commit);
     }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/MappingManager.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/MappingManager.java
@@ -351,7 +351,7 @@ public class MappingManager {
         else if (required != null && userInput.containsKey(fieldId) && userInput.get(fieldId).toString().isBlank()) {
             throw new UnprocessableEntityException(importService.getMissingUserInputMsg(metadata.name()));
         }
-        else if (userInput.containsKey(fieldId)) {
+        else if (userInput != null && userInput.containsKey(fieldId)) {
             String value = userInput.get(fieldId).toString();
             if (!isCorrectType(type.type(), value)) {
                 throw new UnprocessableEntityException(importService.getWrongUserInputDataTypeMsg(metadata.name(), type.type().toString().toLowerCase()));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/MappingManager.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/MappingManager.java
@@ -53,6 +53,12 @@ public class MappingManager {
 
     private ImportConfigManager configManager;
 
+    public static String wrongDataTypeMsg = "Column name \"%s\" must be integer type, but non-integer type provided.";
+    public static String blankRequiredField = "Required field \"%s\" cannot contain empty values";
+    public static String missingColumn = "Column name \"%s\" does not exist in file";
+    public static String missingUserInput = "User input, \"%s\" is required";
+    public static String wrongUserInputDataType = "User input, \"%s\" must be an %s";
+
     @Inject
     MappingManager(ImportConfigManager configManager) {
         this.configManager = configManager;
@@ -339,7 +345,7 @@ public class MappingManager {
 
         // Only supports user input at the top level of an object at the moment. No nested objects. Map<String, String>
         String fieldId = metadata.id();
-        if (!userInput.containsKey(fieldId) && required != null) {
+        if ((userInput == null || !userInput.containsKey(fieldId)) && required != null) {
             throw new UnprocessableEntityException(importService.getMissingUserInputMsg(metadata.name()));
         }
         else if (required != null && userInput.containsKey(fieldId) && userInput.get(fieldId).toString().isBlank()) {
@@ -369,12 +375,15 @@ public class MappingManager {
 
     private Boolean isCorrectType(ImportFieldTypeEnum expectedType, String value) {
         if (!value.isBlank()) {
-            if (expectedType == ImportFieldTypeEnum.INTEGER) {
-                try {
+            try {
+                if (expectedType == ImportFieldTypeEnum.INTEGER) {
                     Integer d = Integer.parseInt(value);
-                } catch (NumberFormatException nfe) {
-                    return false;
                 }
+                if (expectedType == ImportFieldTypeEnum.BOOLEAN) {
+                    Boolean b = Boolean.parseBoolean(value);
+                }
+            } catch (NumberFormatException nfe) {
+                return false;
             }
         }
         return true;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/MappingManager.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/MappingManager.java
@@ -375,14 +375,14 @@ public class MappingManager {
 
     private Boolean isCorrectType(ImportFieldTypeEnum expectedType, String value) {
         if (!value.isBlank()) {
-            try {
-                if (expectedType == ImportFieldTypeEnum.INTEGER) {
-                    Integer d = Integer.parseInt(value);
+            if (expectedType == ImportFieldTypeEnum.INTEGER) {
+                try {
+                    Integer.parseInt(value);
+                } catch (NumberFormatException nfe) {
+                    return false;
                 }
-                if (expectedType == ImportFieldTypeEnum.BOOLEAN) {
-                    Boolean b = Boolean.parseBoolean(value);
-                }
-            } catch (NumberFormatException nfe) {
+            }
+            if (expectedType == ImportFieldTypeEnum.BOOLEAN && !String.valueOf(Boolean.parseBoolean(value)).equals(value)) {
                 return false;
             }
         }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -16,6 +16,9 @@
  */
 package org.breedinginsight.brapps.importer.services.processors;
 
+import com.google.gson.JsonArray;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.micronaut.context.annotation.Property;
@@ -27,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.brapi.client.v2.JSON;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.*;
@@ -46,6 +50,7 @@ import org.breedinginsight.brapps.importer.daos.*;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.base.AdditionalInfo;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
+import org.breedinginsight.brapps.importer.model.imports.ChangeLogEntry;
 import org.breedinginsight.brapps.importer.model.imports.PendingImport;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation.Columns;
@@ -95,6 +100,9 @@ public class ExperimentProcessor implements Processor {
     private static final String TIMESTAMP_REGEX = "^"+TIMESTAMP_PREFIX+"\\s*";
     private static final String COMMA_DELIMITER = ",";
     private static final String BLANK_FIELD = "Required field is blank";
+    private static final String BLANK_FIELD_EXPERIMENT = "Field is blank when creating a new experiment";
+    private static final String BLANK_FIELD_ENV = "Field is blank when creating a new environment";
+    private static final String BLANK_FIELD_OBS = "Field is blank when creating new observations";
     private static final String ENV_LOCATION_MISMATCH = "All locations must be the same for a given environment";
     private static final String ENV_YEAR_MISMATCH = "All years must be the same for a given environment";
 
@@ -136,6 +144,8 @@ public class ExperimentProcessor implements Processor {
 
     // Associates timestamp columns to associated phenotype column name for ease of storage
     private final Map<String, Column<?>> timeStampColByPheno = new HashMap<>();
+    private final Gson gson;
+
 
     @Inject
     public ExperimentProcessor(DSLContext dsl,
@@ -159,6 +169,7 @@ public class ExperimentProcessor implements Processor {
         this.brAPIListDAO = brAPIListDAO;
         this.ontologyService = ontologyService;
         this.fileMappingUtil = fileMappingUtil;
+        this.gson = new JSON().getGson();
     }
 
     @Override
@@ -235,7 +246,7 @@ public class ExperimentProcessor implements Processor {
 
         prepareDataForValidation(importRows, phenotypeCols, mappedBrAPIImport);
 
-        validateFields(importRows, validationErrors, mappedBrAPIImport, referencedTraits, program, phenotypeCols, commit);
+        validateFields(importRows, validationErrors, mappedBrAPIImport, referencedTraits, program, phenotypeCols, commit, user);
 
         if (validationErrors.hasErrors()) {
             throw new ValidatorException(validationErrors);
@@ -552,7 +563,7 @@ public class ExperimentProcessor implements Processor {
     }
 
     private ValidationErrors validateFields(List<BrAPIImport> importRows, ValidationErrors validationErrors, Map<Integer, PendingImport> mappedBrAPIImport, List<Trait> referencedTraits, Program program,
-                                            List<Column<?>> phenotypeCols, boolean commit) throws MissingRequiredInfoException, ApiException {
+                                List<Column<?>> phenotypeCols, boolean commit, User user) throws MissingRequiredInfoException, ApiException {
         //fetching any existing observations for any OUs in the import
         this.existingObsByObsHash = fetchExistingObservations(referencedTraits, program);
         CaseInsensitiveMap<String, Trait> colVarMap = new CaseInsensitiveMap<>();
@@ -576,7 +587,7 @@ public class ExperimentProcessor implements Processor {
 
             validateConditionallyRequired(validationErrors, rowNum, importRow, program, commit);
             validateObservationUnits(validationErrors, uniqueStudyAndObsUnit, rowNum, importRow);
-            validateObservations(validationErrors, rowNum, importRows.size(), importRow, phenotypeCols, colVarMap, commit);
+            validateObservations(validationErrors, rowNum, importRows.size(), importRow, phenotypeCols, colVarMap, commit, user);
         }
         return validationErrors;
     }
@@ -605,8 +616,8 @@ public class ExperimentProcessor implements Processor {
         observationUnitByNameNoScope.values().forEach(ou -> {
             if(StringUtils.isNotBlank(ou.getBrAPIObject().getObservationUnitDbId())) {
                 ouDbIds.add(ou.getBrAPIObject().getObservationUnitDbId());
-                ouNameByDbId.put(ou.getBrAPIObject().getObservationUnitDbId(), Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getBrAPIObject().getObservationUnitName(), program.getKey()));
             }
+            ouNameByDbId.put(ou.getBrAPIObject().getObservationUnitDbId(), Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getBrAPIObject().getObservationUnitName(), program.getKey()));
         });
 
         for (Trait referencedTrait : referencedTraits) {
@@ -635,7 +646,8 @@ public class ExperimentProcessor implements Processor {
                                       ExperimentObservation importRow,
                                       List<Column<?>> phenotypeCols,
                                       Map<String, Trait> colVarMap,
-                                      boolean commit) {
+                                      boolean commit,
+                                      User user) {
         phenotypeCols.forEach(phenoCol -> {
             var importHash = getImportObservationHash(importRow, phenoCol.name());
 
@@ -657,6 +669,27 @@ public class ExperimentProcessor implements Processor {
                     !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1))) {
                 observationByHash.get(importHash).getBrAPIObject().setValue(phenoCol.getString(numRows - rowNum -1));
                 observationByHash.get(importHash).setState(ImportObjectState.MUTATED);
+
+                // add a change log entry when updating the value of an observation
+                if (commit) {
+                    BrAPIObservation pendingObservation = observationByHash.get(importHash).getBrAPIObject();
+                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd:hh-mm-ssZ");
+                    String timestamp = formatter.format(OffsetDateTime.now());
+                    ChangeLogEntry change = new ChangeLogEntry(existingObsByObsHash.get(importHash).getValue(),
+                            importRow.getOverwriteReason(),
+                            user.getId(),
+                            timestamp
+                    );
+                    if (pendingObservation.getAdditionalInfo().isJsonNull()) {
+                        pendingObservation.setAdditionalInfo(new JsonObject());
+                        pendingObservation.getAdditionalInfo().add(BrAPIAdditionalInfoFields.CHANGELOG, new JsonArray());
+                    }
+
+                    if (pendingObservation.getAdditionalInfo() != null && !pendingObservation.getAdditionalInfo().has(BrAPIAdditionalInfoFields.CHANGELOG)) {
+                        pendingObservation.getAdditionalInfo().add(BrAPIAdditionalInfoFields.CHANGELOG, new JsonArray());
+                    }
+                    pendingObservation.getAdditionalInfo().get(BrAPIAdditionalInfoFields.CHANGELOG).getAsJsonArray().add(gson.toJson(change));
+                }
 
             // preview case where observation has already been committed and import ObsVar data is either empty or the
             // same as has been committed prior to import
@@ -708,7 +741,12 @@ public class ExperimentProcessor implements Processor {
                                                             .getState();
         ImportObjectState envState = this.studyByNameNoScope.get(importRow.getEnv()).getState();
 
-        String errorMessage = BLANK_FIELD;
+        String errorMessage = BLANK_FIELD_EXPERIMENT;
+        if (expState == ImportObjectState.EXISTING && envState == ImportObjectState.NEW) {
+            errorMessage = BLANK_FIELD_ENV;
+        } else if(expState == ImportObjectState.EXISTING && envState == ImportObjectState.EXISTING) {
+            errorMessage = BLANK_FIELD_OBS;
+        }
 
         if(expState == ImportObjectState.NEW || envState == ImportObjectState.NEW) {
             validateRequiredCell(importRow.getGid(), Columns.GERMPLASM_GID, errorMessage, validationErrors, rowNum);
@@ -875,20 +913,18 @@ public class ExperimentProcessor implements Processor {
     }
 
 
-    private PendingImportObject<BrAPIObservation> fetchOrCreateObservationPIO(Program program,
-                                                                              User user,
-                                                                              ExperimentObservation importRow,
-                                                                              String variableName,
-                                                                              String value,
-                                                                              String timeStampValue,
-                                                                              boolean commit,
-                                                                              String seasonDbId,
-                                                                              PendingImportObject<BrAPIObservationUnit> obsUnitPIO) {
+    private void fetchOrCreateObservationPIO(Program program,
+                                             User user,
+                                             ExperimentObservation importRow,
+                                             String variableName,
+                                             String value,
+                                             String timeStampValue,
+                                             boolean commit,
+                                             String seasonDbId,
+                                             PendingImportObject<BrAPIObservationUnit> obsUnitPIO) {
         PendingImportObject<BrAPIObservation> pio;
         String key = getImportObservationHash(importRow, variableName);
-        if (this.observationByHash.containsKey(key)) {
-            pio = observationByHash.get(key);
-        } else {
+        if (!this.observationByHash.containsKey(key)) {
             PendingImportObject<BrAPITrial> trialPIO = this.trialByNameNoScope.get(importRow.getExpTitle());
             UUID trialID = trialPIO.getId();
             PendingImportObject<BrAPIStudy> studyPIO = this.studyByNameNoScope.get(importRow.getEnv());
@@ -906,13 +942,17 @@ public class ExperimentProcessor implements Processor {
             pio = new PendingImportObject<>(ImportObjectState.NEW, newObservation);
             this.observationByHash.put(key, pio);
         }
-        return pio;
     }
     private void addObsVarsToDatasetDetails(PendingImportObject<BrAPIListDetails> pio, List<Trait> referencedTraits, Program program) {
         BrAPIListDetails details = pio.getBrAPIObject();
         referencedTraits.forEach(trait -> {
-            String id = trait.getRawObservationVariableName();
+            String id = Utilities.appendProgramKey(trait.getObservationVariableName(), program.getKey());
 
+            // Don't append the key if connected to a brapi service operating with legacy data(no appended program key)
+            if (trait.getFullName() == null) {
+                id = trait.getObservationVariableName();
+            }
+            
             if (!details.getData().contains(id) && ImportObjectState.EXISTING != pio.getState()) {
                 details.getData().add(id);
             }
@@ -968,7 +1008,7 @@ public class ExperimentProcessor implements Processor {
 
             // It is assumed that the study has only one season, And that the Years and not
             // the dbId's are stored in getSeason() list.
-            String year = newStudy.getSeasons().get(0);
+            String year = newStudy.getSeasons().get(0); // It is assumed that the study has only one season
             if (commit) {
                 if(StringUtils.isNotBlank(year)) {
                     String seasonID = this.yearToSeasonDbId(year, program.getId());
@@ -977,7 +1017,6 @@ public class ExperimentProcessor implements Processor {
             } else {
                 addYearToStudyAdditionalInfo(program, newStudy, year);
             }
-
 
             pio = new PendingImportObject<>(ImportObjectState.NEW, newStudy, id);
             this.studyByNameNoScope.put(importRow.getEnv(), pio);
@@ -1016,16 +1055,13 @@ public class ExperimentProcessor implements Processor {
         }
     }
 
-    private PendingImportObject<ProgramLocation> fetchOrCreateLocationPIO(ExperimentObservation importRow) {
+    private void fetchOrCreateLocationPIO(ExperimentObservation importRow) {
         PendingImportObject<ProgramLocation> pio;
-        if (locationByName.containsKey((importRow.getEnvLocation()))) {
-            pio = locationByName.get(importRow.getEnvLocation());
-        } else {
+        if (! locationByName.containsKey((importRow.getEnvLocation()))) {
             ProgramLocation newLocation = importRow.constructProgramLocation();
             pio = new PendingImportObject<>(ImportObjectState.NEW, newLocation, UUID.randomUUID());
             this.locationByName.put(importRow.getEnvLocation(), pio);
         }
-        return pio;
     }
 
     private PendingImportObject<BrAPITrial> fetchOrCreateTrialPIO(Program program, User user, boolean commit, ExperimentObservation importRow, Supplier<BigInteger> expNextVal) throws UnprocessableEntityException {
@@ -1381,7 +1417,7 @@ public class ExperimentProcessor implements Processor {
             BrAPIListDetails dataSetDetails = brAPIListDAO
                     .getListById(existingDatasets.get(0).getListDbId(), program.getId())
                     .getResult();
-            processAndCacheObsVarDataset(dataSetDetails, program, obsVarDatasetByName);
+            processAndCacheObsVarDataset(dataSetDetails, obsVarDatasetByName);
           } catch (ApiException e) {
             log.error(Utilities.generateApiExceptionLogMessage(e), e);
             throw new InternalServerException(e.toString(), e);
@@ -1405,7 +1441,7 @@ public class ExperimentProcessor implements Processor {
 
         return Optional.ofNullable(this.trialByNameNoScope.get(expTitle.get()));
     }
-    private void processAndCacheObsVarDataset(BrAPIListDetails existingList, Program program, Map<String, PendingImportObject<BrAPIListDetails>> obsVarDatasetByName) {
+    private void processAndCacheObsVarDataset(BrAPIListDetails existingList, Map<String, PendingImportObject<BrAPIListDetails>> obsVarDatasetByName) {
         BrAPIExternalReference xref = Utilities.getExternalReference(existingList.getExternalReferences(),
                         String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.DATASET.getName()))
                 .orElseThrow(() -> new IllegalStateException("External references wasn't found for list (dbid): " + existingList.getListDbId()));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -602,7 +602,7 @@ public class ExperimentProcessor implements Processor {
 
             validateConditionallyRequired(validationErrors, rowNum, importRow, program, commit);
             validateObservationUnits(validationErrors, uniqueStudyAndObsUnit, rowNum, importRow);
-            validateObservations(validationErrors, rowNum, importRows.size(), importRow, phenotypeCols, colVarMap, commit, user);
+            validateObservations(validationErrors, rowNum, importRow, phenotypeCols, colVarMap, commit, user);
         }
     }
 
@@ -662,7 +662,6 @@ public class ExperimentProcessor implements Processor {
 
     private void validateObservations(ValidationErrors validationErrors,
                                       int rowNum,
-                                      int numRows,
                                       ExperimentObservation importRow,
                                       List<Column<?>> phenotypeCols,
                                       Map<String, Trait> colVarMap,
@@ -674,8 +673,8 @@ public class ExperimentProcessor implements Processor {
             // error if import observation data already exists and user has not selected to overwrite
             if(commit && importRow.getOverwrite().equals("false") &&
                     this.existingObsByObsHash.containsKey(importHash) &&
-                    StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum - 1)) &&
-                    !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum - 1))) {
+                    StringUtils.isNotBlank(phenoCol.getString(rowNum)) &&
+                    !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(rowNum))) {
                 addRowError(
                         phenoCol.name(),
                         String.format("Value already exists for ObsUnitId: %s, Phenotype: %s", importRow.getObsUnitID(), phenoCol.name()),
@@ -685,8 +684,8 @@ public class ExperimentProcessor implements Processor {
             // preview case where observation has already been committed and the import row ObsVar data differs from what
             // had been saved prior to import
             } else if (this.existingObsByObsHash.containsKey(importHash) &&
-                    StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum -1)) &&
-                    !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1))) {
+                    StringUtils.isNotBlank(phenoCol.getString(rowNum)) &&
+                    !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(rowNum))) {
 
                 // add a change log entry when updating the value of an observation
                 if (commit) {
@@ -713,14 +712,14 @@ public class ExperimentProcessor implements Processor {
             // preview case where observation has already been committed and import ObsVar data is either empty or the
             // same as has been committed prior to import
             } else if(this.existingObsByObsHash.containsKey(importHash) &&
-                    (StringUtils.isBlank(phenoCol.getString(numRows - rowNum -1)) ||
-                            this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1)))) {
+                    (StringUtils.isBlank(phenoCol.getString(rowNum)) ||
+                            this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(rowNum)))) {
                 BrAPIObservation existingObs = this.existingObsByObsHash.get(importHash);
                 existingObs.setObservationVariableName(phenoCol.name());
                 observationByHash.get(importHash).setState(ImportObjectState.EXISTING);
                 observationByHash.get(importHash).setBrAPIObject(existingObs);
             } else {
-                validateObservationValue(colVarMap.get(phenoCol.name()), phenoCol.getString(numRows - rowNum -1), phenoCol.name(), validationErrors, rowNum);
+                validateObservationValue(colVarMap.get(phenoCol.name()), phenoCol.getString(rowNum), phenoCol.name(), validationErrors, rowNum);
 
                 //Timestamp validation
                 if(timeStampColByPheno.containsKey(phenoCol.name())) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -234,7 +234,7 @@ public class ExperimentProcessor implements Processor {
             }
         }
 
-        List<Trait> referencedTraits = verifyTraits(program.getId(), phenotypeCols, timestampCols, validationErrors);
+        List<Trait> referencedTraits = verifyTraits(program.getId(), phenotypeCols, timestampCols);
 
         //Now know timestamps all valid phenotypes, can associate with phenotype column name for easy retrieval
         for (Column<?> tsColumn : timestampCols) {
@@ -254,7 +254,7 @@ public class ExperimentProcessor implements Processor {
 
         log.debug("done processing experiment import");
         // Construct our response object
-        return generateStatisticsMap(importRows, phenotypeCols);
+        return generateStatisticsMap(importRows);
     }
 
     @Override
@@ -271,7 +271,7 @@ public class ExperimentProcessor implements Processor {
                 .getMutationsByObjectId(trialByNameNoScope, BrAPITrial::getTrialDbId);
 
         Map<String, BrAPIObservation> mutatedObservationByDbId = ProcessorData
-                .getMutationsByObjectId(observationByHash, observation -> observation.getObservationDbId());
+                .getMutationsByObjectId(observationByHash, BrAPIObservation::getObservationDbId);
 
         List<ProgramLocationRequest> newLocations = ProcessorData.getNewObjects(this.locationByName)
                                                                  .stream()
@@ -432,7 +432,7 @@ public class ExperimentProcessor implements Processor {
         }
     }
 
-    private List<Trait> verifyTraits(UUID programId, List<Column<?>> phenotypeCols, List<Column<?>> timestampCols, ValidationErrors validationErrors) {
+    private List<Trait> verifyTraits(UUID programId, List<Column<?>> phenotypeCols, List<Column<?>> timestampCols) {
         Set<String> varNames = phenotypeCols.stream()
                                             .map(Column::name)
                                             .collect(Collectors.toSet());
@@ -578,8 +578,8 @@ public class ExperimentProcessor implements Processor {
         return DigestUtils.sha256Hex(concat);
     }
 
-    private ValidationErrors validateFields(List<BrAPIImport> importRows, ValidationErrors validationErrors, Map<Integer, PendingImport> mappedBrAPIImport, List<Trait> referencedTraits, Program program,
-                                List<Column<?>> phenotypeCols, boolean commit, User user) throws MissingRequiredInfoException, ApiException {
+    private void validateFields(List<BrAPIImport> importRows, ValidationErrors validationErrors, Map<Integer, PendingImport> mappedBrAPIImport, List<Trait> referencedTraits, Program program,
+                                List<Column<?>> phenotypeCols, boolean commit, User user) {
         //fetching any existing observations for any OUs in the import
         CaseInsensitiveMap<String, Trait> colVarMap = new CaseInsensitiveMap<>();
         for ( Trait trait: referencedTraits) {
@@ -593,7 +593,7 @@ public class ExperimentProcessor implements Processor {
                 validateGermplasm(importRow, validationErrors, rowNum, mappedImportRow.getGermplasm());
             }
             validateTestOrCheck(importRow, validationErrors, rowNum);
-
+            //TODO: providing obs unit ID does not supersede import row inout data as expected and needs to be fixed
             //Check if existing environment. If so, ObsUnitId must be assigned
 //            if ((mappedImportRow.getStudy().getState() == ImportObjectState.EXISTING)
 //                    && (StringUtils.isBlank(importRow.getObsUnitID()))) {
@@ -604,7 +604,6 @@ public class ExperimentProcessor implements Processor {
             validateObservationUnits(validationErrors, uniqueStudyAndObsUnit, rowNum, importRow);
             validateObservations(validationErrors, rowNum, importRows.size(), importRow, phenotypeCols, colVarMap, commit, user);
         }
-        return validationErrors;
     }
 
     private void validateObservationUnits(ValidationErrors validationErrors, Set<String> uniqueStudyAndObsUnit, int rowNum, ExperimentObservation importRow) {
@@ -628,7 +627,7 @@ public class ExperimentProcessor implements Processor {
                                                                 .map(PendingImportObject::getBrAPIObject)
                                                                 .collect(Collectors.toMap(BrAPIStudy::getStudyDbId, brAPIStudy -> Utilities.removeProgramKeyAndUnknownAdditionalData(brAPIStudy.getStudyName(), program.getKey())));
 
-        studyNameByDbId.keySet().stream().forEach(studyDbId -> {
+        studyNameByDbId.keySet().forEach(studyDbId -> {
             try {
                 brAPIObservationUnitDAO.getObservationUnitsForStudyDbId(studyDbId, program).forEach(ou -> {
                     if(StringUtils.isNotBlank(ou.getObservationUnitDbId())) {
@@ -640,12 +639,6 @@ public class ExperimentProcessor implements Processor {
                 throw new RuntimeException(e);
             }
         });
-//        observationUnitByNameNoScope.values().forEach(ou -> {
-//            if(StringUtils.isNotBlank(ou.getBrAPIObject().getObservationUnitDbId())) {
-//                ouDbIds.add(ou.getBrAPIObject().getObservationUnitDbId());
-//            }
-//            ouNameByDbId.put(ou.getBrAPIObject().getObservationUnitDbId(), Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getBrAPIObject().getObservationUnitName(), program.getKey()));
-//        });
 
         for (Trait referencedTrait : referencedTraits) {
             variableDbIds.add(referencedTrait.getObservationVariableDbId());
@@ -803,6 +796,7 @@ public class ExperimentProcessor implements Processor {
                 addRowError(Columns.OBS_UNIT_ID, "ObsUnitID cannot be specified when creating a new environment", validationErrors, rowNum);
             }
         } else {
+            //TODO: include this step once user-supplied obs unit id correctly supersedes other row data
             //validateRequiredCell(importRow.getObsUnitID(), Columns.OBS_UNIT_ID, errorMessage, validationErrors, rowNum);
         }
     }
@@ -826,7 +820,7 @@ public class ExperimentProcessor implements Processor {
         }
     }
 
-    private Map<String, ImportPreviewStatistics> generateStatisticsMap(List<BrAPIImport> importRows, List<Column<?>> phenotypeCols) {
+    private Map<String, ImportPreviewStatistics> generateStatisticsMap(List<BrAPIImport> importRows) {
         // Data for stats.
         HashSet<String> environmentNameCounter = new HashSet<>(); // set of unique environment names
         HashSet<String> obsUnitsIDCounter = new HashSet<>(); // set of unique observation unit ID's
@@ -892,8 +886,8 @@ public class ExperimentProcessor implements Processor {
                 "Observation_Units", obdUnitStats,
                 "GIDs", gidStats,
                 "Observations", observationStats,
-                "Existing Observations", existingObservationStats,
-                "Mutated Observations", mutatedObservationStats
+                "Existing_Observations", existingObservationStats,
+                "Mutated_Observations", mutatedObservationStats
         );
     }
 
@@ -1030,7 +1024,7 @@ public class ExperimentProcessor implements Processor {
             }
         });
     }
-    private PendingImportObject<BrAPIListDetails> fetchOrCreateDatasetPIO(ExperimentObservation importRow, Program program, List<Trait> referencedTraits) {
+    private void fetchOrCreateDatasetPIO(ExperimentObservation importRow, Program program, List<Trait> referencedTraits) {
         PendingImportObject<BrAPIListDetails> pio;
         PendingImportObject<BrAPITrial> trialPIO = trialByNameNoScope.get(importRow.getExpTitle());
         String name = String.format("Observation Dataset [%s-%s]",
@@ -1057,7 +1051,6 @@ public class ExperimentProcessor implements Processor {
             obsVarDatasetByName.put(name, pio);
         }
         addObsVarsToDatasetDetails(pio, referencedTraits, program);
-        return pio;
     }
 
     private PendingImportObject<BrAPIStudy> fetchOrCreateStudyPIO(Program program, boolean commit, String expSequenceValue, ExperimentObservation importRow, Supplier<BigInteger> envNextVal) {
@@ -1413,9 +1406,7 @@ public class ExperimentProcessor implements Processor {
                                                                .collect(Collectors.toSet());
 
         List<BrAPIStudy> studies = fetchStudiesByDbId(studyDbIds, program);
-        studies.forEach(study -> {
-            processAndCacheStudy(study, program, studyByName);
-        });
+        studies.forEach(study -> processAndCacheStudy(study, program, studyByName));
     }
 
     private List<BrAPIStudy> fetchStudiesByDbId(Set<String> studyDbIds, Program program) throws ApiException {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -280,6 +280,7 @@ public class ExperimentProcessor implements Processor {
                 .getMutationsByObjectId(obsVarDatasetByName, BrAPIListSummary::getListDbId);
 
         List<BrAPIObservationUnit> newObservationUnits = ProcessorData.getNewObjects(this.observationUnitByNameNoScope);
+
         // filter out observations with no 'value' so they will not be saved
         List<BrAPIObservation> newObservations = ProcessorData.getNewObjects(this.observationByHash)
                                                               .stream()
@@ -654,7 +655,8 @@ public class ExperimentProcessor implements Processor {
             } else if (this.existingObsByObsHash.containsKey(importHash) &&
                     StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum -1)) &&
                     !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1))) {
-                observationByHash.get(importHash).setState(ImportObjectState.EXISTING);
+                observationByHash.get(importHash).getBrAPIObject().setValue(phenoCol.getString(numRows - rowNum -1));
+                observationByHash.get(importHash).setState(ImportObjectState.MUTATED);
 
             // preview case where observation has already been committed and import ObsVar data is either empty or the
             // same as has been committed prior to import
@@ -786,7 +788,7 @@ public class ExperimentProcessor implements Processor {
         int numExistingObservations = Math.toIntExact(
                 this.observationByHash.values()
                         .stream()
-                        .filter(preview -> preview != null && preview.getState() == ImportObjectState.EXISTING &&
+                        .filter(preview -> preview != null && (preview.getState() == ImportObjectState.EXISTING || preview.getState() == ImportObjectState.MUTATED) &&
                                 !StringUtils.isBlank(preview.getBrAPIObject()
                                         .getValue()))
                         .count()

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -668,7 +668,7 @@ public class ExperimentProcessor implements Processor {
             var importHash = getImportObservationHash(importRow, phenoCol.name());
 
             // error if import observation data already exists and user has not selected to overwrite
-            if(commit && !importRow.isOverwrite() &&
+            if(commit && importRow.getOverwrite().equals("false") &&
                     this.existingObsByObsHash.containsKey(importHash) &&
                     StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum - 1)) &&
                     !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum - 1))) {
@@ -684,6 +684,7 @@ public class ExperimentProcessor implements Processor {
                     StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum -1)) &&
                     !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1))) {
                 //observationByHash.get(importHash).getBrAPIObject().setValue(phenoCol.getString(numRows - rowNum -1));
+                //this.existingObsByObsHash.get(importHash).setObservationVariableName(phenoCol.name());
                 observationByHash.get(importHash).setState(ImportObjectState.MUTATED);
 
                 // add a change log entry when updating the value of an observation

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -44,6 +44,7 @@ import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapps.importer.daos.*;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
+import org.breedinginsight.brapps.importer.model.base.AdditionalInfo;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
 import org.breedinginsight.brapps.importer.model.imports.PendingImport;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
@@ -76,6 +77,8 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import static org.breedinginsight.brapps.importer.services.FileMappingUtil.EXPERIMENT_TEMPLATE_NAME;
 
 @Slf4j
 @Prototype
@@ -127,7 +130,7 @@ public class ExperimentProcessor implements Processor {
     private Map<String, PendingImportObject<BrAPIObservationUnit>> observationUnitByNameNoScope = null;
 
     private final Map<String, PendingImportObject<BrAPIObservation>> observationByHash = new HashMap<>();
-
+    private Map<String, BrAPIObservation> existingObsByObsHash = new HashMap<>();
     // existingGermplasmByGID is populated by getExistingBrapiData(), but not updated by the getNewBrapiData() method
     private Map<String, PendingImportObject<BrAPIGermplasm>> existingGermplasmByGID = null;
 
@@ -240,7 +243,7 @@ public class ExperimentProcessor implements Processor {
 
         log.debug("done processing experiment import");
         // Construct our response object
-        return generateStatisticsMap(importRows);
+        return generateStatisticsMap(importRows, phenotypeCols);
     }
 
     @Override
@@ -550,7 +553,7 @@ public class ExperimentProcessor implements Processor {
     private ValidationErrors validateFields(List<BrAPIImport> importRows, ValidationErrors validationErrors, Map<Integer, PendingImport> mappedBrAPIImport, List<Trait> referencedTraits, Program program,
                                             List<Column<?>> phenotypeCols, boolean commit) throws MissingRequiredInfoException, ApiException {
         //fetching any existing observations for any OUs in the import
-        Map<String, BrAPIObservation> existingObsByObsHash = fetchExistingObservations(referencedTraits, program);
+        this.existingObsByObsHash = fetchExistingObservations(referencedTraits, program);
         CaseInsensitiveMap<String, Trait> colVarMap = new CaseInsensitiveMap<>();
         for ( Trait trait: referencedTraits) {
             colVarMap.put(trait.getObservationVariableName(),trait);
@@ -572,7 +575,7 @@ public class ExperimentProcessor implements Processor {
 
             validateConditionallyRequired(validationErrors, rowNum, importRow, program, commit);
             validateObservationUnits(validationErrors, uniqueStudyAndObsUnit, rowNum, importRow);
-            validateObservations(validationErrors, rowNum, importRow, phenotypeCols, colVarMap, existingObsByObsHash);
+            validateObservations(validationErrors, rowNum, importRows.size(), importRow, phenotypeCols, colVarMap, commit);
         }
         return validationErrors;
     }
@@ -625,22 +628,45 @@ public class ExperimentProcessor implements Processor {
                                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    private void validateObservations(ValidationErrors validationErrors, int rowNum, ExperimentObservation importRow, List<Column<?>> phenotypeCols, CaseInsensitiveMap<String, Trait> colVarMap, Map<String, BrAPIObservation> existingObservations) {
+    private void validateObservations(ValidationErrors validationErrors,
+                                      int rowNum,
+                                      int numRows,
+                                      ExperimentObservation importRow,
+                                      List<Column<?>> phenotypeCols,
+                                      Map<String, Trait> colVarMap,
+                                      boolean commit) {
         phenotypeCols.forEach(phenoCol -> {
             var importHash = getImportObservationHash(importRow, phenoCol.name());
-            if(existingObservations.containsKey(importHash) && StringUtils.isNotBlank(phenoCol.getString(rowNum)) && !existingObservations.get(importHash).getValue().equals(phenoCol.getString(rowNum))) {
+
+            // error if import observation data already exists and user has not selected to overwrite
+            if(commit && !importRow.isOverwrite() &&
+                    this.existingObsByObsHash.containsKey(importHash) &&
+                    StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum - 1)) &&
+                    !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum - 1))) {
                 addRowError(
                         phenoCol.name(),
                         String.format("Value already exists for ObsUnitId: %s, Phenotype: %s", importRow.getObsUnitID(), phenoCol.name()),
                         validationErrors, rowNum
                 );
-            } else if(existingObservations.containsKey(importHash) && (StringUtils.isBlank(phenoCol.getString(rowNum)) || existingObservations.get(importHash).getValue().equals(phenoCol.getString(rowNum)))) {
-                BrAPIObservation existingObs = existingObservations.get(importHash);
+
+            // preview case where observation has already been committed and the import row ObsVar data differs from what
+            // had been saved prior to import
+            } else if (this.existingObsByObsHash.containsKey(importHash) &&
+                    StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum -1)) &&
+                    !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1))) {
+                observationByHash.get(importHash).setState(ImportObjectState.EXISTING);
+
+            // preview case where observation has already been committed and import ObsVar data is either empty or the
+            // same as has been committed prior to import
+            } else if(this.existingObsByObsHash.containsKey(importHash) &&
+                    (StringUtils.isBlank(phenoCol.getString(numRows - rowNum -1)) ||
+                            this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1)))) {
+                BrAPIObservation existingObs = this.existingObsByObsHash.get(importHash);
                 existingObs.setObservationVariableName(phenoCol.name());
                 observationByHash.get(importHash).setState(ImportObjectState.EXISTING);
                 observationByHash.get(importHash).setBrAPIObject(existingObs);
             } else {
-                validateObservationValue(colVarMap.get(phenoCol.name()), phenoCol.getString(rowNum), phenoCol.name(), validationErrors, rowNum);
+                validateObservationValue(colVarMap.get(phenoCol.name()), phenoCol.getString(numRows - rowNum -1), phenoCol.name(), validationErrors, rowNum);
 
                 //Timestamp validation
                 if(timeStampColByPheno.containsKey(phenoCol.name())) {
@@ -734,7 +760,7 @@ public class ExperimentProcessor implements Processor {
         }
     }
 
-    private Map<String, ImportPreviewStatistics> generateStatisticsMap(List<BrAPIImport> importRows) {
+    private Map<String, ImportPreviewStatistics> generateStatisticsMap(List<BrAPIImport> importRows, List<Column<?>> phenotypeCols) {
         // Data for stats.
         HashSet<String> environmentNameCounter = new HashSet<>(); // set of unique environment names
         HashSet<String> obsUnitsIDCounter = new HashSet<>(); // set of unique observation unit ID's
@@ -757,6 +783,15 @@ public class ExperimentProcessor implements Processor {
                                  .count()
         );
 
+        int numExistingObservations = Math.toIntExact(
+                this.observationByHash.values()
+                        .stream()
+                        .filter(preview -> preview != null && preview.getState() == ImportObjectState.EXISTING &&
+                                !StringUtils.isBlank(preview.getBrAPIObject()
+                                        .getValue()))
+                        .count()
+        );
+
         ImportPreviewStatistics environmentStats = ImportPreviewStatistics.builder()
                                                                           .newObjectCount(environmentNameCounter.size())
                                                                           .build();
@@ -769,12 +804,16 @@ public class ExperimentProcessor implements Processor {
         ImportPreviewStatistics observationStats = ImportPreviewStatistics.builder()
                                                                           .newObjectCount(numNewObservations)
                                                                           .build();
+        ImportPreviewStatistics existingObservationStats = ImportPreviewStatistics.builder()
+                .newObjectCount(numExistingObservations)
+                .build();
 
         return Map.of(
                 "Environments", environmentStats,
                 "Observation_Units", obdUnitStats,
                 "GIDs", gidStats,
-                "Observations", observationStats
+                "Observations", observationStats,
+                "Existing Observations", existingObservationStats
         );
     }
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -694,9 +694,6 @@ public class ExperimentProcessor implements Processor {
             } else if (this.existingObsByObsHash.containsKey(importHash) &&
                     StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum -1)) &&
                     !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1))) {
-                //observationByHash.get(importHash).getBrAPIObject().setValue(phenoCol.getString(numRows - rowNum -1));
-                //this.existingObsByObsHash.get(importHash).setObservationVariableName(phenoCol.name());
-                //observationByHash.get(importHash).setState(ImportObjectState.MUTATED);
 
                 // add a change log entry when updating the value of an observation
                 if (commit) {
@@ -717,7 +714,7 @@ public class ExperimentProcessor implements Processor {
                     if (pendingObservation.getAdditionalInfo() != null && !pendingObservation.getAdditionalInfo().has(BrAPIAdditionalInfoFields.CHANGELOG)) {
                         pendingObservation.getAdditionalInfo().add(BrAPIAdditionalInfoFields.CHANGELOG, new JsonArray());
                     }
-                    pendingObservation.getAdditionalInfo().get(BrAPIAdditionalInfoFields.CHANGELOG).getAsJsonArray().add(gson.toJson(change));
+                    pendingObservation.getAdditionalInfo().get(BrAPIAdditionalInfoFields.CHANGELOG).getAsJsonArray().add(gson.toJsonTree(change).getAsJsonObject());
                 }
 
             // preview case where observation has already been committed and import ObsVar data is either empty or the

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -691,8 +691,9 @@ public class ExperimentProcessor implements Processor {
                     BrAPIObservation pendingObservation = observationByHash.get(importHash).getBrAPIObject();
                     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd:hh-mm-ssZ");
                     String timestamp = formatter.format(OffsetDateTime.now());
+                    String reason = importRow.getOverwriteReason() != null ? importRow.getOverwriteReason() : "";
                     ChangeLogEntry change = new ChangeLogEntry(existingObsByObsHash.get(importHash).getValue(),
-                            importRow.getOverwriteReason(),
+                            reason,
                             user.getId(),
                             timestamp
                     );

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -270,6 +270,9 @@ public class ExperimentProcessor implements Processor {
         Map<String, BrAPITrial> mutatedTrialsById = ProcessorData
                 .getMutationsByObjectId(trialByNameNoScope, BrAPITrial::getTrialDbId);
 
+        Map<String, BrAPIObservation> mutatedObservationByDbId = ProcessorData
+                .getMutationsByObjectId(observationByHash, observation -> observation.getObservationDbId());
+
         List<ProgramLocationRequest> newLocations = ProcessorData.getNewObjects(this.locationByName)
                                                                  .stream()
                                                                  .map(location -> ProgramLocationRequest.builder()
@@ -388,6 +391,19 @@ public class ExperimentProcessor implements Processor {
                 throw new InternalServerException(e.getMessage(), e);
             }
         });
+
+        mutatedObservationByDbId.forEach((id, observation) ->  {
+            try {
+                brAPIObservationDAO.updateBrAPIObservation(id, observation, program.getId());
+            } catch (ApiException e) {
+                log.error("Error updating observation: " + Utilities.generateApiExceptionLogMessage(e), e);
+                throw new InternalServerException("Error saving experiment import", e);
+            } catch (Exception e) {
+                log.error("Error updating observation: ", e);
+                throw new InternalServerException(e.getMessage(), e);
+            }
+        });
+
         log.debug("experiment import complete");
 
     }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -683,7 +683,7 @@ public class ExperimentProcessor implements Processor {
             } else if (this.existingObsByObsHash.containsKey(importHash) &&
                     StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum -1)) &&
                     !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1))) {
-                observationByHash.get(importHash).getBrAPIObject().setValue(phenoCol.getString(numRows - rowNum -1));
+                //observationByHash.get(importHash).getBrAPIObject().setValue(phenoCol.getString(numRows - rowNum -1));
                 observationByHash.get(importHash).setState(ImportObjectState.MUTATED);
 
                 // add a change log entry when updating the value of an observation
@@ -843,11 +843,21 @@ public class ExperimentProcessor implements Processor {
         int numExistingObservations = Math.toIntExact(
                 this.observationByHash.values()
                         .stream()
-                        .filter(preview -> preview != null && (preview.getState() == ImportObjectState.EXISTING || preview.getState() == ImportObjectState.MUTATED) &&
+                        .filter(preview -> preview != null && preview.getState() == ImportObjectState.EXISTING &&
                                 !StringUtils.isBlank(preview.getBrAPIObject()
                                         .getValue()))
                         .count()
         );
+
+        int numMutatedObservations = Math.toIntExact(
+                this.observationByHash.values()
+                        .stream()
+                        .filter(preview -> preview != null && preview.getState() == ImportObjectState.MUTATED &&
+                                !StringUtils.isBlank(preview.getBrAPIObject()
+                                        .getValue()))
+                        .count()
+        );
+
 
         ImportPreviewStatistics environmentStats = ImportPreviewStatistics.builder()
                                                                           .newObjectCount(environmentNameCounter.size())
@@ -864,13 +874,17 @@ public class ExperimentProcessor implements Processor {
         ImportPreviewStatistics existingObservationStats = ImportPreviewStatistics.builder()
                 .newObjectCount(numExistingObservations)
                 .build();
+        ImportPreviewStatistics mutatedObservationStats = ImportPreviewStatistics.builder()
+                .newObjectCount(numMutatedObservations)
+                .build();
 
         return Map.of(
                 "Environments", environmentStats,
                 "Observation_Units", obdUnitStats,
                 "GIDs", gidStats,
                 "Observations", observationStats,
-                "Existing Observations", existingObservationStats
+                "Existing Observations", existingObservationStats,
+                "Mutated Observations", mutatedObservationStats
         );
     }
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -76,6 +76,7 @@ import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 
 import javax.inject.Inject;
+import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.OffsetDateTime;
@@ -93,7 +94,10 @@ import static org.breedinginsight.brapps.importer.services.FileMappingUtil.EXPER
 public class ExperimentProcessor implements Processor {
 
     private static final String NAME = "Experiment";
-    private static final String EXISTING_ENV = "Cannot create a new observation unit for existing environment: ";
+    private static final String EXISTING_ENV = "Cannot create new observation unit %s for existing environment %s." +
+            "If you’re trying to add these units to the experiment, please create a new environment" +
+            " with all appropriate experiment units (NOTE: this will generate new Observation Unit Ids " +
+            "for each experiment unit).";
     private static final String MISSING_OBS_UNIT_ID_ERROR = "Experiment Units are missing Observation Unit Id.<br/><br/>" +
             "If you’re trying to add these units to the experiment, please create a new environment" +
             " with all appropriate experiment units (NOTE: this will generate new Observation Unit Ids " +
@@ -948,9 +952,10 @@ public class ExperimentProcessor implements Processor {
                 List<BrAPIObservationUnit> existingOUs = brAPIObservationUnitDAO.getObservationUnitsForStudyDbId(studyPIO.getBrAPIObject().getStudyDbId(), program);
                 List<BrAPIObservationUnit> matchingOU = existingOUs.stream().filter(ou -> importRow.getExpUnitId().equals(Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getObservationUnitName(), program.getKey()))).collect(Collectors.toList());
                 if (matchingOU.isEmpty()) {
-                    throw new UnprocessableEntityException(EXISTING_ENV + Utilities.removeProgramKeyAndUnknownAdditionalData(studyPIO.getBrAPIObject().getStudyName(), program.getKey()));
+                    throw new UnprocessableEntityException(String.format(EXISTING_ENV, importRow.getExpUnitId(),
+                            Utilities.removeProgramKeyAndUnknownAdditionalData(studyPIO.getBrAPIObject().getStudyName(), program.getKey())));
                 } else {
-                    pio = new PendingImportObject<>(ImportObjectState.EXISTING, matchingOU.get(0));
+                    pio = new PendingImportObject<>(ImportObjectState.EXISTING, (BrAPIObservationUnit) Utilities.formatBrapiObjForDisplay(matchingOU.get(0), BrAPIObservationUnit.class, program));
                 }
             } else {
                 pio = new PendingImportObject<>(ImportObjectState.NEW, newObservationUnit, id);
@@ -961,16 +966,17 @@ public class ExperimentProcessor implements Processor {
     }
 
 
+
     private void fetchOrCreateObservationPIO(Program program,
-                                                                              User user,
-                                                                              ExperimentObservation importRow,
-                                                                              String variableName,
-                                                                              String value,
-                                                                              String timeStampValue,
-                                                                              boolean commit,
-                                                                              String seasonDbId,
-                                                                              PendingImportObject<BrAPIObservationUnit> obsUnitPIO,
-                                                                              List<Trait> referencedTraits) throws ApiException {
+                                             User user,
+                                             ExperimentObservation importRow,
+                                             String variableName,
+                                             String value,
+                                             String timeStampValue,
+                                             boolean commit,
+                                             String seasonDbId,
+                                             PendingImportObject<BrAPIObservationUnit> obsUnitPIO,
+                                             List<Trait> referencedTraits) throws ApiException {
         PendingImportObject<BrAPIObservation> pio;
         BrAPIObservation newObservation;
         String key = getImportObservationHash(importRow, variableName);
@@ -982,11 +988,11 @@ public class ExperimentProcessor implements Processor {
                 // prior observation with updated value
                 newObservation = gson.fromJson(gson.toJson(existingObsByObsHash.get(key)), BrAPIObservation.class);
                 newObservation.setValue(value);
-                pio = new PendingImportObject<>(ImportObjectState.MUTATED, newObservation);
+                pio = new PendingImportObject<>(ImportObjectState.MUTATED, (BrAPIObservation) Utilities.formatBrapiObjForDisplay(newObservation, BrAPIObservation.class, program));
             } else {
 
                 // prior observation
-                pio = new PendingImportObject<>(ImportObjectState.EXISTING, existingObsByObsHash.get(key));
+                pio = new PendingImportObject<>(ImportObjectState.EXISTING, (BrAPIObservation) Utilities.formatBrapiObjForDisplay(existingObsByObsHash.get(key), BrAPIObservation.class, program));
             }
 
             observationByHash.put(key, pio);
@@ -1566,7 +1572,7 @@ public class ExperimentProcessor implements Processor {
                                                .orElseThrow(() -> new IllegalStateException("External references wasn't found for study (dbid): " + existingStudy.getStudyDbId()));
         studyByName.put(
                 Utilities.removeProgramKeyAndUnknownAdditionalData(existingStudy.getStudyName(), program.getKey()),
-                new PendingImportObject<>(ImportObjectState.EXISTING, existingStudy, UUID.fromString(xref.getReferenceID())));
+                new PendingImportObject<>(ImportObjectState.EXISTING, (BrAPIStudy) Utilities.formatBrapiObjForDisplay(existingStudy, BrAPIStudy.class, program), UUID.fromString(xref.getReferenceID())));
     }
 
     private void initializeTrialsForExistingObservationUnits(Program program, Map<String, PendingImportObject<BrAPITrial>> trialByName) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/Processor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/Processor.java
@@ -55,7 +55,7 @@ public interface Processor {
     Map<String, ImportPreviewStatistics> process(ImportUpload upload, List<BrAPIImport> importRows,
                                                  Map<Integer, PendingImport> mappedBrAPIImport, Table data,
                                                  Program program, User user, boolean commit)
-            throws ValidatorException, MissingRequiredInfoException, ApiException;
+            throws Exception;
 
     /**
      * Given mapped brapi import with updates from prior dependencies, check if have everything needed

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/Processor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/Processor.java
@@ -23,7 +23,6 @@ import org.breedinginsight.brapps.importer.model.imports.PendingImport;
 import org.breedinginsight.brapps.importer.model.response.ImportPreviewStatistics;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
-import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
 import org.breedinginsight.services.exceptions.ValidatorException;
 import tech.tablesaw.api.Table;
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
@@ -18,7 +18,6 @@ package org.breedinginsight.brapps.importer.services.processors;
 
 import io.micronaut.context.annotation.Prototype;
 import lombok.extern.slf4j.Slf4j;
-import org.brapi.client.v2.model.exceptions.ApiException;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
 import org.breedinginsight.brapps.importer.model.imports.PendingImport;
@@ -27,7 +26,6 @@ import org.breedinginsight.brapps.importer.model.response.ImportPreviewStatistic
 import org.breedinginsight.brapps.importer.services.ImportStatusService;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
-import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
 import org.breedinginsight.services.exceptions.ValidatorException;
 import tech.tablesaw.api.Table;
 
@@ -53,7 +51,7 @@ public class ProcessorManager {
         this.statusService = statusService;
     }
 
-    public ImportPreviewResponse process(List<BrAPIImport> importRows, List<Processor> processors, Table data, Program program, ImportUpload upload, User user, boolean commit) throws ValidatorException, ApiException, MissingRequiredInfoException {
+    public ImportPreviewResponse process(List<BrAPIImport> importRows, List<Processor> processors, Table data, Program program, ImportUpload upload, User user, boolean commit) throws Exception {
 
         this.processors = processors;
 

--- a/src/main/java/org/breedinginsight/utilities/Utilities.java
+++ b/src/main/java/org/breedinginsight/utilities/Utilities.java
@@ -139,11 +139,11 @@ public class Utilities {
                 try {
                     field.setAccessible(true);
 
-                    // remove key of form [%s-%s]
+                    // remove either of possible key formats, [%s-%s] and [%s]
                     String valueSansKeyAndInfo = removeProgramKeyAndUnknownAdditionalData((String) field.get(brapiInstance), program.getKey());
-
-                    //remove key of form [%s]
                     String valueSansKey = removeProgramKey(valueSansKeyAndInfo, program.getKey());
+
+                    // set the value without key or additional info
                     field.set(brapiInstance, valueSansKey);
                 } catch (IllegalAccessException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/org/breedinginsight/utilities/Utilities.java
+++ b/src/main/java/org/breedinginsight/utilities/Utilities.java
@@ -20,7 +20,6 @@ package org.breedinginsight.utilities;
 import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.BrAPIExternalReference;
-import org.brapi.v2.model.pheno.BrAPIObservationUnit;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.model.Program;
 import org.flywaydb.core.api.migration.Context;

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -604,7 +604,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
         assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt(), "Returned data: " + result);
 
-        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Cannot create a new observation unit"));
+        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Cannot create new observation unit"));
     }
 
     @Test

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -86,6 +86,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ExperimentFileImportTest extends BrAPITest {
+    private static final String OVERWRITE = "overwrite";
 
     private FannyPack securityFp;
     private String mappingId;
@@ -603,7 +604,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
         assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt(), "Returned data: " + result);
 
-        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Experiment Units are missing Observation Unit Id."));
+        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Cannot create a new observation unit for existing environment:"));
     }
 
     @Test

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -604,7 +604,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
         assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt(), "Returned data: " + result);
 
-        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Cannot create a new observation unit for existing environment:"));
+        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Cannot create a new observation unit"));
     }
 
     @Test


### PR DESCRIPTION
# Description
**Story:** [BI-1830](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-1830)

The expected behavior of a user-supplied observation unit dbid superseding experiment, environment, and unit import values has apparently regressed. Fixing this regression will be handled in a separate card, and the parts of `ExperimentProcessor` involved commented out with TODOs. For this feature, observations are updated by filling out the complete import row with the ObsUnitID value blank.

1. Fields `overwrite` and `overwriteReason` added to `ExperimentObservation`
2. validation of existing observations updated
3. a `changeLog` entry is added to additionalInfo when committing updates to existing observations
4. `postBrapiData` was updated to both post new observations and put updates to existing observations



# Dependencies
bi-web `feature/BI-1265`

# Testing
1. import germplasm, observation variables, and a new experiment
2. alter some of the rows of the experiment import file
- change the values of a prior observation
- leave the rest (environment, experiment, unit #, etc.)of the import row the same
3. import the new file
4. view details of the experiment and verify any changes to observation values.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1830]: https://breedinginsight.atlassian.net/browse/BI-1830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ