### PR TITLE
BI-1910 - Allow Breeder to Upload a Genotype Sample File

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -55,3 +55,6 @@ AWS_ACCESS_KEY_ID=<access key>
 AWS_SECRET_KEY=<secret>
 AWS_GENO_BUCKET=<s3 bucket for genotypic data uploads>
 AWS_S3_ENDPOINT=<s3 endpoint, default https://s3.us-east-1.amazonaws.com>
+
+BRAPI_VENDOR_SUBMISSION_ENABLED=false #can a submission be sent to a vendor via BrAPI
+BRAPI_VENDOR_CHECK_FREQUENCY=1d #how often to check for vendor updates for sample submissions

--- a/localstack/startup_info.json
+++ b/localstack/startup_info.json
@@ -1,0 +1,1 @@
+[{"timestamp": "2022-11-17T17:01:36.401503", "localstack_version": "1.2.0", "localstack_ext_version": "1.2.0", "pro_activated": false}]

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <guava.version>31.0.1-jre</guava.version>
         <okhttp.version>4.9.3</okhttp.version>
         <mockito.version>4.3.1</mockito.version>
-        <brapi-java-client.version>2.1-SNAPSHOT</brapi-java-client.version>
+        <brapi-java-client.version>2.1.0</brapi-java-client.version>
         <commons-io.version>2.11.0</commons-io.version>
         <tika-app.version>2.2.1</tika-app.version>
         <!-- Version of apache-poi depends on version of tika. Tika uses these. -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Breeding Insight API</name>
+    <name>DeltaBreed API</name>
     <description></description>
     <url>https://breedinginsight.org</url>
 
@@ -57,6 +57,10 @@
             <name>David Phillips</name>
             <email>drp227@cornell.edu</email>
         </developer>
+        <developer>
+            <name>Matthew Mandych</name>
+            <email>mlm483@cornell.edu</email>
+        </developer>
     </developers>
 
     <properties>
@@ -85,7 +89,7 @@
         <guava.version>31.0.1-jre</guava.version>
         <okhttp.version>4.9.3</okhttp.version>
         <mockito.version>4.3.1</mockito.version>
-        <brapi-java-client.version>2.1.0</brapi-java-client.version>
+        <brapi-java-client.version>2.1-SNAPSHOT</brapi-java-client.version>
         <commons-io.version>2.11.0</commons-io.version>
         <tika-app.version>2.2.1</tika-app.version>
         <!-- Version of apache-poi depends on version of tika. Tika uses these. -->
@@ -145,6 +149,13 @@
         <repository> <!-- repo where micronaut snapshots are deployed -->
             <id>jfrog-snapshot</id>
             <url>https://oss.jfrog.org/artifactory/jfrog-dependencies</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>

--- a/settings.xml
+++ b/settings.xml
@@ -50,13 +50,6 @@
                     <snapshots><enabled>true</enabled></snapshots>
                 </repository>
                 <repository>
-                    <id>github-brapi</id>
-                    <name>GitHub Breeding Insight Apache Maven Packages</name>
-                    <url>https://maven.pkg.github.com/Breeding-Insight/brapi</url>
-                    <releases><enabled>true</enabled></releases>
-                    <snapshots><enabled>true</enabled></snapshots>
-                </repository>
-                <repository>
                     <id>github-fannypack</id>
                     <name>FannyPack github repository</name>
                     <url>https://maven.pkg.github.com/Kowalski-IO/fannypack</url>
@@ -70,11 +63,6 @@
     <servers>
         <server>
             <id>github-jooq</id>
-            <username>${GITHUB_ACTOR}</username>
-            <password>${GITHUB_TOKEN}</password>
-        </server>
-        <server>
-            <id>github-brapi</id>
             <username>${GITHUB_ACTOR}</username>
             <password>${GITHUB_TOKEN}</password>
         </server>

--- a/src/main/java/org/breedinginsight/api/model/PendingBrAPIImport.java
+++ b/src/main/java/org/breedinginsight/api/model/PendingBrAPIImport.java
@@ -1,4 +1,0 @@
-package org.breedinginsight.api.model;
-
-public class PendingBrAPIImport {
-}

--- a/src/main/java/org/breedinginsight/api/model/PendingBrAPIImport.java
+++ b/src/main/java/org/breedinginsight/api/model/PendingBrAPIImport.java
@@ -1,0 +1,4 @@
+package org.breedinginsight.api.model;
+
+public class PendingBrAPIImport {
+}

--- a/src/main/java/org/breedinginsight/api/v1/controller/geno/SampleSubmissionController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/geno/SampleSubmissionController.java
@@ -63,7 +63,7 @@ public class SampleSubmissionController {
     private final Gson gson;
 
     @Inject
-    public SampleSubmissionController(@Property(name = "brapi.vendors.submission-enabled") boolean brapiSubmissionEnabled, SampleSubmissionService sampleSubmissionService, ProgramService programService, SecurityService securityService, UserService userService) {
+    public SampleSubmissionController(@Property(name = "brapi.vendor-submission-enabled") boolean brapiSubmissionEnabled, SampleSubmissionService sampleSubmissionService, ProgramService programService, SecurityService securityService, UserService userService) {
         this.brapiSubmissionEnabled = brapiSubmissionEnabled;
         this.sampleSubmissionService = sampleSubmissionService;
         this.programService = programService;

--- a/src/main/java/org/breedinginsight/api/v1/controller/geno/SampleSubmissionController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/geno/SampleSubmissionController.java
@@ -1,0 +1,272 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.api.v1.controller.geno;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import io.micronaut.http.*;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.server.types.files.StreamedFile;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.rules.SecurityRule;
+import lombok.extern.slf4j.Slf4j;
+import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.v2.model.geno.BrAPIVendorOrderSubmission;
+import org.breedinginsight.api.auth.*;
+import org.breedinginsight.api.model.v1.response.DataResponse;
+import org.breedinginsight.api.model.v1.response.Response;
+import org.breedinginsight.api.model.v1.response.metadata.Metadata;
+import org.breedinginsight.api.model.v1.response.metadata.Pagination;
+import org.breedinginsight.api.model.v1.response.metadata.Status;
+import org.breedinginsight.api.model.v1.response.metadata.StatusCode;
+import org.breedinginsight.model.*;
+import org.breedinginsight.services.ProgramService;
+import org.breedinginsight.services.SampleSubmissionService;
+import org.breedinginsight.services.UserService;
+import org.breedinginsight.utilities.Utilities;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.validation.constraints.NotBlank;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Controller("/${micronaut.bi.api.version}")
+@Secured(SecurityRule.IS_AUTHENTICATED)
+public class SampleSubmissionController {
+    private final SampleSubmissionService sampleSubmissionService;
+    private final ProgramService programService;
+    private final SecurityService securityService;
+    private final UserService userService;
+
+    private final Gson gson;
+
+    @Inject
+    public SampleSubmissionController(SampleSubmissionService sampleSubmissionService, ProgramService programService, SecurityService securityService, UserService userService) {
+        this.sampleSubmissionService = sampleSubmissionService;
+        this.programService = programService;
+        this.securityService = securityService;
+        this.userService = userService;
+        this.gson = new Gson();
+    }
+
+    @Get("programs/{programId}/submissions")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ProgramSecured(roleGroups = ProgramSecuredRoleGroup.ALL)
+    public HttpResponse<Response<DataResponse<SampleSubmission>>> getProgramSampleSubmissions(@PathVariable UUID programId) {
+        Optional<Program> program = programService.getById(programId);
+        if(program.isEmpty()) {
+            log.info(String.format("programId not found: %s", programId.toString()));
+            return HttpResponse.notFound();
+        }
+
+        List<SampleSubmission> submissions = sampleSubmissionService.getProgramSubmissions(program.get());
+        Metadata metadata = new Metadata(new Pagination(submissions.size(), submissions.size(), 1, 0),
+                List.of(new Status(StatusCode.INFO, "Successful Query")));
+        Response<DataResponse<SampleSubmission>> response = new Response<>(metadata, new DataResponse<>(submissions));
+        return HttpResponse.ok(response);
+    }
+
+    @Get("programs/{programId}/submissions/{submissionId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ProgramSecured(roleGroups = ProgramSecuredRoleGroup.ALL)
+    public HttpResponse<Response<SampleSubmission>> getSubmissionById(@PathVariable UUID programId, @PathVariable UUID submissionId, @QueryValue(value = "details", defaultValue = "false") @Nullable Boolean fetchDetails) {
+        Optional<Program> program = programService.getById(programId);
+        if(program.isEmpty()) {
+            log.info(String.format("programId not found: %s", programId.toString()));
+            return HttpResponse.notFound();
+        }
+
+        try {
+            Optional<SampleSubmission> submission = sampleSubmissionService.getSampleSubmission(program.get(), submissionId, fetchDetails);
+
+            if(submission.isEmpty()) {
+                return HttpResponse.notFound();
+            }
+
+            Metadata metadata = new Metadata(new Pagination(1, 1, 1, 0),
+                    List.of(new Status(StatusCode.INFO, "Successful Query")));
+            Response<SampleSubmission> response = new Response<>(metadata, submission.get());
+            return HttpResponse.ok(response);
+        } catch (ApiException e) {
+            log.error(Utilities.generateApiExceptionLogMessage(e), e);
+            return HttpResponse.serverError();
+        }
+    }
+
+    @Put("programs/{programId}/submissions/{submissionId}/status")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ProgramSecured(roles = {ProgramSecuredRole.SYSTEM_ADMIN})
+    public HttpResponse<Response<SampleSubmission>> updateSubmissionStatus(@PathVariable UUID programId, @PathVariable UUID submissionId, @Body String body) {
+        Optional<Program> program = programService.getById(programId);
+        if(program.isEmpty()) {
+            log.info(String.format("programId not found: %s", programId.toString()));
+            return HttpResponse.notFound();
+        }
+
+        AuthenticatedUser actingUser = securityService.getUser();
+        Optional<User> user = userService.getById(actingUser.getId());
+        if (user.isEmpty()) {
+            return HttpResponse.unauthorized();
+        }
+
+        SampleSubmission.Status status = SampleSubmission.Status.fromValue(gson.fromJson(body, JsonObject.class).get("status").getAsString());
+        if(status == null) {
+            HttpResponse response = HttpResponse.badRequest("Unrecognized status");
+            return response;
+        }
+
+        try {
+            Optional<SampleSubmission> submission = sampleSubmissionService.updateSubmissionStatus(program.get(), submissionId, status, user.get());
+
+            if(submission.isEmpty()) {
+                return HttpResponse.notFound();
+            }
+
+            Metadata metadata = new Metadata(new Pagination(1, 1, 1, 0),
+                    List.of(new Status(StatusCode.INFO, "Successful Update")));
+            Response<SampleSubmission> response = new Response<>(metadata, submission.get());
+            return HttpResponse.ok(response);
+        } catch (ApiException e) {
+            log.error(Utilities.generateApiExceptionLogMessage(e), e);
+            return HttpResponse.serverError();
+        }
+    }
+
+
+    @Get("/programs/{programId}/submissions/{submissionId}/dart")
+    @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
+    @Produces(value={"text/csv", "application/vnd.ms-excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "application/octet-stream"})
+    public HttpResponse<StreamedFile> generateDArTFile(@PathVariable UUID programId, @PathVariable UUID submissionId) {
+        try {
+            Optional<Program> program = programService.getById(programId);
+            if(program.isEmpty()) {
+                return HttpResponse.notFound();
+            }
+            Optional<DownloadFile> downloadFile = sampleSubmissionService.generateDArTFile(program.get(), submissionId);
+            if(downloadFile.isEmpty()) {
+                return HttpResponse.notFound();
+            }
+            HttpResponse<StreamedFile> response = HttpResponse
+                    .ok(downloadFile.get().getStreamedFile())
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + downloadFile.get().getFileName());
+            return response;
+        } catch (ApiException e) {
+            log.error(Utilities.generateApiExceptionLogMessage(e), e);
+            return HttpResponse.serverError();
+        } catch (IOException e) {
+            log.error("Error generating DArT file", e);
+            HttpResponse response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, "Error generating DArT file").contentType(MediaType.TEXT_PLAIN).body("Error generating DArT file");
+            return response;
+        }
+    }
+
+    @Get("/programs/{programId}/submissions/{submissionId}/lookup")
+    @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
+    @Produces(value={"text/csv", "application/vnd.ms-excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "application/octet-stream"})
+    public HttpResponse<StreamedFile> generateLookupFile(@PathVariable UUID programId, @PathVariable UUID submissionId) {
+        try {
+            Optional<Program> program = programService.getById(programId);
+            if(program.isEmpty()) {
+                return HttpResponse.notFound();
+            }
+            Optional<DownloadFile> downloadFile = sampleSubmissionService.generateLookupFile(program.get(), submissionId);
+            if(downloadFile.isEmpty()) {
+                return HttpResponse.notFound();
+            }
+            HttpResponse<StreamedFile> response = HttpResponse
+                    .ok(downloadFile.get().getStreamedFile())
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + downloadFile.get().getFileName());
+            return response;
+        } catch (ApiException e) {
+            log.error(Utilities.generateApiExceptionLogMessage(e), e);
+            return HttpResponse.serverError();
+        } catch (IOException e) {
+            log.error("Error generating lookup file", e);
+            HttpResponse response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, "Error generating lookup file").contentType(MediaType.TEXT_PLAIN).body("Error generating lookup file");
+            return response;
+        }
+    }
+
+    @Post("programs/{programId}/submissions/{submissionId}/submit")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ProgramSecured(roles = {ProgramSecuredRole.SYSTEM_ADMIN})
+    public HttpResponse<Response<BrAPIVendorOrderSubmission>> submitOrder(@PathVariable UUID programId, @PathVariable UUID submissionId, @QueryValue(value = "vendor") @NotBlank String vendorName) {
+        try {
+            GenotypeVendor vendor = GenotypeVendor.fromName(vendorName);
+            if(vendor != null) {
+                Optional<Program> program = programService.getById(programId);
+                if (program.isEmpty()) {
+                    return HttpResponse.notFound();
+                }
+
+                AuthenticatedUser actingUser = securityService.getUser();
+                Optional<User> user = userService.getById(actingUser.getId());
+                if (user.isEmpty()) {
+                    return HttpResponse.unauthorized();
+                }
+
+                Optional<BrAPIVendorOrderSubmission> order = sampleSubmissionService.submitOrder(program.get(), submissionId, user.get(), vendor);
+                if (order.isEmpty()) {
+                    return HttpResponse.notFound();
+                }
+
+                Metadata metadata = new Metadata(new Pagination(1, 1, 1, 0),
+                        List.of(new Status(StatusCode.INFO, "Successful submission")));
+                Response<BrAPIVendorOrderSubmission> response = new Response<>(metadata, order.get());
+                return HttpResponse.ok(response);
+            } else {
+                HttpResponse response = HttpResponse.badRequest("Unrecognized vendor");
+                return response;
+            }
+        } catch (ApiException e) {
+            log.error(Utilities.generateApiExceptionLogMessage(e), e);
+            return HttpResponse.serverError();
+        }
+    }
+
+    @Get("programs/{programId}/submissions/{submissionId}/status")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ProgramSecured(roles = {ProgramSecuredRole.SYSTEM_ADMIN})
+    public HttpResponse<Response<SampleSubmission>> checkVendorStatus(@PathVariable UUID programId, @PathVariable UUID submissionId) {
+        Optional<Program> program = programService.getById(programId);
+        if(program.isEmpty()) {
+            log.info(String.format("programId not found: %s", programId.toString()));
+            return HttpResponse.notFound();
+        }
+
+        try {
+            Optional<SampleSubmission> submission = sampleSubmissionService.checkVendorStatus(program.get(), submissionId);
+
+            if(submission.isEmpty()) {
+                return HttpResponse.notFound();
+            }
+
+            Metadata metadata = new Metadata(new Pagination(1, 1, 1, 0),
+                    List.of(new Status(StatusCode.INFO, "Successful Query")));
+            Response<SampleSubmission> response = new Response<>(metadata, submission.get());
+            return HttpResponse.ok(response);
+        } catch (ApiException e) {
+            log.error(Utilities.generateApiExceptionLogMessage(e), e);
+            return HttpResponse.serverError();
+        }
+    }
+}

--- a/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
@@ -48,4 +48,10 @@ public final class BrAPIAdditionalInfoFields {
 	public static final String TREATMENTS = "treatments";
     public static final String GID = "gid";
     public static final String ENV_YEAR = "envYear";
+    public static final String GERMPLASM_UUID = "germplasmId";
+    public static final String SAMPLE_ORGANISM = "organism";
+    public static final String SAMPLE_SPECIES = "species";
+    public static final String OBS_UNIT_ID = "obsUnitID";
+    public static final String GERMPLASM_NAME = "germplasmName";
+    public static final String SUBMISSION_NAME = "submissionName";
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -29,9 +29,8 @@ import org.breedinginsight.model.Program;
 import org.breedinginsight.model.*;
 import org.breedinginsight.services.exceptions.DoesNotExistException;
 import org.breedinginsight.services.parsers.experiment.ExperimentFileColumns;
-import org.breedinginsight.services.writers.CSVWriter;
-import org.breedinginsight.services.writers.ExcelWriter;
 import org.breedinginsight.utilities.IntOrderComparator;
+import org.breedinginsight.utilities.FileUtil;
 import org.breedinginsight.utilities.Utilities;
 import org.jetbrains.annotations.NotNull;
 
@@ -242,7 +241,7 @@ public class BrAPITrialService {
             for (Map.Entry<String, List<Map<String, Object>>> entry: rowsByStudyId.entrySet()) {
                 List<Map<String, Object>> rows = entry.getValue();
                 sortDefaultForExportRows(rows);
-                StreamedFile streamedFile = writeToStreamedFile(columns, rows, fileType, SHEET_NAME);
+                StreamedFile streamedFile = FileUtil.writeToStreamedFile(columns, rows, fileType, SHEET_NAME);
                 String name = makeFileName(experiment, program, studyByDbId.get(entry.getKey()).getStudyName()) + fileType.getExtension();
                 // Add to file list.
                 files.add(new DownloadFile(name, streamedFile));
@@ -261,7 +260,7 @@ public class BrAPITrialService {
             List<Map<String, Object>> exportRows = new ArrayList<>(rowByOUId.values());
             sortDefaultForExportRows(exportRows);
             // write export data to requested file format
-            StreamedFile streamedFile = writeToStreamedFile(columns, exportRows, fileType, SHEET_NAME);
+            StreamedFile streamedFile = FileUtil.writeToStreamedFile(columns, exportRows, fileType, SHEET_NAME);
             // Set filename.
             String envFilenameFragment = params.getEnvironments() == null ? "All Environments" : params.getEnvironments();
             String fileName = makeFileName(experiment, program, envFilenameFragment) + fileType.getExtension();
@@ -269,14 +268,6 @@ public class BrAPITrialService {
         }
 
         return downloadFile;
-    }
-
-    private StreamedFile writeToStreamedFile(List<Column> columns, List<Map<String, Object>> data, FileType extension, String sheetName) throws IOException {
-        if (extension.equals(FileType.CSV)){
-            return CSVWriter.writeToDownload(columns, data, extension);
-        } else {
-            return ExcelWriter.writeToDownload(sheetName, columns, data, extension);
-        }
     }
 
     private StreamedFile zipFiles(List<DownloadFile> files) throws IOException {

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIPlateDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPIPlateDAO.java
@@ -1,0 +1,98 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapps.importer.daos;
+
+import io.micronaut.context.annotation.Property;
+import lombok.extern.slf4j.Slf4j;
+import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.client.v2.modules.genotype.PlatesApi;
+import org.brapi.v2.model.geno.BrAPIPlate;
+import org.brapi.v2.model.geno.request.BrAPIPlateNewRequest;
+import org.brapi.v2.model.geno.request.BrAPIPlateSearchRequest;
+import org.breedinginsight.brapps.importer.model.ImportUpload;
+import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.daos.ProgramDAO;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.services.brapi.BrAPIEndpointProvider;
+import org.breedinginsight.utilities.BrAPIDAOUtil;
+import org.breedinginsight.utilities.Utilities;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Singleton
+public class BrAPIPlateDAO {
+
+    private final String referenceSource;
+
+    private final ProgramDAO programDAO;
+    private final ImportDAO importDAO;
+    private final BrAPIDAOUtil brAPIDAOUtil;
+    private final BrAPIEndpointProvider brAPIEndpointProvider;
+
+    @Inject
+    public BrAPIPlateDAO(ProgramDAO programDAO,
+                         ImportDAO importDAO,
+                         BrAPIDAOUtil brAPIDAOUtil,
+                         BrAPIEndpointProvider brAPIEndpointProvider,
+                         @Property(name = "brapi.server.reference-source") String referenceSource) {
+        this.referenceSource = referenceSource;
+        this.programDAO = programDAO;
+        this.importDAO = importDAO;
+        this.brAPIDAOUtil = brAPIDAOUtil;
+        this.brAPIEndpointProvider = brAPIEndpointProvider;
+    }
+
+    public List<BrAPIPlate> createPlates(Program program, List<BrAPIPlate> platesToSave, ImportUpload upload) throws ApiException {
+        PlatesApi platesApi = brAPIEndpointProvider.get(programDAO.getSampleClient(program.getId()), PlatesApi.class);
+        List<BrAPIPlateNewRequest> newPlatesRequests = platesToSave.stream()
+                                                                   .map(plate -> new BrAPIPlateNewRequest().additionalInfo(plate.getAdditionalInfo())
+                                                                                                           .externalReferences(plate.getExternalReferences())
+                                                                                                           .plateBarcode(plate.getPlateBarcode())
+                                                                                                           .plateFormat(plate.getPlateFormat())
+                                                                                                           .plateName(plate.getPlateName())
+                                                                                                           .programDbId(plate.getProgramDbId())
+                                                                                                           .sampleType(plate.getSampleType())
+                                                                                                           .studyDbId(plate.getStudyDbId())
+                                                                                                           .trialDbId(plate.getTrialDbId())
+                                                                   )
+                                                                   .collect(Collectors.toList());
+        return brAPIDAOUtil.post(newPlatesRequests, upload, platesApi::platesPost, importDAO::update);
+    }
+
+    public List<BrAPIPlate> readPlatesByIds(Program program, List<String> plateExternalIds) throws ApiException {
+        PlatesApi platesApi = brAPIEndpointProvider.get(programDAO.getSampleClient(program.getId()), PlatesApi.class);
+
+        BrAPIPlateSearchRequest request = new BrAPIPlateSearchRequest().externalReferenceIDs(plateExternalIds)
+                                                                       .externalReferenceSources(List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PLATES)));
+
+        return brAPIDAOUtil.search(platesApi::searchPlatesPost, platesApi::searchPlatesSearchResultsDbIdGet, request);
+    }
+
+    public List<BrAPIPlate> readPlatesBySubmissionIds(Program program, List<String> submissionExternalIds) throws ApiException {
+        PlatesApi platesApi = brAPIEndpointProvider.get(programDAO.getSampleClient(program.getId()), PlatesApi.class);
+
+        BrAPIPlateSearchRequest request = new BrAPIPlateSearchRequest().externalReferenceIDs(submissionExternalIds)
+                                                                       .externalReferenceSources(List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PLATE_SUBMISSIONS)));
+
+        return brAPIDAOUtil.search(platesApi::searchPlatesPost, platesApi::searchPlatesSearchResultsDbIdGet, request);
+    }
+}

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPISampleDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPISampleDAO.java
@@ -1,0 +1,105 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapps.importer.daos;
+
+import io.micronaut.context.annotation.Property;
+import lombok.extern.slf4j.Slf4j;
+import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.client.v2.modules.genotype.SamplesApi;
+import org.brapi.v2.model.geno.BrAPISample;
+import org.brapi.v2.model.geno.request.BrAPISampleSearchRequest;
+import org.breedinginsight.brapps.importer.model.ImportUpload;
+import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.daos.ProgramDAO;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.services.brapi.BrAPIEndpointProvider;
+import org.breedinginsight.utilities.BrAPIDAOUtil;
+import org.breedinginsight.utilities.Utilities;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Singleton
+public class BrAPISampleDAO {
+
+    private final String referenceSource;
+
+    private final ProgramDAO programDAO;
+    private final ImportDAO importDAO;
+    private final BrAPIDAOUtil brAPIDAOUtil;
+    private final BrAPIEndpointProvider brAPIEndpointProvider;
+
+    @Inject
+    public BrAPISampleDAO(ProgramDAO programDAO,
+                          ImportDAO importDAO,
+                          BrAPIDAOUtil brAPIDAOUtil,
+                          BrAPIEndpointProvider brAPIEndpointProvider,
+                          @Property(name = "brapi.server.reference-source") String referenceSource) {
+        this.referenceSource = referenceSource;
+        this.programDAO = programDAO;
+        this.importDAO = importDAO;
+        this.brAPIDAOUtil = brAPIDAOUtil;
+        this.brAPIEndpointProvider = brAPIEndpointProvider;
+    }
+
+    public List<BrAPISample> createSamples(Program program, List<BrAPISample> samplesToSave, ImportUpload upload) throws ApiException {
+        SamplesApi samplesApi = brAPIEndpointProvider.get(programDAO.getSampleClient(program.getId()), SamplesApi.class);
+
+        return brAPIDAOUtil.post(samplesToSave, upload, samplesApi::samplesPost, importDAO::update);
+    }
+
+    public List<BrAPISample> readSamplesByIds(Program program, List<String> sampleExternalIds) throws ApiException {
+        if(sampleExternalIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        BrAPISampleSearchRequest searchRequest = new BrAPISampleSearchRequest().externalReferenceIDs(sampleExternalIds)
+                                                                               .externalReferenceSources(List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.SAMPLES)));
+
+        SamplesApi samplesApi = brAPIEndpointProvider.get(programDAO.getSampleClient(program.getId()), SamplesApi.class);
+        return brAPIDAOUtil.search(samplesApi::searchSamplesPost, samplesApi::searchSamplesSearchResultsDbIdGet, searchRequest);
+    }
+
+    public List<BrAPISample> readSamplesByPlateIds(Program program, List<String> plateExternalIds) throws ApiException {
+        if(plateExternalIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        BrAPISampleSearchRequest searchRequest = new BrAPISampleSearchRequest().externalReferenceIDs(plateExternalIds)
+                                                                               .externalReferenceSources(List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PLATES)));
+
+        SamplesApi samplesApi = brAPIEndpointProvider.get(programDAO.getSampleClient(program.getId()), SamplesApi.class);
+        return brAPIDAOUtil.search(samplesApi::searchSamplesPost, samplesApi::searchSamplesSearchResultsDbIdGet, searchRequest);
+    }
+
+    public List<BrAPISample> readSamplesBySubmissionIds(Program program, List<String> submissionExternalIds) throws ApiException {
+        if(submissionExternalIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        BrAPISampleSearchRequest searchRequest = new BrAPISampleSearchRequest().externalReferenceIDs(submissionExternalIds)
+                                                                               .externalReferenceSources(List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PLATE_SUBMISSIONS)));
+
+        SamplesApi samplesApi = brAPIEndpointProvider.get(programDAO.getSampleClient(program.getId()), SamplesApi.class);
+        return brAPIDAOUtil.search(samplesApi::searchSamplesPost, samplesApi::searchSamplesSearchResultsDbIdGet, searchRequest);
+    }
+}

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
@@ -30,24 +30,24 @@ import tech.tablesaw.api.Table;
 
 import java.util.List;
 
-public abstract class BrAPIImportService {
-    public String getImportTypeId() {return null;}
-    public BrAPIImport getImportClass() {return null;}
-    public String getInvalidIntegerMsg(String columnName) {
+public interface BrAPIImportService {
+    String getImportTypeId();
+    BrAPIImport getImportClass();
+    default String getInvalidIntegerMsg(String columnName) {
         return String.format("Column name \"%s\" must be integer type, but non-integer type provided.", columnName);
     }
-    public String getBlankRequiredFieldMsg(String fieldName) {
+    default String getBlankRequiredFieldMsg(String fieldName) {
         return String.format("Required field \"%s\" cannot contain empty values", fieldName);
     }
-    public String getMissingColumnMsg(String columnName) {
+    default String getMissingColumnMsg(String columnName) {
         return String.format("Column name \"%s\" does not exist in file", columnName);
     }
-    public String getMissingUserInputMsg(String fieldName) {
+    default String getMissingUserInputMsg(String fieldName) {
         return String.format("User input, \"%s\" is required", fieldName);
     }
-    public String getWrongUserInputDataTypeMsg(String fieldName, String typeName) {
+    default String getWrongUserInputDataTypeMsg(String fieldName, String typeName) {
         return String.format("User input, \"%s\" must be an %s", fieldName, typeName);
     }
-    public ImportPreviewResponse process(List<BrAPIImport> brAPIImports, Table data, Program program, ImportUpload upload, User user, Boolean commit)
-            throws UnprocessableEntityException, DoesNotExistException, ValidatorException, ApiException, MissingRequiredInfoException {return null;}
+    ImportPreviewResponse process(List<BrAPIImport> brAPIImports, Table data, Program program, ImportUpload upload, User user, Boolean commit)
+            throws UnprocessableEntityException, DoesNotExistException, ValidatorException, ApiException, MissingRequiredInfoException;
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/PendingImport.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/PendingImport.java
@@ -21,9 +21,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.brapi.v2.model.core.BrAPILocation;
 import org.brapi.v2.model.core.BrAPIStudy;
 import org.brapi.v2.model.core.BrAPITrial;
+import org.brapi.v2.model.geno.BrAPIPlate;
+import org.brapi.v2.model.geno.BrAPISample;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
@@ -44,6 +45,8 @@ public class PendingImport {
     private PendingImportObject<BrAPIStudy> study;
     private PendingImportObject<BrAPIObservationUnit> observationUnit;
     private List<PendingImportObject<BrAPIObservation>> observations = new ArrayList<>();
+    private PendingImportObject<BrAPIPlate> plate;
+    private PendingImportObject<BrAPISample> sample;
 
     @JsonIgnore
     public PendingImportObject<BrAPIObservation> getObservation() {

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentImportService.java
@@ -39,7 +39,7 @@ import java.util.List;
 
 @Singleton
 @Slf4j
-public class ExperimentImportService extends BrAPIImportService {
+public class ExperimentImportService implements BrAPIImportService {
 
     private final String IMPORT_TYPE_ID = "ExperimentImport";
 

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/germplasm/GermplasmImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/germplasm/GermplasmImportService.java
@@ -39,7 +39,7 @@ import java.util.*;
 
 @Singleton
 @Slf4j
-public class GermplasmImportService extends BrAPIImportService {
+public class GermplasmImportService implements BrAPIImportService {
 
     private final String IMPORT_TYPE_ID = "GermplasmImport";
 

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/sample/SampleSubmissionImport.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/sample/SampleSubmissionImport.java
@@ -1,0 +1,194 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapps.importer.model.imports.sample;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.geno.BrAPIPlate;
+import org.brapi.v2.model.geno.BrAPIPlateFormat;
+import org.brapi.v2.model.geno.BrAPISample;
+import org.brapi.v2.model.geno.BrAPISampleTypeEnum;
+import org.brapi.v2.model.germ.BrAPIGermplasm;
+import org.brapi.v2.model.pheno.BrAPIObservationUnit;
+import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
+import org.breedinginsight.brapps.importer.model.config.*;
+import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
+import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.model.User;
+import org.breedinginsight.utilities.Utilities;
+
+import java.util.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ImportConfigMetadata(id = "SampleImport", name = "Sample Import",
+        description = "This import is used to create Genotype Samples")
+public class SampleSubmissionImport implements BrAPIImport {
+
+    private static final String SAMPLE_NAME_FORMAT = "%s__%s_%s%s";
+
+    @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
+    @ImportFieldMetadata(id = "plateId", name = Columns.PLATE_ID, description = "The ID which uniquely identifies this plate to the client making the request")
+    private String plateId;
+
+    @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
+    @ImportFieldMetadata(id = "row", name = Columns.ROW, description = "The Row identifier for this samples location in the plate, ex: B")
+    private String row;
+
+    @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
+    @ImportFieldMetadata(id = "column", name = Columns.COLUMN, description = "The Column identifier for this samples location in the plate, ex: 6")
+    private String column;
+
+    @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
+    @ImportFieldMetadata(id = "organism", name = Columns.ORGANISM, description = "Scientific organism name")
+    private String organism;
+
+    @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
+    @ImportFieldMetadata(id = "species", name = Columns.SPECIES, description = "Scientific species name")
+    private String species;
+
+    @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
+    @ImportFieldMetadata(id = "germplasmName", name = Columns.GERMPLASM_NAME, description = "Name of germplasm")
+    private String germplasmName;
+
+    @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
+    @ImportFieldMetadata(id = "gid", name = Columns.GERMPLASM_GID, description = "Unique germplasm identifier")
+    private String gid;
+
+    @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
+    @ImportFieldMetadata(id = "obsUnitId", name = Columns.OBS_UNIT_ID, description = "The Observation Unit that this sample was collected from")
+    private String obsUnitId;
+
+    @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
+    @ImportFieldMetadata(id = "tissue", name = Columns.TISSUE, description = "The type of tissue in this sample. List of accepted tissue types can be found in the Vendor Specs.")
+    private String tissue;
+
+    @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
+    @ImportFieldMetadata(id = "comment", name = Columns.COMMENT, description = "Generic comments about this sample for the vendor")
+    private String comment;
+
+    @ImportFieldType(type= ImportFieldTypeEnum.TEXT, collectTime = ImportCollectTimeEnum.UPLOAD)
+    @ImportMappingRequired
+    @ImportFieldMetadata(id="submissionName", name="Submission Name", description = "Name of the submission imported.")
+    private String submissionName;
+
+    public static final class Columns {
+        public static final String PLATE_ID = "PlateID";
+        public static final String ROW = "Row";
+        public static final String COLUMN = "Column";
+        public static final String ORGANISM = "Organism";
+        public static final String SPECIES = "Species";
+        public static final String GERMPLASM_NAME = "Germplasm Name";
+        public static final String GERMPLASM_GID = "Germplasm GID";
+        public static final String TISSUE = "Tissue";
+        public static final String COMMENT = "Comment";
+        public static final String OBS_UNIT_ID = "ObsUnitID";
+    }
+
+    public BrAPISample constructBrAPISample(boolean commit, Program program, User user, BrAPIPlate plate, String referenceSource, String submissionId, BrAPIGermplasm germplasm, BrAPIObservationUnit ou) {
+        List<BrAPIExternalReference> xrefs = new ArrayList<>();
+        xrefs.add(new BrAPIExternalReference().referenceSource(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS))
+                                              .referenceId(program.getId()
+                                                                  .toString()));
+        String germXrefSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.GERMPLASM);
+        xrefs.add(germplasm.getExternalReferences()
+                           .stream()
+                           .filter(xref -> xref.getReferenceSource().equals(referenceSource) || xref.getReferenceSource().equals(germXrefSource))
+                           .findFirst()
+                           .orElseThrow(() -> new IllegalStateException(String.format("Germplasm %s doesn't have an xref! -> %s", germplasm.getAccessionNumber(), germplasm.toString()))).referenceSource(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.GERMPLASM)));
+        if(commit) {
+            xrefs.add(new BrAPIExternalReference().referenceSource(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.SAMPLES))
+                                                  .referenceId(UUID.randomUUID().toString()));
+            xrefs.add(Utilities.getExternalReference(plate.getExternalReferences(), Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PLATES))
+                               .get());
+        }
+        if (submissionId != null) {
+            xrefs.add(new BrAPIExternalReference().referenceSource(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PLATE_SUBMISSIONS))
+                                                  .referenceId(submissionId));
+        }
+
+        Map<String, String> createdBy = new HashMap<>();
+        createdBy.put(BrAPIAdditionalInfoFields.CREATED_BY_USER_ID,
+                      user.getId().toString());
+        createdBy.put(BrAPIAdditionalInfoFields.CREATED_BY_USER_NAME, user.getName());
+
+        BrAPISample brAPISample = new BrAPISample()
+                .putAdditionalInfoItem(BrAPIAdditionalInfoFields.CREATED_BY, createdBy)
+                .putAdditionalInfoItem(BrAPIAdditionalInfoFields.SAMPLE_SPECIES, species)
+                .putAdditionalInfoItem(BrAPIAdditionalInfoFields.SAMPLE_ORGANISM, organism)
+                .putAdditionalInfoItem(BrAPIAdditionalInfoFields.GID, germplasm.getAccessionNumber())
+                .putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_NAME, germplasm.getDefaultDisplayName())
+                .externalReferences(xrefs)
+                .plateName(plateId)
+                .plateDbId(plate.getPlateDbId())
+                .sampleName(String.format(SAMPLE_NAME_FORMAT, germplasm.getDefaultDisplayName(), plate.getPlateName(), row, column))
+                .germplasmDbId(germplasm.getGermplasmDbId())
+                .row(row)
+                .column(Integer.valueOf(column))
+                .tissueType(tissue)
+                .sampleDescription(comment);
+
+        if (ou != null) {
+            brAPISample
+                    .putAdditionalInfoItem(BrAPIAdditionalInfoFields.OBS_UNIT_ID,
+                                           Utilities.getExternalReference(ou.getExternalReferences(), Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.OBSERVATION_UNITS))
+                                                    .get()
+                                                    .getReferenceId())
+                    .observationUnitDbId(ou.getObservationUnitDbId());
+        }
+
+        return brAPISample;
+    }
+
+    public BrAPIPlate constructBrAPIPlate(boolean commit, Program program, User user, String referenceSource, String submissionId) {
+        List<BrAPIExternalReference> xrefs = new ArrayList<>();
+        xrefs.add(new BrAPIExternalReference().referenceSource(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS))
+                                              .referenceId(program.getId()
+                                                                  .toString()));
+
+        BrAPIPlate brAPIPlate = new BrAPIPlate();
+        if(commit) {
+            xrefs.add(new BrAPIExternalReference().referenceSource(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PLATES))
+                                                  .referenceId(UUID.randomUUID().toString()));
+        }
+        if (submissionId != null) {
+            xrefs.add(new BrAPIExternalReference().referenceSource(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PLATE_SUBMISSIONS))
+                                                  .referenceId(submissionId));
+            brAPIPlate.putAdditionalInfoItem(BrAPIAdditionalInfoFields.SUBMISSION_NAME, submissionName);
+        }
+        Map<String, String> createdBy = new HashMap<>();
+        createdBy.put(BrAPIAdditionalInfoFields.CREATED_BY_USER_ID,
+                      user.getId()
+                          .toString());
+        createdBy.put(BrAPIAdditionalInfoFields.CREATED_BY_USER_NAME, user.getName());
+
+
+
+        return brAPIPlate
+                .externalReferences(xrefs)
+                .putAdditionalInfoItem(BrAPIAdditionalInfoFields.CREATED_BY, createdBy)
+                .plateName(plateId)
+                .sampleType(BrAPISampleTypeEnum.fromValue(tissue.toUpperCase()))
+                .plateFormat(BrAPIPlateFormat.PLATE_96);
+
+    }
+}

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/sample/SampleSubmissionImport.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/sample/SampleSubmissionImport.java
@@ -143,7 +143,7 @@ public class SampleSubmissionImport implements BrAPIImport {
                 .plateDbId(plate.getPlateDbId())
                 .sampleName(generateSampleName(germplasm, plate))
                 .germplasmDbId(germplasm.getGermplasmDbId())
-                .row(row)
+                .row(row.toUpperCase())
                 .column(Integer.valueOf(column))
                 .tissueType(tissue)
                 .sampleDescription(comments);

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/sample/SampleSubmissionImport.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/sample/SampleSubmissionImport.java
@@ -84,8 +84,8 @@ public class SampleSubmissionImport implements BrAPIImport {
     private String tissue;
 
     @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
-    @ImportFieldMetadata(id = "comment", name = Columns.COMMENTS, description = "Generic comments about this sample for the vendor")
-    private String comment;
+    @ImportFieldMetadata(id = "comments", name = Columns.COMMENTS, description = "Generic comments about this sample for the vendor")
+    private String comments;
 
     @ImportFieldType(type= ImportFieldTypeEnum.TEXT, collectTime = ImportCollectTimeEnum.UPLOAD)
     @ImportMappingRequired
@@ -99,7 +99,7 @@ public class SampleSubmissionImport implements BrAPIImport {
         public static final String ORGANISM = "Organism";
         public static final String SPECIES = "Species";
         public static final String GERMPLASM_NAME = "Germplasm Name";
-        public static final String GERMPLASM_GID = "Germplasm GID";
+        public static final String GERMPLASM_GID = "GID";
         public static final String TISSUE = "Tissue";
         public static final String COMMENTS = "Comments";
         public static final String OBS_UNIT_ID = "ObsUnitID";
@@ -146,7 +146,7 @@ public class SampleSubmissionImport implements BrAPIImport {
                 .row(row)
                 .column(Integer.valueOf(column))
                 .tissueType(tissue)
-                .sampleDescription(comment);
+                .sampleDescription(comments);
 
         if (ou != null) {
             brAPISample

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/sample/SampleSubmissionImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/sample/SampleSubmissionImportService.java
@@ -1,0 +1,76 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapps.importer.model.imports.sample;
+
+import lombok.extern.slf4j.Slf4j;
+import org.brapi.client.v2.model.exceptions.ApiException;
+import org.breedinginsight.brapps.importer.model.ImportUpload;
+import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
+import org.breedinginsight.brapps.importer.model.imports.BrAPIImportService;
+import org.breedinginsight.brapps.importer.model.response.ImportPreviewResponse;
+import org.breedinginsight.brapps.importer.services.processors.Processor;
+import org.breedinginsight.brapps.importer.services.processors.ProcessorManager;
+import org.breedinginsight.brapps.importer.services.processors.SampleSubmissionProcessor;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.model.User;
+import org.breedinginsight.services.exceptions.DoesNotExistException;
+import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
+import org.breedinginsight.services.exceptions.UnprocessableEntityException;
+import org.breedinginsight.services.exceptions.ValidatorException;
+import tech.tablesaw.api.Table;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.util.List;
+
+@Singleton
+@Slf4j
+public class SampleSubmissionImportService implements BrAPIImportService {
+    private final String IMPORT_TYPE_ID = "SampleImport";
+    private final Provider<SampleSubmissionProcessor> sampleProcessorProvider;
+    private final Provider<ProcessorManager> processorManagerProvider;
+
+    @Inject
+    public SampleSubmissionImportService(Provider<SampleSubmissionProcessor> sampleProcessorProvider, Provider<ProcessorManager> processorManagerProvider)
+    {
+        this.sampleProcessorProvider = sampleProcessorProvider;
+        this.processorManagerProvider = processorManagerProvider;
+    }
+
+    @Override
+    public String getImportTypeId() {
+        return IMPORT_TYPE_ID;
+    }
+
+    @Override
+    public BrAPIImport getImportClass() {
+        return new SampleSubmissionImport();
+    }
+
+    @Override
+    public ImportPreviewResponse process(List<BrAPIImport> brAPIImports,
+                                         Table data,
+                                         Program program,
+                                         ImportUpload upload,
+                                         User user,
+                                         Boolean commit) throws UnprocessableEntityException, DoesNotExistException, ValidatorException, ApiException, MissingRequiredInfoException {
+        List<Processor> processors = List.of(sampleProcessorProvider.get());
+        return processorManagerProvider.get().process(brAPIImports, processors, data, program, upload, user, commit);
+    }
+}

--- a/src/main/java/org/breedinginsight/brapps/importer/services/ExternalReferenceSource.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/ExternalReferenceSource.java
@@ -10,7 +10,11 @@ public enum ExternalReferenceSource {
     OBSERVATION_UNITS("observationunits"),
     DATASET("dataset"),
     LISTS("lists"),
-    OBSERVATIONS("observations");
+    OBSERVATIONS("observations"),
+    GERMPLASM("germplasm"),
+    PLATES("plates"),
+    SAMPLES("samples"),
+    PLATE_SUBMISSIONS("plates/submissions");
 
     private String name;
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
@@ -454,7 +454,7 @@ public class FileImportService {
                 progress.setUpdatedBy(actingUser.getId());
                 importDAO.update(upload);
             }catch (ValidatorException e) {
-                log.info("Validation errors", e);
+                log.info("Validation errors: \n" + e);
                 ImportProgress progress = upload.getProgress();
                 progress.setStatuscode((short) HttpStatus.UNPROCESSABLE_ENTITY.getCode());
                 progress.setMessage("Multiple Errors");

--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
@@ -156,7 +156,8 @@ public class FileImportService {
                 throw new HttpStatusException(HttpStatus.BAD_REQUEST, "Error parsing csv: " + e.getMessage());
             }
         } else if (mediaType.toString().equals(SupportedMediaType.XLS) ||
-                mediaType.toString().equals(SupportedMediaType.XLSX)) {
+                mediaType.toString().equals(SupportedMediaType.XLSX) ||
+                mediaType.toString().equals(SupportedMediaType.XLSB)) {
 
             try {
                 //TODO: Allow them to pass in header row index in the future

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/SampleSubmissionProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/SampleSubmissionProcessor.java
@@ -1,0 +1,281 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapps.importer.services.processors;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.v2.model.geno.BrAPIPlate;
+import org.brapi.v2.model.geno.BrAPISample;
+import org.brapi.v2.model.germ.BrAPIGermplasm;
+import org.brapi.v2.model.pheno.BrAPIObservationUnit;
+import org.breedinginsight.api.model.v1.response.ValidationError;
+import org.breedinginsight.api.model.v1.response.ValidationErrors;
+import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
+import org.breedinginsight.brapps.importer.daos.BrAPIObservationUnitDAO;
+import org.breedinginsight.brapps.importer.daos.BrAPIPlateDAO;
+import org.breedinginsight.brapps.importer.daos.BrAPISampleDAO;
+import org.breedinginsight.brapps.importer.model.ImportUpload;
+import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
+import org.breedinginsight.brapps.importer.model.imports.PendingImport;
+import org.breedinginsight.brapps.importer.model.imports.sample.SampleSubmissionImport;
+import org.breedinginsight.brapps.importer.model.response.ImportObjectState;
+import org.breedinginsight.brapps.importer.model.response.ImportPreviewStatistics;
+import org.breedinginsight.brapps.importer.model.response.PendingImportObject;
+import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.dao.db.tables.daos.SampleSubmissionDao;
+import org.breedinginsight.dao.db.tables.pojos.SampleSubmissionEntity;
+import org.breedinginsight.daos.SampleSubmissionDAO;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.model.SampleSubmission;
+import org.breedinginsight.model.User;
+import org.breedinginsight.services.SampleSubmissionService;
+import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
+import org.breedinginsight.services.exceptions.ValidatorException;
+import org.breedinginsight.utilities.Utilities;
+import org.jooq.DSLContext;
+import tech.tablesaw.api.Table;
+
+import javax.inject.Inject;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Prototype
+public class SampleSubmissionProcessor implements Processor {
+
+    private static final String MISSING_REQUIRED_DATA = "Missing required data";
+    private final String referenceSource;
+    private final BrAPIGermplasmDAO germplasmDAO;
+    private final BrAPIObservationUnitDAO observationUnitDAO;
+    private final SampleSubmissionService sampleSubmissionService;
+    private final DSLContext dsl;
+    private final BrAPIPlateDAO plateDAO;
+    private final BrAPISampleDAO sampleDAO;
+
+    private SampleSubmission submission;
+    private Map<String, BrAPIGermplasm> germplasmByGID = new HashMap<>();
+    private Map<String, BrAPIGermplasm> germplasmByDbId = new HashMap<>();
+    private Map<String, BrAPIObservationUnit> observationUnitsById = new HashMap<>();
+    private Map<String, PendingImportObject<BrAPIPlate>> plateById = new HashMap<>();
+    private Map<String, int[][]> plateLayouts = new HashMap<>();
+
+    @Inject
+    public SampleSubmissionProcessor(@Property(name = "brapi.server.reference-source") String referenceSource,
+                                     BrAPIGermplasmDAO germplasmDAO,
+                                     BrAPIObservationUnitDAO observationUnitDAO,
+                                     SampleSubmissionService sampleSubmissionService,
+                                     DSLContext dsl,
+                                     BrAPIPlateDAO plateDAO,
+                                     BrAPISampleDAO sampleDAO) {
+        this.referenceSource = referenceSource;
+        this.germplasmDAO = germplasmDAO;
+        this.observationUnitDAO = observationUnitDAO;
+        this.sampleSubmissionService = sampleSubmissionService;
+        this.dsl = dsl;
+        this.plateDAO = plateDAO;
+        this.sampleDAO = sampleDAO;
+    }
+
+    @Override
+    public void getExistingBrapiData(List<BrAPIImport> importRows, Program program) throws ValidatorException, ApiException {
+        Set<String> gids = importRows.stream()
+                                     .filter((row -> StringUtils.isNotBlank(((SampleSubmissionImport) row).getGid())))
+                                     .map(row -> ((SampleSubmissionImport) row).getGid())
+                                     .collect(Collectors.toSet());
+
+        List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasm(program.getId());
+
+        List<String> obsUnitIds = importRows.stream()
+                                            .filter((row -> StringUtils.isNotBlank(((SampleSubmissionImport) row).getObsUnitId())))
+                                            .map(row -> ((SampleSubmissionImport) row).getObsUnitId())
+                                            .distinct()
+                                            .collect(Collectors.toList());
+
+        List<BrAPIObservationUnit> observationUnits = observationUnitDAO.getObservationUnitsById(obsUnitIds, program);
+        Set<String> germDbIds = new HashSet<>();
+        String ouRefSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.OBSERVATION_UNITS);
+        observationUnits.forEach(ou -> {
+            observationUnitsById.put(Utilities.getExternalReference(ou.getExternalReferences(), ouRefSource)
+                                              .get()
+                                              .getReferenceId(), ou);
+            germDbIds.add(ou.getGermplasmDbId());
+        });
+        germplasm.stream()
+                 .filter(germ -> gids.contains(germ.getAccessionNumber()) || germDbIds.contains(germ.getGermplasmDbId()))
+                 .forEach(germ -> {
+                     germplasmByGID.put(germ.getAccessionNumber(), germ);
+                     germplasmByDbId.put(germ.getGermplasmDbId(), germ);
+                 });
+    }
+
+    @Override
+    public Map<String, ImportPreviewStatistics> process(ImportUpload upload,
+                                                        List<BrAPIImport> importRows,
+                                                        Map<Integer, PendingImport> mappedBrAPIImport,
+                                                        Table data,
+                                                        Program program,
+                                                        User user,
+                                                        boolean commit) throws ValidatorException, MissingRequiredInfoException, ApiException {
+        ValidationErrors validationErrors = new ValidationErrors();
+
+        String submissionId = null;
+        if (commit) {
+            submissionId = UUID.randomUUID()
+                               .toString();
+            SampleSubmissionImport row = (SampleSubmissionImport) importRows.get(0);
+            submission = SampleSubmission.builder()
+                    .id(UUID.fromString(submissionId))
+                    .name(row.getSubmissionName())
+                    .createdBy(user.getId())
+                    .build();
+        }
+
+        for (int i = 0; i < importRows.size(); i++) {
+            int rowNum = i + 2; //accounts for column header and 0-index of i
+            SampleSubmissionImport row = (SampleSubmissionImport) importRows.get(i);
+
+            if (validRow(row, rowNum, validationErrors)) {
+                PendingImport pendingImport = new PendingImport();
+                PendingImportObject<BrAPIPlate> plate = plateById.getOrDefault(row.getPlateId(), new PendingImportObject<>(ImportObjectState.NEW, row.constructBrAPIPlate(commit, program, user, referenceSource, submissionId)));
+                pendingImport.setPlate(plate);
+                plateById.putIfAbsent(plate.getBrAPIObject()
+                                           .getPlateName(), plate);
+
+                BrAPIGermplasm germ;
+                if (StringUtils.isNotBlank(row.getObsUnitId())) {
+                    germ = germplasmByDbId.get(observationUnitsById.get(row.getObsUnitId())
+                                                                   .getGermplasmDbId());
+                } else {
+                    germ = germplasmByGID.get(row.getGid());
+                }
+                pendingImport.setSample(new PendingImportObject<>(ImportObjectState.NEW,
+                                                                  row.constructBrAPISample(commit, program, user, plate.getBrAPIObject(), referenceSource, submissionId, germ, observationUnitsById.get(row.getObsUnitId()))));
+                mappedBrAPIImport.put(rowNum, pendingImport);
+            }
+        }
+
+        if (validationErrors.hasErrors()) {
+            throw new ValidatorException(validationErrors);
+        }
+
+        return Map.of("Plates",
+                      ImportPreviewStatistics.builder()
+                                             .newObjectCount(plateById.size())
+                                             .build(),
+                      "Samples",
+                      ImportPreviewStatistics.builder()
+                                             .newObjectCount(importRows.size())
+                                             .build());
+    }
+
+    private boolean validRow(SampleSubmissionImport row, int rowNum, ValidationErrors validationErrors) {
+        int numErrorsBefore = validationErrors.getRowErrors()
+                                              .size();
+        if (StringUtils.isBlank(row.getPlateId())) {
+            validationErrors.addError(rowNum, new ValidationError(SampleSubmissionImport.Columns.PLATE_ID, MISSING_REQUIRED_DATA, HttpStatus.UNPROCESSABLE_ENTITY));
+        }
+        int plateRow = -1;
+        if (StringUtils.isBlank(row.getRow())) {
+            validationErrors.addError(rowNum, new ValidationError(SampleSubmissionImport.Columns.ROW, MISSING_REQUIRED_DATA, HttpStatus.UNPROCESSABLE_ENTITY));
+        } else if (row.getRow()
+                      .length() > 1 || row.getRow()
+                                          .toUpperCase()
+                                          .charAt(0) - 'A' < 0 || row.getRow()
+                                                                     .toUpperCase()
+                                                                     .charAt(0) - 'H' > 0) {
+            validationErrors.addError(rowNum, new ValidationError(SampleSubmissionImport.Columns.ROW, "Row must be a a letter between A and H", HttpStatus.UNPROCESSABLE_ENTITY));
+        } else {
+            plateRow = row.getRow()
+                          .toUpperCase()
+                          .charAt(0) - 'A';
+        }
+        int plateCol = -1;
+        if (StringUtils.isBlank(row.getColumn())) {
+            validationErrors.addError(rowNum, new ValidationError(SampleSubmissionImport.Columns.COLUMN, MISSING_REQUIRED_DATA, HttpStatus.UNPROCESSABLE_ENTITY));
+        } else {
+            try {
+                plateCol = Integer.parseInt(row.getColumn());
+                if (plateCol < 1 || plateCol > 12) {
+                    validationErrors.addError(rowNum, new ValidationError(SampleSubmissionImport.Columns.COLUMN, "Column must be a number between 1 and 12", HttpStatus.UNPROCESSABLE_ENTITY));
+                    plateCol = -1;
+                }
+            } catch (NumberFormatException e) {
+                validationErrors.addError(rowNum, new ValidationError(SampleSubmissionImport.Columns.COLUMN, "Column must be a number between 1 and 12", HttpStatus.UNPROCESSABLE_ENTITY));
+            }
+        }
+        if (StringUtils.isBlank(row.getOrganism())) {
+            validationErrors.addError(rowNum, new ValidationError(SampleSubmissionImport.Columns.ORGANISM, MISSING_REQUIRED_DATA, HttpStatus.UNPROCESSABLE_ENTITY));
+        }
+        if (StringUtils.isBlank(row.getSpecies())) {
+            validationErrors.addError(rowNum, new ValidationError(SampleSubmissionImport.Columns.SPECIES, MISSING_REQUIRED_DATA, HttpStatus.UNPROCESSABLE_ENTITY));
+        }
+        if (StringUtils.isBlank(row.getGid()) && StringUtils.isBlank(row.getObsUnitId())) {
+            validationErrors.addError(rowNum, new ValidationError(SampleSubmissionImport.Columns.GERMPLASM_GID, "One of GID or ObsUnitID is required", HttpStatus.UNPROCESSABLE_ENTITY));
+        } else if (StringUtils.isNotBlank(row.getObsUnitId()) && !observationUnitsById.containsKey(row.getObsUnitId())) {
+            validationErrors.addError(rowNum, new ValidationError(SampleSubmissionImport.Columns.OBS_UNIT_ID, "Unknown ObsUnitID", HttpStatus.UNPROCESSABLE_ENTITY));
+        } else if (StringUtils.isNotBlank(row.getGid()) && !germplasmByGID.containsKey(row.getGid())) {
+            validationErrors.addError(rowNum, new ValidationError(SampleSubmissionImport.Columns.GERMPLASM_GID, "Unknown germplasm GID", HttpStatus.UNPROCESSABLE_ENTITY));
+        }
+        if (StringUtils.isBlank(row.getTissue())) {
+            validationErrors.addError(rowNum, new ValidationError(SampleSubmissionImport.Columns.TISSUE, MISSING_REQUIRED_DATA, HttpStatus.UNPROCESSABLE_ENTITY));
+        }
+
+        if (plateRow > -1 && plateCol > -1) {
+            int[][] plateLayout = plateLayouts.getOrDefault(row.getPlateId(), new int[9][13]);
+            if (plateLayout[plateRow][plateCol] > 0) {
+                validationErrors.addError(rowNum,
+                                          new ValidationError(SampleSubmissionImport.Columns.ROW + "/" + SampleSubmissionImport.Columns.COLUMN,
+                                                              String.format("The sample in row %d is already in row: %s, column: %d", plateLayout[plateRow][plateCol], Character.toString('A' + plateRow), plateCol),
+                                                              HttpStatus.UNPROCESSABLE_ENTITY));
+            } else {
+                plateLayout[plateRow][plateCol] = rowNum;
+                plateLayouts.put(row.getPlateId(), plateLayout);
+            }
+        }
+
+        return numErrorsBefore == validationErrors.getRowErrors()
+                                                  .size();
+    }
+
+    @Override
+    public void validateDependencies(Map<Integer, PendingImport> mappedBrAPIImport) throws ValidatorException {
+
+    }
+
+    @Override
+    public void postBrapiData(Map<Integer, PendingImport> mappedBrAPIImport, Program program, ImportUpload upload) throws ValidatorException {
+        dsl.transaction(() -> {
+            List<BrAPIPlate> platesToSave = plateById.values().stream().map(PendingImportObject::getBrAPIObject).collect(Collectors.toList());
+            List<BrAPISample> samplesToSave = mappedBrAPIImport.values().stream().map(row -> row.getSample().getBrAPIObject()).collect(Collectors.toList());
+
+            submission.setPlates(platesToSave);
+            submission.setSamples(samplesToSave);
+
+            sampleSubmissionService.createSubmission(submission, program, upload);
+        });
+    }
+
+    @Override
+    public String getName() {
+        return "SampleSubmission";
+    }
+}

--- a/src/main/java/org/breedinginsight/daos/ProgramDAO.java
+++ b/src/main/java/org/breedinginsight/daos/ProgramDAO.java
@@ -62,4 +62,6 @@ public interface ProgramDAO extends DAO<ProgramRecord, ProgramEntity, UUID> {
     BrAPIClient getCoreClient(UUID programId);
 
     BrAPIClient getPhenoClient(UUID programId);
+
+    BrAPIClient getSampleClient(UUID programId);
 }

--- a/src/main/java/org/breedinginsight/daos/SampleSubmissionDAO.java
+++ b/src/main/java/org/breedinginsight/daos/SampleSubmissionDAO.java
@@ -1,0 +1,58 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.daos;
+
+import org.breedinginsight.dao.db.Tables;
+import org.breedinginsight.dao.db.tables.daos.SampleSubmissionDao;
+import org.breedinginsight.dao.db.tables.pojos.SampleSubmissionEntity;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.model.SampleSubmission;
+import org.jooq.Configuration;
+import org.jooq.DSLContext;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.breedinginsight.dao.db.Tables.SAMPLE_SUBMISSION;
+
+@Singleton
+public class SampleSubmissionDAO extends SampleSubmissionDao {
+
+    private DSLContext dsl;
+
+    @Inject
+    public SampleSubmissionDAO(Configuration config, DSLContext dsl) {
+        super(config);
+        this.dsl = dsl;
+    }
+
+    public List<SampleSubmission> getBySubmissionId(Program program, UUID submissionId) {
+        return dsl.select()
+                  .from(SAMPLE_SUBMISSION)
+                  .where(SAMPLE_SUBMISSION.PROGRAM_ID.eq(program.getId()))
+                  .and(SAMPLE_SUBMISSION.ID.eq(submissionId))
+                  .fetchInto(SampleSubmissionEntity.class)
+                  .stream()
+                  .map(SampleSubmission::new)
+                  .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/org/breedinginsight/daos/impl/ProgramDAOImpl.java
+++ b/src/main/java/org/breedinginsight/daos/impl/ProgramDAOImpl.java
@@ -36,7 +36,6 @@ import org.brapi.v2.model.core.response.BrAPIServerInfoResponse;
 import org.breedinginsight.dao.db.tables.BiUserTable;
 import org.breedinginsight.dao.db.tables.daos.ProgramDao;
 import org.breedinginsight.dao.db.tables.pojos.ProgramEntity;
-import org.breedinginsight.dao.db.tables.records.ProgramRecord;
 import org.breedinginsight.daos.ProgramDAO;
 import org.breedinginsight.model.User;
 import org.breedinginsight.model.*;
@@ -389,6 +388,14 @@ public class ProgramDAOImpl extends ProgramDao implements ProgramDAO {
     public BrAPIClient getPhenoClient(UUID programId) {
         Program program = get(programId).get(0);
         String brapiUrl = !program.getBrapiUrl().equals(SYSTEM_DEFAULT) ? program.getBrapiUrl() : defaultBrAPIPhenoUrl;
+        BrAPIClient client = new BrAPIClient(brapiUrl);
+        initializeHttpClient(client);
+        return client;
+    }
+
+    @Override
+    public BrAPIClient getSampleClient(UUID programId) {
+        String brapiUrl = defaultBrAPIPhenoUrl;
         BrAPIClient client = new BrAPIClient(brapiUrl);
         initializeHttpClient(client);
         return client;

--- a/src/main/java/org/breedinginsight/model/GenotypeVendor.java
+++ b/src/main/java/org/breedinginsight/model/GenotypeVendor.java
@@ -1,0 +1,37 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model;
+
+public enum GenotypeVendor {
+    DART("DArT");
+
+    private final String name;
+
+    GenotypeVendor(String name) {
+        this.name = name;
+    }
+
+    public static GenotypeVendor fromName(String name) {
+        for(var vendor : GenotypeVendor.values()) {
+            if(vendor.name.equalsIgnoreCase(name)) {
+                return vendor;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/breedinginsight/model/SampleSubmission.java
+++ b/src/main/java/org/breedinginsight/model/SampleSubmission.java
@@ -1,0 +1,60 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.micronaut.core.annotation.Introspected;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+import org.brapi.v2.model.geno.BrAPIPlate;
+import org.brapi.v2.model.geno.BrAPISample;
+import org.breedinginsight.dao.db.tables.pojos.SampleSubmissionEntity;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Accessors(chain=true)
+@ToString
+@SuperBuilder
+@NoArgsConstructor
+@Introspected
+@Jacksonized
+//@JsonIgnoreProperties(value = {"createdBy", "updatedBy"})
+public class SampleSubmission extends SampleSubmissionEntity {
+    private List<BrAPIPlate> plates;
+    private List<BrAPISample> samples;
+
+    public SampleSubmission(SampleSubmissionEntity entity) {
+        this.setId(entity.getId());
+        this.setName(entity.getName());
+        this.setSubmitted(entity.getSubmitted());
+        this.setVendorOrderId(entity.getVendorOrderId());
+        this.setShipmentforms(entity.getShipmentforms());
+        this.setProgramId(entity.getProgramId());
+        this.setCreatedAt(entity.getCreatedAt());
+        this.setCreatedBy(entity.getCreatedBy());
+        this.setUpdatedAt(entity.getUpdatedAt());
+        this.setUpdatedBy(entity.getUpdatedBy());
+    }
+}

--- a/src/main/java/org/breedinginsight/model/SampleSubmission.java
+++ b/src/main/java/org/breedinginsight/model/SampleSubmission.java
@@ -18,6 +18,8 @@
 package org.breedinginsight.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import io.micronaut.core.annotation.Introspected;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,7 +30,9 @@ import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 import org.brapi.v2.model.geno.BrAPIPlate;
 import org.brapi.v2.model.geno.BrAPISample;
+import org.brapi.v2.model.geno.BrAPIShipmentForm;
 import org.breedinginsight.dao.db.tables.pojos.SampleSubmissionEntity;
+import org.jooq.JSONB;
 
 import java.util.List;
 
@@ -40,8 +44,12 @@ import java.util.List;
 @NoArgsConstructor
 @Introspected
 @Jacksonized
-//@JsonIgnoreProperties(value = {"createdBy", "updatedBy"})
+@JsonIgnoreProperties(value = {"createdBy", "updatedBy", "submittedBy", "shipmentforms"})
 public class SampleSubmission extends SampleSubmissionEntity {
+    private User createdByUser;
+    private User updatedByUser;
+    private User submittedByUser;
+    private List<BrAPIShipmentForm> shipmentForms;
     private List<BrAPIPlate> plates;
     private List<BrAPISample> samples;
 
@@ -49,12 +57,50 @@ public class SampleSubmission extends SampleSubmissionEntity {
         this.setId(entity.getId());
         this.setName(entity.getName());
         this.setSubmitted(entity.getSubmitted());
+        this.setSubmittedDate(entity.getSubmittedDate());
+        this.setSubmittedBy(entity.getSubmittedBy());
         this.setVendorOrderId(entity.getVendorOrderId());
+        this.setVendorStatus(entity.getVendorStatus());
+        this.setVendorStatusLastCheck(entity.getVendorStatusLastCheck());
         this.setShipmentforms(entity.getShipmentforms());
         this.setProgramId(entity.getProgramId());
         this.setCreatedAt(entity.getCreatedAt());
         this.setCreatedBy(entity.getCreatedBy());
         this.setUpdatedAt(entity.getUpdatedAt());
         this.setUpdatedBy(entity.getUpdatedBy());
+
+        parseShipmentForms(super.getShipmentforms());
+    }
+
+    private void parseShipmentForms(JSONB shipmentforms) {
+        if(shipmentforms != null) {
+            Gson gson = new Gson();
+            this.shipmentForms = gson.fromJson(shipmentforms.data(), new TypeToken<List<BrAPIShipmentForm>>() {}.getType());
+        }
+    }
+
+    public enum Status {
+        NOT_SUBMITTED("NOT SUBMITTED"),
+        SUBMITTED("SUBMITTED"),
+        COMPLETED("COMPLETED");
+
+        private final String value;
+
+        Status(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public static Status fromValue(String value) {
+            for(Status status : Status.values()) {
+                if(status.value.equals(value)) {
+                    return status;
+                }
+            }
+            return null;
+        }
     }
 }

--- a/src/main/java/org/breedinginsight/model/User.java
+++ b/src/main/java/org/breedinginsight/model/User.java
@@ -32,6 +32,7 @@ import javax.validation.constraints.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.breedinginsight.dao.db.Tables.BI_USER;
 
@@ -43,7 +44,7 @@ import static org.breedinginsight.dao.db.Tables.BI_USER;
 @Introspected
 @Jacksonized
 @JsonIgnoreProperties(value = {"accountToken"})
-public class User extends BiUserEntity{
+public class User extends BiUserEntity {
 
     @JsonInclude()
     @NotNull

--- a/src/main/java/org/breedinginsight/services/SampleSubmissionService.java
+++ b/src/main/java/org/breedinginsight/services/SampleSubmissionService.java
@@ -81,9 +81,9 @@ public class SampleSubmissionService {
 
     @Inject
     public SampleSubmissionService(@Property(name = "brapi.server.reference-source") String referenceSource,
-                                   @Property(name = "brapi.server.vendor.dart-url") String dartBrapiUrl,
-                                   @Property(name = "brapi.server.vendor.dart-client-id") String dartClientId,
-                                   @Property(name = "brapi.server.vendor.dart-token") String dartToken,
+                                   @Property(name = "brapi.vendors.dart.url") String dartBrapiUrl,
+                                   @Property(name = "brapi.vendors.dart.client-id") String dartClientId,
+                                   @Property(name = "brapi.vendors.dart.token") String dartToken,
                                    @Value(value = "${brapi.read-timeout:5m}") Duration requestTimeout,
                                    SampleSubmissionDAO submissionDAO,
                                    BrAPIPlateDAO plateDAO,

--- a/src/main/java/org/breedinginsight/services/SampleSubmissionService.java
+++ b/src/main/java/org/breedinginsight/services/SampleSubmissionService.java
@@ -1,0 +1,115 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.services;
+
+import io.micronaut.context.annotation.Property;
+import lombok.extern.slf4j.Slf4j;
+import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.geno.BrAPIPlate;
+import org.brapi.v2.model.geno.BrAPISample;
+import org.breedinginsight.brapps.importer.daos.BrAPIPlateDAO;
+import org.breedinginsight.brapps.importer.daos.BrAPISampleDAO;
+import org.breedinginsight.brapps.importer.model.ImportUpload;
+import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.daos.SampleSubmissionDAO;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.model.SampleSubmission;
+import org.breedinginsight.utilities.Utilities;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Singleton
+public class SampleSubmissionService {
+
+    private final String referenceSource;
+
+    private final SampleSubmissionDAO submissionDAO;
+    private final BrAPIPlateDAO plateDAO;
+    private final BrAPISampleDAO sampleDAO;
+
+    @Inject
+    public SampleSubmissionService(@Property(name = "brapi.server.reference-source") String referenceSource, SampleSubmissionDAO submissionDAO, BrAPIPlateDAO plateDAO, BrAPISampleDAO sampleDAO) {
+        this.referenceSource = referenceSource;
+        this.submissionDAO = submissionDAO;
+        this.plateDAO = plateDAO;
+        this.sampleDAO = sampleDAO;
+    }
+
+    public SampleSubmission createSubmission(SampleSubmission submission, Program program, ImportUpload upload) throws ApiException {
+        submission.setProgramId(program.getId());
+        submission.setCreatedBy(upload.getCreatedBy());
+        submission.setUpdatedBy(upload.getUpdatedBy());
+        submissionDAO.insert(submission);
+
+        List<BrAPIPlate> savedPlates = plateDAO.createPlates(program, submission.getPlates(), upload);
+        submission.setPlates(savedPlates);
+        Map<String, String> plateNameToDbId = savedPlates.stream().collect(Collectors.toMap(BrAPIPlate::getPlateName, BrAPIPlate::getPlateDbId));
+
+        List<BrAPISample> samplesToSave = submission.getSamples().stream().map(sample -> sample.plateDbId(plateNameToDbId.get(sample.getPlateName()))).collect(Collectors.toList());
+        List<BrAPISample> savedSamples = sampleDAO.createSamples(program, samplesToSave, upload);
+        submission.setSamples(savedSamples);
+
+        return submission;
+    }
+
+    public Optional<SampleSubmission> getSampleSubmission(Program program, UUID submissionId) throws ApiException {
+        return populateSubmissions(program, submissionDAO.getBySubmissionId(program, submissionId)).stream().findFirst();
+    }
+
+    public List<SampleSubmission> getProgramSubmissions(Program program) {
+        return submissionDAO.fetchByProgramId(program.getId())
+                .stream()
+                .map(SampleSubmission::new)
+                .collect(Collectors.toList());
+    }
+
+    private List<SampleSubmission> populateSubmissions(Program program, List<SampleSubmission> submissions) throws ApiException {
+        List<String> submissionIds = submissions.stream().map(s -> s.getId().toString()).collect(Collectors.toList());
+        List<BrAPIPlate> plates = plateDAO.readPlatesBySubmissionIds(program, submissionIds);
+        List<BrAPISample> samples = sampleDAO.readSamplesBySubmissionIds(program, submissionIds);
+
+        Map<String, List<BrAPIPlate>> platesBySubmissionId = new HashMap<>();
+        String submissionXrefSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PLATE_SUBMISSIONS);
+        plates.forEach(plate -> {
+            BrAPIExternalReference brAPIExternalReference = Utilities.getExternalReference(plate.getExternalReferences(), submissionXrefSource).orElseThrow(() -> new IllegalStateException(String.format("Plate %s does not have a submission ID", plate.getPlateName())));
+            List<BrAPIPlate> submissionPlates = platesBySubmissionId.getOrDefault(brAPIExternalReference.getReferenceId(), new ArrayList<>());
+            submissionPlates.add(plate);
+            platesBySubmissionId.putIfAbsent(brAPIExternalReference.getReferenceId(), submissionPlates);
+        });
+
+        Map<String, List<BrAPISample>> samplesBySubmissionId = new HashMap<>();
+        samples.forEach(sample -> {
+            BrAPIExternalReference brAPIExternalReference = Utilities.getExternalReference(sample.getExternalReferences(), submissionXrefSource).orElseThrow(() -> new IllegalStateException(String.format("Plate %s does not have a submission ID", sample.getPlateName())));
+            List<BrAPISample> submissionSamples = samplesBySubmissionId.getOrDefault(brAPIExternalReference.getReferenceId(), new ArrayList<>());
+            submissionSamples.add(sample);
+            samplesBySubmissionId.putIfAbsent(brAPIExternalReference.getReferenceId(), submissionSamples);
+        });
+
+        submissions.forEach(submission -> {
+            submission.setPlates(platesBySubmissionId.get(submission.getId().toString()));
+            submission.setSamples(samplesBySubmissionId.get(submission.getId().toString()));
+        });
+
+        return submissions;
+    }
+}

--- a/src/main/java/org/breedinginsight/services/SampleSubmissionService.java
+++ b/src/main/java/org/breedinginsight/services/SampleSubmissionService.java
@@ -18,22 +18,44 @@
 package org.breedinginsight.services;
 
 import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.scheduling.annotation.Scheduled;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.brapi.client.v2.ApiResponse;
+import org.brapi.client.v2.BrAPIClient;
+import org.brapi.client.v2.auth.Authentication;
+import org.brapi.client.v2.auth.OAuth;
 import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.client.v2.modules.genotype.VendorApi;
 import org.brapi.v2.model.BrAPIExternalReference;
-import org.brapi.v2.model.geno.BrAPIPlate;
-import org.brapi.v2.model.geno.BrAPISample;
+import org.brapi.v2.model.geno.*;
+import org.brapi.v2.model.geno.request.BrAPIVendorOrderSubmissionRequest;
+import org.brapi.v2.model.geno.response.BrAPIVendorOrderStatusResponse;
+import org.brapi.v2.model.geno.response.BrAPIVendorOrderStatusResponseResult;
+import org.brapi.v2.model.geno.response.BrAPIVendorOrderSubmissionSingleResponse;
+import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapps.importer.daos.BrAPIPlateDAO;
 import org.breedinginsight.brapps.importer.daos.BrAPISampleDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
+import org.breedinginsight.brapps.importer.model.exports.FileType;
+import org.breedinginsight.brapps.importer.model.imports.sample.SampleSubmissionImport;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.daos.ProgramDAO;
 import org.breedinginsight.daos.SampleSubmissionDAO;
-import org.breedinginsight.model.Program;
-import org.breedinginsight.model.SampleSubmission;
+import org.breedinginsight.model.*;
+import org.breedinginsight.services.brapi.BrAPIEndpointProvider;
+import org.breedinginsight.utilities.FileUtil;
 import org.breedinginsight.utilities.Utilities;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -41,24 +63,70 @@ import java.util.stream.Collectors;
 @Singleton
 public class SampleSubmissionService {
 
+    private static final String COLUMN_GENOTYPE = "Genotype";
+    private static final String VENDOR_NOT_SUBMITTED_STATUS = "NOT SUBMITTED";
+    private static final String VENDOR_SUBMITTED_STATUS = "SUBMITTED";
     private final String referenceSource;
+    private String dartBrapiUrl;
+    private String dartClientId;
+    private String dartToken;
+    private Duration requestTimeout;
 
     private final SampleSubmissionDAO submissionDAO;
     private final BrAPIPlateDAO plateDAO;
     private final BrAPISampleDAO sampleDAO;
+    private final BrAPIEndpointProvider brAPIEndpointProvider;
+    private final ProgramDAO programDAO;
+    private final DSLContext dsl;
 
     @Inject
-    public SampleSubmissionService(@Property(name = "brapi.server.reference-source") String referenceSource, SampleSubmissionDAO submissionDAO, BrAPIPlateDAO plateDAO, BrAPISampleDAO sampleDAO) {
+    public SampleSubmissionService(@Property(name = "brapi.server.reference-source") String referenceSource,
+                                   @Property(name = "brapi.server.vendor.dart-url") String dartBrapiUrl,
+                                   @Property(name = "brapi.server.vendor.dart-client-id") String dartClientId,
+                                   @Property(name = "brapi.server.vendor.dart-token") String dartToken,
+                                   @Value(value = "${brapi.read-timeout:5m}") Duration requestTimeout,
+                                   SampleSubmissionDAO submissionDAO,
+                                   BrAPIPlateDAO plateDAO,
+                                   BrAPISampleDAO sampleDAO,
+                                   BrAPIEndpointProvider brAPIEndpointProvider,
+                                   ProgramDAO programDAO,
+                                   DSLContext dsl) {
         this.referenceSource = referenceSource;
+        this.dartBrapiUrl = dartBrapiUrl;
+        this.dartClientId = dartClientId;
+        this.dartToken = dartToken;
+        this.requestTimeout = requestTimeout;
         this.submissionDAO = submissionDAO;
         this.plateDAO = plateDAO;
         this.sampleDAO = sampleDAO;
+        this.brAPIEndpointProvider = brAPIEndpointProvider;
+        this.programDAO = programDAO;
+        this.dsl = dsl;
+    }
+
+    @Scheduled(fixedDelay = "${brapi.vendor-check-frequency}", initialDelay = "10s")
+    void checkSubmissionStatuses() {
+        log.trace("checking vendor order statuses");
+        List<SampleSubmission> submittedAndNotCompleted = submissionDAO.getSubmittedAndNotComplete();
+        log.trace(submittedAndNotCompleted.size() + " orders to check");
+        for(var order : submittedAndNotCompleted) {
+            try {
+                this.checkVendorStatus(order);
+            } catch (ApiException e) {
+                log.error("Error checking vendor order status: \n\n" + Utilities.generateApiExceptionLogMessage(e), e);
+                throw new RuntimeException(e);
+            }
+        }
+        log.trace("vendor order status checks complete, sleeping");
     }
 
     public SampleSubmission createSubmission(SampleSubmission submission, Program program, ImportUpload upload) throws ApiException {
         submission.setProgramId(program.getId());
+        submission.setCreatedByUser(upload.getCreatedByUser());
         submission.setCreatedBy(upload.getCreatedBy());
+        submission.setUpdatedByUser(upload.getUpdatedByUser());
         submission.setUpdatedBy(upload.getUpdatedBy());
+
         submissionDAO.insert(submission);
 
         List<BrAPIPlate> savedPlates = plateDAO.createPlates(program, submission.getPlates(), upload);
@@ -72,15 +140,16 @@ public class SampleSubmissionService {
         return submission;
     }
 
-    public Optional<SampleSubmission> getSampleSubmission(Program program, UUID submissionId) throws ApiException {
-        return populateSubmissions(program, submissionDAO.getBySubmissionId(program, submissionId)).stream().findFirst();
+    public Optional<SampleSubmission> getSampleSubmission(Program program, UUID submissionId, boolean fetchDetails) throws ApiException {
+        if (fetchDetails) {
+            return populateSubmissions(program, submissionDAO.getBySubmissionId(program, submissionId)).stream().findFirst();
+        } else {
+            return submissionDAO.getBySubmissionId(program, submissionId).stream().findFirst();
+        }
     }
 
     public List<SampleSubmission> getProgramSubmissions(Program program) {
-        return submissionDAO.fetchByProgramId(program.getId())
-                .stream()
-                .map(SampleSubmission::new)
-                .collect(Collectors.toList());
+        return submissionDAO.getByProgramId(program.getId());
     }
 
     private List<SampleSubmission> populateSubmissions(Program program, List<SampleSubmission> submissions) throws ApiException {
@@ -111,5 +180,243 @@ public class SampleSubmissionService {
         });
 
         return submissions;
+    }
+
+    public Optional<DownloadFile> generateDArTFile(Program program, UUID submissionId) throws ApiException, IOException {
+        Optional<SampleSubmission> submission = getSampleSubmission(program, submissionId, true);
+        if (submission.isEmpty()) {
+            return Optional.empty();
+        }
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_hh-mm-ssZ");
+        String timestamp = formatter.format(OffsetDateTime.now());
+        String filename = Utilities.makePortableFilename(String.format("%s_DArT_Submission_%s.csv", submission.get().getName(), timestamp));
+
+        List<Column> columns = new ArrayList<>();
+        columns.add(Column.builder().value(SampleSubmissionImport.Columns.PLATE_ID).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(SampleSubmissionImport.Columns.ROW).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(SampleSubmissionImport.Columns.COLUMN).dataType(Column.ColumnDataType.INTEGER).build());
+        columns.add(Column.builder().value(SampleSubmissionImport.Columns.ORGANISM).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(SampleSubmissionImport.Columns.SPECIES).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(COLUMN_GENOTYPE).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(SampleSubmissionImport.Columns.TISSUE).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(SampleSubmissionImport.Columns.COMMENTS).dataType(Column.ColumnDataType.STRING).build());
+
+        //TODO sort the samples first
+        List<Map<String, Object>> rows = new ArrayList<>();
+        submission.get().getSamples().forEach(sample -> {
+            Map<String, Object> row = new HashMap<>();
+            row.put(SampleSubmissionImport.Columns.PLATE_ID, sample.getPlateName());
+            row.put(SampleSubmissionImport.Columns.ROW, sample.getRow());
+            row.put(SampleSubmissionImport.Columns.COLUMN, sample.getColumn());
+            row.put(SampleSubmissionImport.Columns.ORGANISM, sample.getAdditionalInfo().get(BrAPIAdditionalInfoFields.SAMPLE_ORGANISM).getAsString());
+            row.put(SampleSubmissionImport.Columns.SPECIES, sample.getAdditionalInfo().has(BrAPIAdditionalInfoFields.SAMPLE_SPECIES) ? sample.getAdditionalInfo().get(BrAPIAdditionalInfoFields.SAMPLE_SPECIES).getAsString() : "");
+            row.put(COLUMN_GENOTYPE, sample.getSampleName());
+            row.put(SampleSubmissionImport.Columns.TISSUE, sample.getTissueType());
+            row.put(SampleSubmissionImport.Columns.COMMENTS, sample.getSampleDescription());
+
+            rows.add(row);
+        });
+
+
+        return Optional.of(new DownloadFile(filename, FileUtil.writeToStreamedFile(columns, rows, FileType.CSV, "Data")));
+    }
+
+    public Optional<DownloadFile> generateLookupFile(Program program, UUID submissionId) throws ApiException, IOException {
+        Optional<SampleSubmission> submission = getSampleSubmission(program, submissionId, true);
+        if (submission.isEmpty()) {
+            return Optional.empty();
+        }
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_hh-mm-ssZ");
+        String timestamp = formatter.format(OffsetDateTime.now());
+        String filename = Utilities.makePortableFilename(String.format("%s_Lookup_File_%s.csv", submission.get().getName(), timestamp));
+
+        List<Column> columns = new ArrayList<>();
+        columns.add(Column.builder().value(COLUMN_GENOTYPE).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(SampleSubmissionImport.Columns.GERMPLASM_NAME).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(SampleSubmissionImport.Columns.GERMPLASM_GID).dataType(Column.ColumnDataType.STRING).build());
+
+        //TODO sort the samples first
+        List<Map<String, Object>> rows = new ArrayList<>();
+        submission.get().getSamples().forEach(sample -> {
+            Map<String, Object> row = new HashMap<>();
+            row.put(COLUMN_GENOTYPE, sample.getSampleName());
+            row.put(SampleSubmissionImport.Columns.GERMPLASM_NAME, sample.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_NAME).getAsString());
+            row.put(SampleSubmissionImport.Columns.GERMPLASM_GID, sample.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GID).getAsString());
+
+            rows.add(row);
+        });
+
+
+        return Optional.of(new DownloadFile(filename, FileUtil.writeToStreamedFile(columns, rows, FileType.CSV, "Data")));
+    }
+
+    public Optional<BrAPIVendorOrderSubmission> submitOrder(Program program, UUID submissionId, User submittingUser, GenotypeVendor vendor) throws ApiException, IllegalStateException {
+        Optional<SampleSubmission> submissionOptional = getSampleSubmission(program, submissionId, true);
+        if (submissionOptional.isEmpty()) {
+            return Optional.empty();
+        }
+        SampleSubmission submission = submissionOptional.get();
+
+        //prevent re-submission
+        if(Boolean.TRUE.equals(submission.getSubmitted())) {
+            if(StringUtils.isNotBlank(submission.getVendorOrderId())) {
+                return Optional.of(new BrAPIVendorOrderSubmission().orderId(submission.getVendorOrderId()));
+            } else {
+                throw new IllegalStateException("Submission has been manually submitted, cannot automatically submit to vendor");
+            }
+        }
+
+        Map<String, BrAPIVendorPlate> platesForOrder = new HashMap<>();
+        submission.getPlates().forEach(plate -> {
+            platesForOrder.put(plate.getPlateDbId(), new BrAPIVendorPlate()
+                    .clientPlateBarcode(plate.getPlateBarcode())
+                    .clientPlateId(plate.getPlateName())
+                    .sampleSubmissionFormat(BrAPIPlateFormat.PLATE_96)
+            );
+        });
+
+        submission.getSamples().forEach(sample -> {
+            BrAPIVendorPlate vendorPlate = platesForOrder.get(sample.getPlateDbId());
+            vendorPlate.addSamplesItem(new BrAPIVendorSample()
+                    .clientSampleId(sample.getSampleName())
+                    .clientSampleBarCode(sample.getSampleBarcode())
+                    .row(sample.getRow())
+                    .column(sample.getColumn())
+                    .comments(sample.getSampleDescription())
+                    .organismName(sample.getAdditionalInfo().get(BrAPIAdditionalInfoFields.SAMPLE_ORGANISM).getAsString())
+                    .speciesName(sample.getAdditionalInfo().has(BrAPIAdditionalInfoFields.SAMPLE_SPECIES) ? sample.getAdditionalInfo().get(BrAPIAdditionalInfoFields.SAMPLE_SPECIES).getAsString() : null)
+                    .tissueType(sample.getTissueType())
+                    .well(String.format("%s%d", sample.getRow(), sample.getColumn()))
+            );
+        });
+
+        //TODO get info for the specific vendor, and verify program has an account
+        BrAPIVendorOrderSubmissionRequest order = new BrAPIVendorOrderSubmissionRequest();
+        VendorApi vendorApi;
+        if(GenotypeVendor.DART.equals(vendor)) {
+            order.setClientId(dartClientId);
+            vendorApi = getVendorApi(dartBrapiUrl, dartToken);
+        } else {
+            throw new IllegalStateException("Unrecognized vendor");
+        }
+
+        order.setNumberOfSamples(submission.getSamples().size());
+        order.setPlates(new ArrayList<>(platesForOrder.values()));
+
+        ApiResponse<BrAPIVendorOrderSubmissionSingleResponse> response = vendorApi.vendorOrdersPost(order);
+
+        if (response.getBody() == null) {
+            throw new ApiException("Response is missing body", response.getStatusCode(), response.getHeaders(), null);
+        }
+        BrAPIVendorOrderSubmissionSingleResponse body = response.getBody();
+        if (body.getResult() == null) {
+            throw new ApiException("Response body is missing result", response.getStatusCode(), response.getHeaders(), response.getBody().toString());
+        }
+        BrAPIVendorOrderSubmission submittedOrder = body.getResult();
+
+        submission.setVendorOrderId(submittedOrder.getOrderId());
+        submission.setVendorStatus(VENDOR_SUBMITTED_STATUS);
+        submission.setSubmitted(true);
+        submission.setSubmittedDate(OffsetDateTime.now());
+        submission.setSubmittedByUser(submittingUser);
+        //TODO: TEMPORARY
+        submittedOrder.addShipmentFormsItem(new BrAPIShipmentForm().fileDescription("This is a shipment manifest form").fileName("Shipment Manifest").fileURL("https://vendor.org/forms/manifest.pdf"));
+        if(submittedOrder.getShipmentForms() != null) {
+
+            submission.setShipmentforms(JSONB.valueOf(vendorApi.getApiClient().getJSON().serialize(submittedOrder.getShipmentForms())));
+        }
+
+        dsl.transaction(() -> {
+            submissionDAO.update(submission, submittingUser);
+        });
+
+        return Optional.of(submittedOrder);
+    }
+
+    public Optional<SampleSubmission> checkVendorStatus(Program program, UUID submissionId) throws ApiException {
+        Optional<SampleSubmission> submissionOptional = getSampleSubmission(program, submissionId, true);
+        if (submissionOptional.isEmpty()) {
+            return Optional.empty();
+        }
+        SampleSubmission submission = submissionOptional.get();
+
+        return Optional.of(checkVendorStatus(submission));
+    }
+
+    private SampleSubmission checkVendorStatus(SampleSubmission submission) throws ApiException {
+        if(submission.getVendorOrderId() == null || BrAPIVendorOrderStatusResponseResult.StatusEnum.COMPLETED.name().equalsIgnoreCase(submission.getVendorStatus())) {
+            return submission;
+        }
+
+        VendorApi vendorApi = getVendorApi(dartBrapiUrl, dartToken);
+        ApiResponse<BrAPIVendorOrderStatusResponse> response = vendorApi.vendorOrdersOrderIdStatusGet(submission.getVendorOrderId());
+        if (response.getBody() == null) {
+            throw new ApiException("Response is missing body", response.getStatusCode(), response.getHeaders(), null);
+        }
+        BrAPIVendorOrderStatusResponse body = response.getBody();
+        if (body.getResult() == null) {
+            throw new ApiException("Response body is missing result", response.getStatusCode(), response.getHeaders(), response.getBody().toString());
+        }
+        BrAPIVendorOrderStatusResponseResult result = body.getResult();
+
+        if(result.getStatus() != null) {
+            submission.setVendorStatus(result.getStatus().name());
+        }
+        submission.setVendorStatusLastCheck(OffsetDateTime.now());
+
+        dsl.transaction(() -> {
+            submissionDAO.update(submission, submission.getUpdatedByUser());
+        });
+
+        return submission;
+    }
+
+    private VendorApi getVendorApi(String url, String authToken) {
+        BrAPIClient client = new BrAPIClient(url);
+        client.setHttpClient(client.getHttpClient()
+                .newBuilder()
+                .readTimeout(requestTimeout)
+                .build());
+
+        Authentication authorizationToken = client.getAuthentication("AuthorizationToken");
+        if(authorizationToken instanceof OAuth) {
+            ((OAuth)authorizationToken).setAccessToken(authToken);
+        }
+
+        return brAPIEndpointProvider.get(client, VendorApi.class);
+    }
+
+    public Optional<SampleSubmission> updateSubmissionStatus(Program program, UUID submissionId, SampleSubmission.Status status, User user) throws ApiException {
+        Optional<SampleSubmission> submissionOptional = this.getSampleSubmission(program, submissionId, false);
+        if(submissionOptional.isEmpty()) {
+            return Optional.empty();
+        }
+
+        SampleSubmission submission = submissionOptional.get();
+        if(StringUtils.isBlank(submission.getVendorOrderId())) {
+            SampleSubmission.Status currentStatus = SampleSubmission.Status.fromValue(submission.getVendorStatus());
+            if(currentStatus != status) {
+                if((currentStatus == null || currentStatus == SampleSubmission.Status.NOT_SUBMITTED) && status != SampleSubmission.Status.NOT_SUBMITTED) {
+                    submission.setSubmitted(true);
+                    submission.setSubmittedByUser(user);
+                    submission.setSubmittedDate(OffsetDateTime.now());
+                }
+                submission.setVendorStatus(status.getValue());
+
+                if(status == SampleSubmission.Status.NOT_SUBMITTED){
+                    submission.setSubmitted(false);
+                    submission.setSubmittedBy(null);
+                    submission.setSubmittedByUser(null);
+                    submission.setSubmittedDate(null);
+                    submission.setVendorStatus(null);
+                }
+
+                return Optional.ofNullable(submissionDAO.update(submission, user));
+            }
+        }
+
+        return submissionOptional;
     }
 }

--- a/src/main/java/org/breedinginsight/services/TraitUploadService.java
+++ b/src/main/java/org/breedinginsight/services/TraitUploadService.java
@@ -111,7 +111,8 @@ public class TraitUploadService {
                 throw new HttpStatusException(HttpStatus.BAD_REQUEST, "Error parsing csv: " + e.getMessage());
             }
         } else if (mediaType.toString().equals(SupportedMediaType.XLS) ||
-                   mediaType.toString().equals(SupportedMediaType.XLSX)) {
+                   mediaType.toString().equals(SupportedMediaType.XLSX) ||
+                   mediaType.toString().equals(SupportedMediaType.XLSB)) {
             try {
                 traits = parser.parseExcel(new BOMInputStream(file.getInputStream(), false));
             } catch(IOException | ParsingException e) {

--- a/src/main/java/org/breedinginsight/services/constants/SupportedMediaType.java
+++ b/src/main/java/org/breedinginsight/services/constants/SupportedMediaType.java
@@ -22,4 +22,6 @@ public class SupportedMediaType {
     public static final String XLS = "application/vnd.ms-excel";
     public static final String XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
+    public static final String XLSB = "application/vnd.ms-excel.sheet.binary.macroenabled.12";
+
 }

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -281,12 +281,12 @@ public class BrAPIDAOUtil {
         throw new UnsupportedOperationException();
     }
 
-    public <T> List<T> post(List<T> brapiObjects,
-                                   ImportUpload upload,
-                                   Function<List<T>, ApiResponse> postMethod,
-                                   Consumer<ImportUpload> progressUpdateMethod) throws ApiException {
+    public <T, R> List<R> post(List<T> brapiObjects,
+                            ImportUpload upload,
+                            Function<List<T>, ApiResponse> postMethod,
+                            Consumer<ImportUpload> progressUpdateMethod) throws ApiException {
 
-        List<T> listResult = new ArrayList<>();
+        List<R> listResult = new ArrayList<>();
         try {
             // Make the POST calls in chunks so we don't overload the brapi server
             Integer currentRightBorder = 0;
@@ -314,7 +314,7 @@ public class BrAPIDAOUtil {
                 if (result.getData() == null) {
                     throw new ApiException("Response result is missing data", response.getStatusCode(), response.getHeaders(), response.getBody().toString());
                 }
-                List<T> data = result.getData();
+                List<R> data = result.getData();
                 // TODO: Maybe move this outside of the loop
                 if (data.size() != postChunk.size()) {
                     throw new ApiException("Number of brapi objects returned does not equal number sent");

--- a/src/main/java/org/breedinginsight/utilities/FileUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/FileUtil.java
@@ -17,14 +17,18 @@
 
 package org.breedinginsight.utilities;
 
+import io.micronaut.http.server.types.files.StreamedFile;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.poi.EncryptedDocumentException;
 import org.apache.poi.ss.usermodel.*;
+import org.breedinginsight.brapps.importer.model.exports.FileType;
 import org.breedinginsight.services.parsers.ParsingException;
 import org.breedinginsight.services.parsers.ParsingExceptionType;
+import org.breedinginsight.services.writers.CSVWriter;
+import org.breedinginsight.services.writers.ExcelWriter;
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
@@ -245,5 +249,13 @@ public class FileUtil {
         table.removeColumns(columnsToRemove.toArray(Column[]::new));
 
         return table;
+    }
+
+    public static StreamedFile writeToStreamedFile(List<org.breedinginsight.model.Column> columns, List<Map<String, Object>> data, FileType extension, String sheetName) throws IOException {
+        if (extension.equals(FileType.CSV)){
+            return CSVWriter.writeToDownload(columns, data, extension);
+        } else {
+            return ExcelWriter.writeToDownload(sheetName, columns, data, extension);
+        }
     }
 }

--- a/src/main/resources/application-dev.yml.template
+++ b/src/main/resources/application-dev.yml.template
@@ -1,0 +1,10 @@
+##For local development:
+## 1. spin up a LocalStack container
+## 2. copy this file and rename it to `application-dev.yml`
+## 3. uncomment these lines, and update the `endpoint` value
+## 4. set the environment variable MICRONAUT_ENVIRONMENTS=dev
+#aws:
+#  s3:
+#    buckets:
+#      geno:
+#        endpoint: <url to LocalStack>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -160,8 +160,9 @@ brapi:
     pheno-url: ${brapi.server.default-url}
     geno-url: ${brapi.server.default-url}
     reference-source: ${BRAPI_REFERENCE_SOURCE:breedinginsight.org}
+  vendor-submission-enabled: ${BRAPI_VENDOR_SUBMISSION_ENABLED:false}
+  vendor-check-frequency: ${BRAPI_VENDOR_CHECK_FREQUENCY:1d}
   vendors:
-    submission-enabled: ${BRAPI_VENDOR_SUBMISSION_ENABLED:false}
     dart:
       url: ${DART_VENDOR_URL:`https://test-server.brapi.org`}
       client-id: ${DART_CLIENT_ID:potato-salad}
@@ -171,7 +172,6 @@ brapi:
   search:
     wait-time: 1000
   post-group-size: ${POST_CHUNK_SIZE:1000}
-  vendor-check-frequency: ${VENDOR_CHECK_FREQUENCY:30s}
 
 email:
   relay-server:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -159,11 +159,13 @@ brapi:
     core-url: ${brapi.server.default-url}
     pheno-url: ${brapi.server.default-url}
     geno-url: ${brapi.server.default-url}
-    vendor:
-      dart-url: ${DART_VENDOR_URL}
-      dart-client-id: ${DART_CLIENT_ID:potato-salad}
-      dart-token: ${DART_TOKEN:YYYY}
     reference-source: ${BRAPI_REFERENCE_SOURCE:breedinginsight.org}
+  vendors:
+    submission-enabled: ${BRAPI_VENDOR_SUBMISSION_ENABLED:false}
+    dart:
+      url: ${DART_VENDOR_URL:`https://test-server.brapi.org`}
+      client-id: ${DART_CLIENT_ID:potato-salad}
+      token: ${DART_TOKEN:YYYY}
   read-timeout: ${BRAPI_READ_TIMEOUT:10m}
   page-size: 1000
   search:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -154,17 +154,22 @@ web:
 
 brapi:
   server:
-    default-url: ${BRAPI_DEFAULT_URL:`https://test-server.brapi.org`}
+    default-url: ${BRAPI_DEFAULT_URL}
     # leave these for future but all point to default for now
     core-url: ${brapi.server.default-url}
     pheno-url: ${brapi.server.default-url}
     geno-url: ${brapi.server.default-url}
+    vendor:
+      dart-url: ${DART_VENDOR_URL}
+      dart-client-id: ${DART_CLIENT_ID:potato-salad}
+      dart-token: ${DART_TOKEN:YYYY}
     reference-source: ${BRAPI_REFERENCE_SOURCE:breedinginsight.org}
   read-timeout: ${BRAPI_READ_TIMEOUT:10m}
   page-size: 1000
   search:
     wait-time: 1000
   post-group-size: ${POST_CHUNK_SIZE:1000}
+  vendor-check-frequency: ${VENDOR_CHECK_FREQUENCY:30s}
 
 email:
   relay-server:

--- a/src/main/resources/db/migration/V1.16.0__create_sampleimport_mapping.sql
+++ b/src/main/resources/db/migration/V1.16.0__create_sampleimport_mapping.sql
@@ -1,0 +1,108 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+DO
+$$
+    DECLARE
+        user_id UUID;
+    BEGIN
+
+        user_id := (SELECT id FROM bi_user WHERE name = 'system');
+
+        INSERT INTO public.importer_mapping (id, name, import_type_id, mapping, file, draft, created_at, updated_at, created_by, updated_by)
+        VALUES (uuid_generate_v4(),
+                'SampleImport',
+                'SampleImport', '[
+            {
+              "id": "e4038afd-02b9-475a-88b2-4692e331c399",
+              "value": {
+                "fileFieldName": "PlateID"
+              },
+              "objectId": "plateId"
+            },
+            {
+              "id": "9488023c-ed28-4357-811e-7c517cbd9f68",
+              "value": {
+                "fileFieldName": "Row"
+              },
+              "objectId": "row"
+            },
+            {
+              "id": "54b47821-c868-4fbd-acd6-8b8a64a02230",
+              "value": {
+                "fileFieldName": "Column"
+              },
+              "objectId": "column"
+            },
+            {
+              "id": "f9e39005-e8be-4e83-92b8-a459fe296d2f",
+              "value": {
+                "fileFieldName": "Organism"
+              },
+              "objectId": "organism"
+            },
+            {
+              "id": "fe37a2a5-00e0-4076-b130-846f19b3defd",
+              "value": {
+                "fileFieldName": "Species"
+              },
+              "objectId": "species"
+            },
+            {
+              "id": "e5074e78-b8ba-474e-87df-716a759f0517",
+              "value": {
+                "fileFieldName": "Germplasm Name"
+              },
+              "objectId": "germplasmName"
+            },
+            {
+              "id": "15a20991-ee85-49c6-b5c3-5db4e3dca372",
+              "value": {
+                "fileFieldName": "GID"
+              },
+              "objectId": "gid"
+            },
+            {
+              "id": "11e2af68-ca45-4164-9bbb-326c68894fec",
+              "value": {
+                "fileFieldName": "ObsUnitID"
+              },
+              "objectId": "obsUnitId"
+            },
+            {
+              "id": "e7731381-7b92-42c3-97f0-38fb37208e8d",
+              "value": {
+                "fileFieldName": "Tissue"
+              },
+              "objectId": "tissue"
+            },
+            {
+              "id": "de7fed3a-ec44-4139-83cb-c773e09237bd",
+              "value": {
+                "fileFieldName": "Comment"
+              },
+              "objectId": "comment"
+            }
+          ]', '[]',
+                false,
+                '2023-10-18 02:03:17 +00:00',
+                '2023-10-18 02:03:17 +00:00',
+                user_id,
+                user_id);
+
+    END
+$$;

--- a/src/main/resources/db/migration/V1.16.0__create_sampleimport_mapping.sql
+++ b/src/main/resources/db/migration/V1.16.0__create_sampleimport_mapping.sql
@@ -93,9 +93,9 @@ $$
             {
               "id": "de7fed3a-ec44-4139-83cb-c773e09237bd",
               "value": {
-                "fileFieldName": "Comment"
+                "fileFieldName": "Comments"
               },
-              "objectId": "comment"
+              "objectId": "comments"
             }
           ]', '[]',
                 false,

--- a/src/main/resources/db/migration/V1.17.0__create_sample_submission_table.sql
+++ b/src/main/resources/db/migration/V1.17.0__create_sample_submission_table.sql
@@ -1,0 +1,36 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+create table sample_submission
+(
+    like base_entity INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES,
+    name            TEXT,
+    submitted       bool default false,
+    submittedDate   timestamp(0) with time zone,
+    vendor_order_id TEXT,
+    vendor_status TEXT,
+    shipmentForms   jsonb,
+    program_id      UUID NOT NULL,
+    like base_edit_track_entity INCLUDING ALL
+);
+
+ALTER TABLE sample_submission
+    ADD FOREIGN KEY (created_by) REFERENCES bi_user (id);
+ALTER TABLE sample_submission
+    ADD FOREIGN KEY (updated_by) REFERENCES bi_user (id);
+ALTER TABLE sample_submission
+    ADD FOREIGN KEY (program_id) REFERENCES program (id);

--- a/src/main/resources/db/migration/V1.17.0__create_sample_submission_table.sql
+++ b/src/main/resources/db/migration/V1.17.0__create_sample_submission_table.sql
@@ -20,10 +20,12 @@ create table sample_submission
     like base_entity INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES,
     name            TEXT,
     submitted       bool default false,
-    submittedDate   timestamp(0) with time zone,
+    submitted_date   timestamp(0) with time zone,
+    submitted_by UUID,
     vendor_order_id TEXT,
     vendor_status TEXT,
-    shipmentForms   jsonb,
+    vendor_status_last_check timestamp(0) with time zone,
+    shipmentforms   jsonb,
     program_id      UUID NOT NULL,
     like base_edit_track_entity INCLUDING ALL
 );
@@ -34,3 +36,5 @@ ALTER TABLE sample_submission
     ADD FOREIGN KEY (updated_by) REFERENCES bi_user (id);
 ALTER TABLE sample_submission
     ADD FOREIGN KEY (program_id) REFERENCES program (id);
+ALTER TABLE sample_submission
+    ADD FOREIGN KEY (submitted_by) REFERENCES bi_user (id);

--- a/src/test/java/org/breedinginsight/api/v1/controller/SampleSubmissionControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/SampleSubmissionControllerIntegrationTest.java
@@ -1,0 +1,502 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.api.v1.controller;
+
+import com.eclipsesource.json.Json;
+import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
+import io.kowalski.fannypack.FannyPack;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.RxHttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.netty.cookies.NettyCookie;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.reactivex.Flowable;
+import org.apache.commons.lang3.tuple.Pair;
+import org.brapi.client.v2.BrAPIClient;
+import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.geno.BrAPISample;
+import org.brapi.v2.model.germ.BrAPIGermplasm;
+import org.breedinginsight.BrAPITest;
+import org.breedinginsight.TestUtils;
+import org.breedinginsight.api.model.v1.request.ProgramRequest;
+import org.breedinginsight.api.model.v1.request.SpeciesRequest;
+import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
+import org.breedinginsight.brapps.importer.ImportTestUtils;
+import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
+import org.breedinginsight.brapps.importer.model.imports.sample.SampleSubmissionImport;
+import org.breedinginsight.brapps.importer.model.imports.sample.SampleSubmissionImport.Columns;
+import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.dao.db.tables.pojos.ProgramBreedingMethodEntity;
+import org.breedinginsight.dao.db.tables.pojos.SpeciesEntity;
+import org.breedinginsight.daos.SpeciesDAO;
+import org.breedinginsight.daos.UserDAO;
+import org.breedinginsight.model.*;
+import org.breedinginsight.services.OntologyService;
+import org.breedinginsight.services.parsers.ParsingException;
+import org.breedinginsight.services.parsers.experiment.ExperimentFileColumns;
+import org.breedinginsight.services.writers.CSVWriter;
+import org.breedinginsight.utilities.FileUtil;
+import org.breedinginsight.utilities.Utilities;
+import org.jetbrains.annotations.NotNull;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import tech.tablesaw.api.Table;
+
+import javax.inject.Inject;
+import java.io.*;
+import java.time.OffsetDateTime;
+import java.util.*;
+
+import static io.micronaut.http.HttpRequest.*;
+import static org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields.SUBMISSION_NAME;
+import static org.junit.jupiter.api.Assertions.*;
+
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class SampleSubmissionControllerIntegrationTest extends BrAPITest {
+
+    private Program program;
+
+    private ImportTestUtils importTestUtils;
+
+    private String experimentId;
+    private List<String> envIds = new ArrayList<>();
+    private final List<Map<String, Object>> rows = new ArrayList<>();
+    private final List<Column> columns = ExperimentFileColumns.getOrderedColumns();
+    private List<Trait> traits;
+
+    @Property(name = "brapi.server.reference-source")
+    private String BRAPI_REFERENCE_SOURCE;
+    @Inject
+    private DSLContext dsl;
+    @Inject
+    private UserDAO userDAO;
+    @Inject
+    private SpeciesDAO speciesDAO;
+    @Inject
+    private OntologyService ontologyService;
+    @Inject
+    private BrAPIGermplasmDAO germplasmDAO;
+
+    @Inject
+    @Client("/${micronaut.bi.api.version}")
+    private RxHttpClient client;
+
+//    private final Gson gson = new GsonBuilder().registerTypeAdapter(OffsetDateTime.class, (JsonDeserializer<OffsetDateTime>)
+//                    (json, type, context) -> OffsetDateTime.parse(json.getAsString()))
+//            .create();
+
+    private final Gson gson = new BrAPIClient().getJSON().getGson();
+
+    @BeforeAll
+    void setup() throws Exception {
+        importTestUtils = new ImportTestUtils();
+        FannyPack fp = FannyPack.fill("src/test/resources/sql/ImportControllerIntegrationTest.sql");
+        FannyPack securityFp = FannyPack.fill("src/test/resources/sql/ProgramSecuredAnnotationRuleIntegrationTest.sql");
+        FannyPack brapiFp = FannyPack.fill("src/test/resources/sql/brapi/species.sql");
+
+        // Test User
+        User testUser = userDAO.getUserByOrcId(TestTokenValidator.TEST_USER_ORCID).orElseThrow(Exception::new);
+        dsl.execute(securityFp.get("InsertSystemRoleAdmin"), testUser.getId().toString());
+
+        // Species
+        super.getBrapiDsl().execute(brapiFp.get("InsertSpecies"));
+        SpeciesEntity validSpecies = speciesDAO.findAll().get(0);
+        SpeciesRequest speciesRequest = SpeciesRequest.builder()
+                .commonName(validSpecies.getCommonName())
+                .id(validSpecies.getId())
+                .build();
+
+        // Test Program
+        ProgramRequest programRequest = ProgramRequest.builder()
+                .name("Test Program")
+                .abbreviation("Test")
+                .documentationUrl("localhost:8080")
+                .objective("To test things")
+                .species(speciesRequest)
+                .key("TEST")
+                .build();
+        program = TestUtils.insertAndFetchTestProgram(gson, client, programRequest);
+
+        dsl.execute(securityFp.get("InsertProgramRolesBreeder"), testUser.getId().toString(), program.getId());
+        dsl.execute(securityFp.get("InsertSystemRoleAdmin"), testUser.getId().toString());
+
+        List<BrAPIGermplasm> germplasm = createGermplasm(96);
+        BrAPIExternalReference newReference = new BrAPIExternalReference();
+        newReference.setReferenceSource(String.format("%s/programs", BRAPI_REFERENCE_SOURCE));
+        newReference.setReferenceID(program.getId().toString());
+
+        germplasm.forEach(germ -> germ.getExternalReferences().add(newReference));
+
+        germplasmDAO.createBrAPIGermplasm(germplasm, program.getId(), null);
+    }
+
+    @NotNull
+    @Override
+    public Map<String, String> getProperties() {
+        Map<String, String> properties = super.getProperties();
+
+        properties.put("brapi.vendor-submission-enabled", "true");
+
+        Integer containerPort = getBrapiContainer().getMappedPort(8080);
+        String containerIp = getBrapiContainer().getContainerIpAddress();
+        properties.put("brapi.vendors.dart.url", String.format("http://%s:%s/", containerIp, containerPort));
+
+        return properties;
+    }
+
+    /*
+    Tests
+    - fetch all sample submissions
+    - fetch individual sample submission
+    - manual update submission status
+    - brapi submit
+    - check vendor status
+
+     */
+
+    @Test
+    public void testFetchProgramSubmissions() throws IOException, InterruptedException {
+        List<UUID> submissionIds = new ArrayList<>();
+        submissionIds.add(createSubmission(program).getLeft().getId());
+        submissionIds.add(createSubmission(program).getLeft().getId());
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET(String.format("/programs/%s/submissions", program.getId())).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> response = call.blockingFirst();
+        List<SampleSubmission> submissions = gson.fromJson(JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").getAsJsonArray("data"), new TypeToken<List<SampleSubmission>>(){}.getType());
+        assertTrue(submissions.size() >= 2);
+
+
+        List<UUID> returnedSubmissionIds = new ArrayList<>();
+        for(var submission : submissions) {
+            if(submissionIds.contains(submission.getId())) {
+                returnedSubmissionIds.add(submission.getId());
+            }
+        }
+        assertEquals(submissionIds.size(), returnedSubmissionIds.size());
+    }
+
+    @Test
+    public void testFetchIndividualSubmissions() throws IOException, InterruptedException {
+        Pair<SampleSubmission, List<Map<String, Object>>> uploadedSubmission = createSubmission(program);
+
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET(String.format("/programs/%s/submissions/%s?details=true", program.getId(), uploadedSubmission.getLeft().getId())).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> response = call.blockingFirst();
+        SampleSubmission retrievedSubmission = gson.fromJson(JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result"), SampleSubmission.class);
+
+        assertNotNull(retrievedSubmission);
+        assertEquals(uploadedSubmission.getLeft().getId(), retrievedSubmission.getId());
+        assertEquals(uploadedSubmission.getLeft().getName(), retrievedSubmission.getName());
+        assertEquals(1, retrievedSubmission.getPlates().size());
+        assertEquals(96, retrievedSubmission.getSamples().size());
+    }
+
+    @Test
+    public void testManualUpdateSubmissions() throws IOException, InterruptedException {
+        Pair<SampleSubmission, List<Map<String, Object>>> uploadedSubmission = createSubmission(program);
+
+        Flowable<HttpResponse<String>> putCall = client.exchange(
+                PUT(String.format("/programs/%s/submissions/%s/status", program.getId(), uploadedSubmission.getLeft().getId()), "{status:\"SUBMITTED\"}").cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> putResponse = putCall.blockingFirst();
+        assertNotNull(putResponse.body());
+
+        Flowable<HttpResponse<String>> fetchCall = client.exchange(
+                GET(String.format("/programs/%s/submissions/%s?details=true", program.getId(), uploadedSubmission.getLeft().getId())).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> fetchResponse = fetchCall.blockingFirst();
+        SampleSubmission retrievedSubmission = gson.fromJson(JsonParser.parseString(fetchResponse.body()).getAsJsonObject().getAsJsonObject("result"), SampleSubmission.class);
+
+        assertNotNull(retrievedSubmission);
+        assertEquals("SUBMITTED", retrievedSubmission.getVendorStatus());
+        assertNull(retrievedSubmission.getVendorOrderId());
+        assertNull(retrievedSubmission.getVendorStatusLastCheck());
+    }
+
+    @Test
+    public void testSubmitViaBrAPI() throws IOException, InterruptedException {
+        Pair<SampleSubmission, List<Map<String, Object>>> uploadedSubmission = createSubmission(program);
+
+        Flowable<HttpResponse<String>> postCall = client.exchange(
+                POST(String.format("/programs/%s/submissions/%s/submit?vendor=dart", program.getId(), uploadedSubmission.getLeft().getId()), null).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> postResponse = postCall.blockingFirst();
+        assertNotNull(postResponse.body());
+
+        Flowable<HttpResponse<String>> fetchCall = client.exchange(
+                GET(String.format("/programs/%s/submissions/%s?details=true", program.getId(), uploadedSubmission.getLeft().getId())).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> fetchResponse = fetchCall.blockingFirst();
+        SampleSubmission retrievedSubmission = gson.fromJson(JsonParser.parseString(fetchResponse.body()).getAsJsonObject().getAsJsonObject("result"), SampleSubmission.class);
+
+        assertNotNull(retrievedSubmission);
+        assertEquals("SUBMITTED", retrievedSubmission.getVendorStatus());
+        assertNotNull(retrievedSubmission.getVendorOrderId());
+        assertNull(retrievedSubmission.getVendorStatusLastCheck());
+    }
+
+    @Test
+    public void testCheckVendorStatus() throws IOException, InterruptedException {
+        Pair<SampleSubmission, List<Map<String, Object>>> uploadedSubmission = createSubmission(program);
+
+        Flowable<HttpResponse<String>> postCall = client.exchange(
+                POST(String.format("/programs/%s/submissions/%s/submit?vendor=dart", program.getId(), uploadedSubmission.getLeft().getId()), null).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> postResponse = postCall.blockingFirst();
+        assertNotNull(postResponse.body());
+
+        Flowable<HttpResponse<String>> fetchCall = client.exchange(
+                GET(String.format("/programs/%s/submissions/%s?details=false", program.getId(), uploadedSubmission.getLeft().getId())).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> fetchResponse = fetchCall.blockingFirst();
+        SampleSubmission retrievedSubmission = gson.fromJson(JsonParser.parseString(fetchResponse.body()).getAsJsonObject().getAsJsonObject("result"), SampleSubmission.class);
+
+        assertNotNull(retrievedSubmission);
+        assertNotNull(retrievedSubmission.getVendorOrderId());
+        assertNull(retrievedSubmission.getVendorStatusLastCheck());
+
+        Flowable<HttpResponse<String>> fetchStatus = client.exchange(
+                GET(String.format("/programs/%s/submissions/%s/status", program.getId(), uploadedSubmission.getLeft().getId())).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> fetchStatusResponse = fetchStatus.blockingFirst();
+        assertNotNull(fetchStatusResponse.body());
+
+        Flowable<HttpResponse<String>> fetchSubmissionAfterStatus = client.exchange(
+                GET(String.format("/programs/%s/submissions/%s?details=false", program.getId(), uploadedSubmission.getLeft().getId())).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> fetchSubmissionAfterStatusResponse = fetchSubmissionAfterStatus.blockingFirst();
+        SampleSubmission updatedStatusResponse = gson.fromJson(JsonParser.parseString(fetchSubmissionAfterStatusResponse.body()).getAsJsonObject().getAsJsonObject("result"), SampleSubmission.class);
+        assertNotNull(updatedStatusResponse.getVendorStatusLastCheck());
+
+        Thread.sleep(1000);
+
+        fetchStatus = client.exchange(
+                GET(String.format("/programs/%s/submissions/%s/status", program.getId(), uploadedSubmission.getLeft().getId())).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        fetchStatusResponse = fetchStatus.blockingFirst();
+        assertNotNull(fetchStatusResponse.body());
+
+        fetchSubmissionAfterStatus = client.exchange(
+                GET(String.format("/programs/%s/submissions/%s?details=false", program.getId(), uploadedSubmission.getLeft().getId())).cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        fetchSubmissionAfterStatusResponse = fetchSubmissionAfterStatus.blockingFirst();
+        SampleSubmission updatedStatusResponse2 = gson.fromJson(JsonParser.parseString(fetchSubmissionAfterStatusResponse.body()).getAsJsonObject().getAsJsonObject("result"), SampleSubmission.class);
+        assertTrue(updatedStatusResponse2.getVendorStatusLastCheck().isAfter(updatedStatusResponse.getVendorStatusLastCheck()));
+    }
+
+    @Test
+    public void testGenerateDArTFile() throws IOException, InterruptedException, ParsingException {
+        Pair<SampleSubmission, List<Map<String, Object>>> uploadedSubmission = createSubmission(program);
+
+        Flowable<HttpResponse<byte[]>> call = client.exchange(
+                GET(String.format("/programs/%s/submissions/%s/dart",
+                        program.getId().toString(), uploadedSubmission.getLeft().getId()))
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), byte[].class
+        );
+        HttpResponse<byte[]> response = call.blockingFirst();
+
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        ByteArrayInputStream bodyStream = new ByteArrayInputStream(Objects.requireNonNull(response.body()));
+        Table lookupTable = FileUtil.parseTableFromCsv(bodyStream);
+        assertEquals(8, lookupTable.columnCount());
+        assertEquals(Columns.PLATE_ID, lookupTable.column(0).name());
+        assertEquals(Columns.ROW, lookupTable.column(1).name());
+        assertEquals(Columns.COLUMN, lookupTable.column(2).name());
+        assertEquals(Columns.ORGANISM, lookupTable.column(3).name());
+        assertEquals(Columns.SPECIES, lookupTable.column(4).name());
+        assertEquals("Genotype", lookupTable.column(5).name());
+        assertEquals(Columns.TISSUE, lookupTable.column(6).name());
+        assertEquals(Columns.COMMENTS, lookupTable.column(7).name());
+    }
+
+    @Test
+    public void testGenerateLookupFile() throws IOException, InterruptedException, ParsingException {
+        Pair<SampleSubmission, List<Map<String, Object>>> uploadedSubmission = createSubmission(program);
+
+        Flowable<HttpResponse<byte[]>> call = client.exchange(
+                GET(String.format("/programs/%s/submissions/%s/lookup",
+                        program.getId().toString(), uploadedSubmission.getLeft().getId()))
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")), byte[].class
+        );
+        HttpResponse<byte[]> response = call.blockingFirst();
+
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        ByteArrayInputStream bodyStream = new ByteArrayInputStream(Objects.requireNonNull(response.body()));
+        Table lookupTable = FileUtil.parseTableFromCsv(bodyStream);
+        assertEquals(3, lookupTable.columnCount());
+        assertEquals("Genotype", lookupTable.column(0).name());
+        assertEquals("Germplasm Name", lookupTable.column(1).name());
+        assertEquals("GID", lookupTable.column(2).name());
+    }
+
+
+    private Pair<SampleSubmission, List<Map<String, Object>>> createSubmission(Program program) throws IOException, InterruptedException {
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/import/mappings?importName=SampleImport").cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> response = call.blockingFirst();
+        String sampleMappingId = JsonParser.parseString(response.body()).getAsJsonObject()
+                .getAsJsonObject("result")
+                .getAsJsonArray("data")
+                .get(0).getAsJsonObject().get("id").getAsString();
+
+        var submissionData = makeSubmission();
+        var submission = new SampleSubmission();
+        submission.setName("test-"+UUID.randomUUID());
+
+        JsonObject importResult = importTestUtils.uploadAndFetch(
+                writeSubmissionToFile(submissionData),
+                Map.of(SUBMISSION_NAME, submission.getName()),
+                true,
+                client,
+                program,
+                sampleMappingId);
+        JsonArray previewRows = importResult.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
+        assertEquals(96, previewRows.size());
+        JsonObject row = previewRows.get(0).getAsJsonObject();
+        BrAPISample sample = new Gson().fromJson(row.getAsJsonObject("sample").getAsJsonObject("brAPIObject"), BrAPISample.class);
+        BrAPIExternalReference xref = Utilities.getExternalReference(sample.getExternalReferences(), Utilities.generateReferenceSource(BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.PLATE_SUBMISSIONS)).get();
+        submission.setId(UUID.fromString(xref.getReferenceId()));
+
+        return Pair.of(submission, submissionData);
+    }
+
+    private List<Map<String, Object>> makeSubmission() {
+        List<Map<String, Object>> validFile = new ArrayList<>();
+        int germGidCounter = 1;
+        for(int i = 0; i < 8; i++) {
+            for(int j = 0; j < 12; j++) {
+                Map<String, Object> validRow = new HashMap<>();
+                validRow.put(Columns.PLATE_ID, "valid_1");
+                validRow.put(Columns.ROW, Character.toString('A' + i));
+                validRow.put(Columns.COLUMN, j+1);
+                validRow.put(Columns.ORGANISM, "TEST");
+                validRow.put(Columns.SPECIES, "TEST");
+                validRow.put(Columns.GERMPLASM_NAME, "");
+                validRow.put(Columns.GERMPLASM_GID, germGidCounter++);
+                validRow.put(Columns.OBS_UNIT_ID, "");
+                validRow.put(Columns.TISSUE, "TEST");
+                validRow.put(Columns.COMMENTS, "Test sample");
+                validFile.add(validRow);
+            }
+        }
+
+        return validFile;
+    }
+
+    private String createExperiment(Program program) throws IOException, InterruptedException {
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/import/mappings?importName=ExperimentsTemplateMap").cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> response = call.blockingFirst();
+        String expMappingId = JsonParser.parseString(response.body()).getAsJsonObject()
+                .getAsJsonObject("result")
+                .getAsJsonArray("data")
+                .get(0).getAsJsonObject().get("id").getAsString();
+
+        JsonObject importResult = importTestUtils.uploadAndFetch(
+                importTestUtils.writeExperimentDataToFile(List.of(makeExpImportRow("Env1")), null),
+                null,
+                true,
+                client,
+                program,
+                expMappingId);
+        return importResult
+                .get("preview").getAsJsonObject()
+                .get("rows").getAsJsonArray()
+                .get(0).getAsJsonObject()
+                .get("trial").getAsJsonObject()
+                .get("id").getAsString();
+    }
+
+    private Map<String, Object> makeExpImportRow(String environment) {
+        Map<String, Object> row = new HashMap<>();
+        row.put(ExperimentObservation.Columns.GERMPLASM_GID, "1");
+        row.put(ExperimentObservation.Columns.TEST_CHECK, "T");
+        row.put(ExperimentObservation.Columns.EXP_TITLE, "Test Exp");
+        row.put(ExperimentObservation.Columns.EXP_UNIT, "Plot");
+        row.put(ExperimentObservation.Columns.EXP_TYPE, "Phenotyping");
+        row.put(ExperimentObservation.Columns.ENV, environment);
+        row.put(ExperimentObservation.Columns.ENV_LOCATION, "Location A");
+        row.put(ExperimentObservation.Columns.ENV_YEAR, "2023");
+        row.put(ExperimentObservation.Columns.EXP_UNIT_ID, "a-1");
+        row.put(ExperimentObservation.Columns.REP_NUM, "1");
+        row.put(ExperimentObservation.Columns.BLOCK_NUM, "1");
+        row.put(ExperimentObservation.Columns.ROW, "1");
+        row.put(ExperimentObservation.Columns.COLUMN, "1");
+        return row;
+    }
+
+    public File writeSubmissionToFile(List<Map<String, Object>> data) throws IOException {
+        File file = File.createTempFile("test", ".csv");
+
+        List<Column> columns = new ArrayList<>();
+        columns.add(Column.builder().value(Columns.PLATE_ID).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.ROW).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.COLUMN).dataType(Column.ColumnDataType.INTEGER).build());
+        columns.add(Column.builder().value(Columns.ORGANISM).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.SPECIES).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.GERMPLASM_NAME).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.GERMPLASM_GID).dataType(Column.ColumnDataType.INTEGER).build());
+        columns.add(Column.builder().value(Columns.OBS_UNIT_ID).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.TISSUE).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.COMMENTS).dataType(Column.ColumnDataType.STRING).build());
+
+        ByteArrayOutputStream byteArrayOutputStream = CSVWriter.writeToCSV(columns, data);
+        FileOutputStream fos = new FileOutputStream(file);
+        fos.write(byteArrayOutputStream.toByteArray());
+
+        return file;
+    }
+
+    private List<BrAPIGermplasm> createGermplasm(int numToCreate) {
+        List<BrAPIGermplasm> germplasm = new ArrayList<>();
+        for (int i = 0; i < numToCreate; i++) {
+            String gid = ""+(i+1);
+            BrAPIGermplasm testGermplasm = new BrAPIGermplasm();
+            testGermplasm.setGermplasmName(String.format("Germplasm %s [TEST-%s]", gid, gid));
+            testGermplasm.setSeedSource("Wild");
+            testGermplasm.setAccessionNumber(gid);
+            testGermplasm.setDefaultDisplayName(String.format("Germplasm %s", gid));
+            JsonObject additionalInfo = new JsonObject();
+            additionalInfo.addProperty("importEntryNumber", gid);
+            additionalInfo.addProperty("breedingMethod", "Allopolyploid");
+            testGermplasm.setAdditionalInfo(additionalInfo);
+            List<BrAPIExternalReference> externalRef = new ArrayList<>();
+            BrAPIExternalReference testReference = new BrAPIExternalReference();
+            testReference.setReferenceSource(BRAPI_REFERENCE_SOURCE);
+            testReference.setReferenceID(UUID.randomUUID().toString());
+            externalRef.add(testReference);
+            testGermplasm.setExternalReferences(externalRef);
+            germplasm.add(testGermplasm);
+        }
+
+        return germplasm;
+    }
+}

--- a/src/test/java/org/breedinginsight/api/v1/controller/SampleSubmissionControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/SampleSubmissionControllerIntegrationTest.java
@@ -102,10 +102,6 @@ public class SampleSubmissionControllerIntegrationTest extends BrAPITest {
     @Client("/${micronaut.bi.api.version}")
     private RxHttpClient client;
 
-//    private final Gson gson = new GsonBuilder().registerTypeAdapter(OffsetDateTime.class, (JsonDeserializer<OffsetDateTime>)
-//                    (json, type, context) -> OffsetDateTime.parse(json.getAsString()))
-//            .create();
-
     private final Gson gson = new BrAPIClient().getJSON().getGson();
 
     @BeforeAll

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ControllerIntegrationTest.java
@@ -387,6 +387,7 @@ public class BrAPIV2ControllerIntegrationTest extends BrAPITest {
         return new BrAPIObservationVariable().observationVariableName("test" + random)
                                              .commonCropName("Grape")
                                              .externalReferences(Collections.singletonList(new BrAPIExternalReference().referenceID("abc123")
+                                                                                                                       .referenceId("abc123")
                                                                                                                        .referenceSource("breedinginsight.org")))
                                              .trait(new BrAPITrait().traitClass("Agronomic")
                                                                     .traitName("test trait" + random))

--- a/src/test/java/org/breedinginsight/brapi/v2/ListControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/ListControllerIntegrationTest.java
@@ -142,7 +142,7 @@ public class ListControllerIntegrationTest extends BrAPITest {
         newExp.put(traits.get(0).getObservationVariableName(), "1");
 
         JsonObject result = importTestUtils.uploadAndFetch(
-                importTestUtils.writeDataToFile(List.of(newExp), traits), null, true, client, program, mappingId
+                importTestUtils.writeExperimentDataToFile(List.of(newExp), traits), null, true, client, program, mappingId
         );
 
     }

--- a/src/test/java/org/breedinginsight/brapps/importer/ImportTestUtils.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ImportTestUtils.java
@@ -196,7 +196,7 @@ public class ImportTestUtils {
         return traits;
     }
 
-    public File writeDataToFile(List<Map<String, Object>> data, List<Trait> traits) throws IOException {
+    public File writeExperimentDataToFile(List<Map<String, Object>> data, List<Trait> traits) throws IOException {
         File file = File.createTempFile("test", ".csv");
 
         List<Column> columns = new ArrayList<>();

--- a/src/test/java/org/breedinginsight/brapps/importer/SampleSubmissionFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/SampleSubmissionFileImportTest.java
@@ -1,0 +1,592 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapps.importer;
+
+import com.google.gson.*;
+import io.kowalski.fannypack.FannyPack;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.RxHttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.netty.cookies.NettyCookie;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.reactivex.Flowable;
+import lombok.SneakyThrows;
+import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.client.v2.typeAdapters.PaginationTypeAdapter;
+import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.BrAPIPagination;
+import org.brapi.v2.model.core.BrAPITrial;
+import org.brapi.v2.model.geno.BrAPIPlate;
+import org.brapi.v2.model.geno.BrAPISample;
+import org.brapi.v2.model.germ.BrAPIGermplasm;
+import org.brapi.v2.model.pheno.BrAPIObservationUnit;
+import org.breedinginsight.BrAPITest;
+import org.breedinginsight.TestUtils;
+import org.breedinginsight.api.auth.AuthenticatedUser;
+import org.breedinginsight.api.model.v1.request.ProgramRequest;
+import org.breedinginsight.api.model.v1.request.SpeciesRequest;
+import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
+import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
+import org.breedinginsight.brapps.importer.daos.*;
+import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
+import org.breedinginsight.brapps.importer.model.imports.sample.SampleSubmissionImport.Columns;
+import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.dao.db.tables.pojos.BiUserEntity;
+import org.breedinginsight.dao.db.tables.pojos.SpeciesEntity;
+import org.breedinginsight.daos.SpeciesDAO;
+import org.breedinginsight.daos.UserDAO;
+import org.breedinginsight.model.Column;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.model.SampleSubmission;
+import org.breedinginsight.model.Trait;
+import org.breedinginsight.services.*;
+import org.breedinginsight.services.exceptions.BadRequestException;
+import org.breedinginsight.services.exceptions.DoesNotExistException;
+import org.breedinginsight.services.exceptions.ValidatorException;
+import org.breedinginsight.services.writers.CSVWriter;
+import org.breedinginsight.utilities.Utilities;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.commons.util.StringUtils;
+
+import javax.inject.Inject;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.*;
+
+import static io.micronaut.http.HttpRequest.GET;
+import static org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields.SUBMISSION_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class SampleSubmissionFileImportTest extends BrAPITest {
+
+    private FannyPack securityFp;
+    private String mappingId;
+    private BiUserEntity testUser;
+
+    @Property(name = "brapi.server.reference-source")
+    private String BRAPI_REFERENCE_SOURCE;
+    @Property(name = "brapi.server.core-url")
+    private String BRAPI_URL;
+
+    @Inject
+    private SpeciesService speciesService;
+    @Inject
+    private UserDAO userDAO;
+    @Inject
+    private DSLContext dsl;
+
+    @Inject
+    private SpeciesDAO speciesDAO;
+
+    @Inject
+    private ProgramService programService;
+
+    @Inject
+    @Client("/${micronaut.bi.api.version}")
+    private RxHttpClient client;
+
+    private ImportTestUtils importTestUtils;
+
+    @Inject
+    private OntologyService ontologyService;
+
+    @Inject
+    private BrAPITrialDAO brAPITrialDAO;
+
+    @Inject
+    private BrAPIStudyDAO brAPIStudyDAO;
+
+    @Inject
+    private BrAPIObservationUnitDAO ouDAO;
+
+    @Inject
+    private ProgramLocationService locationService;
+
+    @Inject
+    private BrAPIGermplasmDAO germplasmDAO;
+
+    @Inject
+    private BrAPIObservationDAO observationDAO;
+
+    @Inject
+    private BrAPISeasonDAO seasonDAO;
+
+    @Inject
+    private SampleSubmissionService sampleSubmissionService;
+
+    private Gson gson = new GsonBuilder().registerTypeAdapter(OffsetDateTime.class, (JsonDeserializer<OffsetDateTime>)
+                                                 (json, type, context) -> OffsetDateTime.parse(json.getAsString()))
+                                         .registerTypeAdapter(BrAPIPagination.class, new PaginationTypeAdapter())
+                                         .create();
+
+    @BeforeAll
+    public void setup() {
+        importTestUtils = new ImportTestUtils();
+        Map<String, Object> setupObjects = importTestUtils.setup(client, gson, dsl, speciesService, userDAO, super.getBrapiDsl(), "SampleImport");
+        mappingId = (String) setupObjects.get("mappingId");
+        testUser = (BiUserEntity) setupObjects.get("testUser");
+        securityFp = (FannyPack) setupObjects.get("securityFp");
+
+    }
+
+    /*
+    Tests
+    - valid submission GID
+    - valid submission ObsUnitID
+    - missing columns error
+    - conflicting wells error
+    - bad GID error
+    - bad ObsUnitID error
+     */
+
+    @Test
+    @SneakyThrows
+    public void importGIDSuccess() {
+        Program program = createProgram("Import GID Success", "GIDS", "GIDS", BRAPI_REFERENCE_SOURCE, createGermplasm(96), null);
+        List<Map<String, Object>> validFile = new ArrayList<>();
+
+        int germGidCounter = 1;
+        for(int i = 0; i < 8; i++) {
+            for(int j = 0; j < 12; j++) {
+                Map<String, Object> validRow = new HashMap<>();
+                validRow.put(Columns.PLATE_ID, "valid_1");
+                validRow.put(Columns.ROW, Character.toString('A' + i));
+                validRow.put(Columns.COLUMN, j+1);
+                validRow.put(Columns.ORGANISM, "TEST");
+                validRow.put(Columns.SPECIES, "TEST");
+                validRow.put(Columns.GERMPLASM_NAME, "");
+                validRow.put(Columns.GERMPLASM_GID, germGidCounter++);
+                validRow.put(Columns.OBS_UNIT_ID, "");
+                validRow.put(Columns.TISSUE, "TEST");
+                validRow.put(Columns.COMMENTS, "Test sample");
+                validFile.add(validRow);
+            }
+        }
+
+        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(writeDataToFile(validFile), Map.of(SUBMISSION_NAME, "test-"+UUID.randomUUID()), true, client, program, mappingId);
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.ACCEPTED, response.getStatus());
+        String importId = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").get("importId").getAsString();
+
+        HttpResponse<String> upload = importTestUtils.getUploadedFile(importId, client, program, mappingId);
+        JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
+        assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt(), "Returned data: " + result);
+
+        JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
+        assertEquals(96, previewRows.size());
+        JsonObject row = previewRows.get(0).getAsJsonObject();
+
+        assertEquals("NEW", row.getAsJsonObject("plate").get("state").getAsString());
+        assertEquals("NEW", row.getAsJsonObject("sample").get("state").getAsString());
+
+        BrAPISample sample = new Gson().fromJson(row.getAsJsonObject("sample").getAsJsonObject("brAPIObject"), BrAPISample.class);
+        BrAPIExternalReference xref = Utilities.getExternalReference(sample.getExternalReferences(), Utilities.generateReferenceSource(BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.PLATE_SUBMISSIONS)).get();
+
+        assertFileSaved(validFile, program, UUID.fromString(xref.getReferenceId()));
+    }
+
+    @Test
+    @SneakyThrows
+    public void importObsUnitIdSuccess() {
+        Program program = createProgram("Import ObsUnitID success", "OBSID", "OBSID", BRAPI_REFERENCE_SOURCE, createGermplasm(1), null);
+
+        var experimentId = createExperiment(program);
+
+        BrAPITrial trial = brAPITrialDAO.getTrialById(program.getId(), UUID.fromString(experimentId)).get();
+
+        List<BrAPIObservationUnit> ous = ouDAO.getObservationUnitsForTrialDbId(program.getId(), trial.getTrialDbId());
+        BrAPIExternalReference obsUnitId = Utilities.getExternalReference(ous.get(0).getExternalReferences(), Utilities.generateReferenceSource(BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS)).get();
+
+        List<Map<String, Object>> validFile = new ArrayList<>();
+
+        Map<String, Object> validRow = new HashMap<>();
+        validRow.put(Columns.PLATE_ID, "valid_1");
+        validRow.put(Columns.ROW, "A");
+        validRow.put(Columns.COLUMN, 1);
+        validRow.put(Columns.ORGANISM, "TEST");
+        validRow.put(Columns.SPECIES, "TEST");
+        validRow.put(Columns.GERMPLASM_NAME, "");
+        validRow.put(Columns.GERMPLASM_GID, "");
+        validRow.put(Columns.OBS_UNIT_ID, obsUnitId.getReferenceId());
+        validRow.put(Columns.TISSUE, "TEST");
+        validRow.put(Columns.COMMENTS, "Test sample");
+        validFile.add(validRow);
+
+        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(writeDataToFile(validFile), Map.of(SUBMISSION_NAME, "test-"+UUID.randomUUID()), true, client, program, mappingId);
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.ACCEPTED, response.getStatus());
+        String importId = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").get("importId").getAsString();
+
+        HttpResponse<String> upload = importTestUtils.getUploadedFile(importId, client, program, mappingId);
+        JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
+        assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt(), "Returned data: " + result);
+
+        JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
+        assertEquals(1, previewRows.size());
+        JsonObject row = previewRows.get(0).getAsJsonObject();
+
+        assertEquals("NEW", row.getAsJsonObject("plate").get("state").getAsString());
+        assertEquals("NEW", row.getAsJsonObject("sample").get("state").getAsString());
+
+        BrAPISample sample = new Gson().fromJson(row.getAsJsonObject("sample").getAsJsonObject("brAPIObject"), BrAPISample.class);
+        BrAPIExternalReference xref = Utilities.getExternalReference(sample.getExternalReferences(), Utilities.generateReferenceSource(BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.PLATE_SUBMISSIONS)).get();
+
+        assertFileSaved(validFile, program, UUID.fromString(xref.getReferenceId()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @SneakyThrows
+    public void importMissingGIDAndObsUnitIdFailure(boolean commit) {
+        Program program = createProgram("Missing GID/ObsUnit ID " + (commit ? "C" : "P"), "MGIOB"+ (commit ? "C" : "P"), "MGIOB"+ (commit ? "C" : "P"), BRAPI_REFERENCE_SOURCE, null, null);
+        List<Map<String, Object>> validFile = new ArrayList<>();
+
+        Map<String, Object> validRow = new HashMap<>();
+        validRow.put(Columns.PLATE_ID, "valid_1");
+        validRow.put(Columns.ROW, Character.toString('A'));
+        validRow.put(Columns.COLUMN, 1);
+        validRow.put(Columns.ORGANISM, "TEST");
+        validRow.put(Columns.SPECIES, "TEST");
+        validRow.put(Columns.GERMPLASM_NAME, "");
+        validRow.put(Columns.GERMPLASM_GID, "");
+        validRow.put(Columns.OBS_UNIT_ID, "");
+        validRow.put(Columns.TISSUE, "TEST");
+        validRow.put(Columns.COMMENTS, "Test sample");
+        validFile.add(validRow);
+
+        uploadAndVerifyFailure(program, writeDataToFile(validFile), Columns.GERMPLASM_GID, commit);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @SneakyThrows
+    public void verifyMissingDataThrowsError(boolean commit) {
+        Program program = createProgram("Missing Req Cols "+(commit ? "C" : "P"), "MISS"+(commit ? "C" : "P"), "MISS"+(commit ? "C" : "P"), BRAPI_REFERENCE_SOURCE, createGermplasm(96), null);
+        Map<String, Object> base = new HashMap<>();
+        base.put(Columns.PLATE_ID, "valid_1");
+        base.put(Columns.ROW, "A");
+        base.put(Columns.COLUMN, 1);
+        base.put(Columns.ORGANISM, "TEST");
+        base.put(Columns.SPECIES, "TEST");
+        base.put(Columns.GERMPLASM_NAME, "");
+        base.put(Columns.GERMPLASM_GID, "1");
+        base.put(Columns.OBS_UNIT_ID, "");
+        base.put(Columns.TISSUE, "TEST");
+        base.put(Columns.COMMENTS, "Test sample");
+
+        createUploadAndVerifyFailure(program, base, Columns.PLATE_ID, commit);
+        createUploadAndVerifyFailure(program, base, Columns.ROW, commit);
+        createUploadAndVerifyFailure(program, base, Columns.COLUMN, commit);
+        createUploadAndVerifyFailure(program, base, Columns.ORGANISM, commit);
+        createUploadAndVerifyFailure(program, base, Columns.TISSUE, commit);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @SneakyThrows
+    public void importInvalidGIDFailure(boolean commit) {
+        Program program = createProgram("Invalid GID " + (commit ? "C" : "P"), "INGID"+ (commit ? "C" : "P"), "INGID"+ (commit ? "C" : "P"), BRAPI_REFERENCE_SOURCE, null, null);
+        List<Map<String, Object>> validFile = new ArrayList<>();
+
+        Map<String, Object> validRow = new HashMap<>();
+        validRow.put(Columns.PLATE_ID, "valid_1");
+        validRow.put(Columns.ROW, Character.toString('A'));
+        validRow.put(Columns.COLUMN, 1);
+        validRow.put(Columns.ORGANISM, "TEST");
+        validRow.put(Columns.SPECIES, "TEST");
+        validRow.put(Columns.GERMPLASM_NAME, "");
+        validRow.put(Columns.GERMPLASM_GID, "");
+        validRow.put(Columns.OBS_UNIT_ID, "");
+        validRow.put(Columns.TISSUE, "TEST");
+        validRow.put(Columns.COMMENTS, "Test sample");
+        validFile.add(validRow);
+
+        uploadAndVerifyFailure(program, writeDataToFile(validFile), Columns.GERMPLASM_GID, commit);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @SneakyThrows
+    public void importInvalidObsUnitIdFailure(boolean commit) {
+        Program program = createProgram("Invalid ObsUnit ID " + (commit ? "C" : "P"), "INOBS"+ (commit ? "C" : "P"), "INOBS"+ (commit ? "C" : "P"), BRAPI_REFERENCE_SOURCE, null, null);
+        List<Map<String, Object>> validFile = new ArrayList<>();
+
+        Map<String, Object> validRow = new HashMap<>();
+        validRow.put(Columns.PLATE_ID, "valid_1");
+        validRow.put(Columns.ROW, Character.toString('A'));
+        validRow.put(Columns.COLUMN, 1);
+        validRow.put(Columns.ORGANISM, "TEST");
+        validRow.put(Columns.SPECIES, "TEST");
+        validRow.put(Columns.GERMPLASM_NAME, "");
+        validRow.put(Columns.GERMPLASM_GID, "");
+        validRow.put(Columns.OBS_UNIT_ID, "hgfhgfhg");
+        validRow.put(Columns.TISSUE, "TEST");
+        validRow.put(Columns.COMMENTS, "Test sample");
+        validFile.add(validRow);
+
+        uploadAndVerifyFailure(program, writeDataToFile(validFile), Columns.OBS_UNIT_ID, commit);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @SneakyThrows
+    public void importConflictingWellsFailure(boolean commit) {
+        Program program = createProgram("Conflicting Wells " + (commit ? "C" : "P"), "WELL"+ (commit ? "C" : "P"), "WELL"+ (commit ? "C" : "P"), BRAPI_REFERENCE_SOURCE, createGermplasm(2), null);
+        List<Map<String, Object>> validFile = new ArrayList<>();
+
+        Map<String, Object> validRow = new HashMap<>();
+        validRow.put(Columns.PLATE_ID, "valid_1");
+        validRow.put(Columns.ROW, Character.toString('A'));
+        validRow.put(Columns.COLUMN, 1);
+        validRow.put(Columns.ORGANISM, "TEST");
+        validRow.put(Columns.SPECIES, "TEST");
+        validRow.put(Columns.GERMPLASM_NAME, "");
+        validRow.put(Columns.GERMPLASM_GID, 1);
+        validRow.put(Columns.OBS_UNIT_ID, "");
+        validRow.put(Columns.TISSUE, "TEST");
+        validRow.put(Columns.COMMENTS, "Test sample");
+        validFile.add(validRow);
+        validRow = new HashMap<>();
+        validRow.put(Columns.PLATE_ID, "valid_1");
+        validRow.put(Columns.ROW, Character.toString('A'));
+        validRow.put(Columns.COLUMN, 1);
+        validRow.put(Columns.ORGANISM, "TEST");
+        validRow.put(Columns.SPECIES, "TEST");
+        validRow.put(Columns.GERMPLASM_NAME, "");
+        validRow.put(Columns.GERMPLASM_GID, 2);
+        validRow.put(Columns.OBS_UNIT_ID, "");
+        validRow.put(Columns.TISSUE, "TEST");
+        validRow.put(Columns.COMMENTS, "Test sample");
+        validFile.add(validRow);
+
+        uploadAndVerifyFailure(program, writeDataToFile(validFile), Columns.ROW + "/" + Columns.COLUMN, commit);
+    }
+
+    private void assertFileSaved(List<Map<String, Object>> validFile, Program program, UUID submissionId) throws ApiException {
+        Optional<SampleSubmission> submission = sampleSubmissionService.getSampleSubmission(program, submissionId, true);
+        assertTrue(submission.isPresent(), "Could not find sample submission by ID: " + submissionId);
+        for(var row : validFile) {
+            assertRowSaved(row, program, submission.get());
+        }
+    }
+
+    private Map<String, Object> assertRowSaved(Map<String, Object> expected, Program program, SampleSubmission submission) {
+        Map<String, Object> ret = new HashMap<>();
+
+        Optional<BrAPIPlate> plate = submission.getPlates().stream().filter(p -> p.getPlateName().equals(expected.get(Columns.PLATE_ID))).findFirst();
+        assertTrue(plate.isPresent(), "plate not found");
+
+        Optional<BrAPISample> sample = submission.getSamples().stream().filter(s -> s.getPlateName().equals(expected.get(Columns.PLATE_ID))
+                                                                                    && s.getRow().equals(expected.get(Columns.ROW))
+                                                                                    && s.getColumn().equals(expected.get(Columns.COLUMN)))
+                .findFirst();
+        assertTrue(sample.isPresent(), String.format("sample %s%s not found", expected.get(Columns.ROW), expected.get(Columns.COLUMN)));
+
+        assertEquals(expected.get(Columns.ORGANISM), sample.get().getAdditionalInfo().get(BrAPIAdditionalInfoFields.SAMPLE_ORGANISM).getAsString());
+        assertEquals(expected.get(Columns.SPECIES), sample.get().getAdditionalInfo().get(BrAPIAdditionalInfoFields.SAMPLE_SPECIES).getAsString());
+        assertTrue(sample.get().getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_NAME));
+        assertEquals(expected.get(Columns.TISSUE), sample.get().getTissueType());
+        assertEquals(expected.get(Columns.COMMENTS), sample.get().getSampleDescription());
+
+        if(StringUtils.isNotBlank((String)expected.get(Columns.OBS_UNIT_ID))) {
+            assertTrue(sample.get().getAdditionalInfo().has(BrAPIAdditionalInfoFields.OBS_UNIT_ID));
+            assertEquals(expected.get(Columns.OBS_UNIT_ID), sample.get().getAdditionalInfo().get(BrAPIAdditionalInfoFields.OBS_UNIT_ID).getAsString());
+        } else {
+            assertEquals(String.valueOf(expected.get(Columns.GERMPLASM_GID)), sample.get().getAdditionalInfo().get(BrAPIAdditionalInfoFields.GID).getAsString());
+        }
+
+        return ret;
+    }
+
+    private Program createProgram(String name, String abbv, String key, String referenceSource, List<BrAPIGermplasm> germplasm, List<Trait> traits) throws ApiException, DoesNotExistException, ValidatorException, BadRequestException {
+        SpeciesEntity validSpecies = speciesDAO.findAll().get(0);
+        SpeciesRequest speciesRequest = SpeciesRequest.builder()
+                                                      .commonName(validSpecies.getCommonName())
+                                                      .id(validSpecies.getId())
+                                                      .build();
+        ProgramRequest programRequest1 = ProgramRequest.builder()
+                                                       .name(name)
+                                                       .abbreviation(abbv)
+                                                       .documentationUrl("localhost:8080")
+                                                       .objective("To test things")
+                                                       .species(speciesRequest)
+                                                       .key(key)
+                                                       .build();
+
+
+        TestUtils.insertAndFetchTestProgram(gson, client, programRequest1);
+
+        // Get main program
+        Program program = programService.getByKey(key).get();
+
+        dsl.execute(securityFp.get("InsertProgramRolesBreeder"), testUser.getId().toString(), program.getId().toString());
+
+        if(germplasm != null && !germplasm.isEmpty()) {
+            BrAPIExternalReference newReference = new BrAPIExternalReference();
+            newReference.setReferenceSource(String.format("%s/programs", referenceSource));
+            newReference.setReferenceID(program.getId().toString());
+
+            germplasm.forEach(germ -> germ.getExternalReferences().add(newReference));
+
+            germplasmDAO.createBrAPIGermplasm(germplasm, program.getId(), null);
+        }
+
+        if(traits != null && !traits.isEmpty()) {
+            AuthenticatedUser user = new AuthenticatedUser(testUser.getName(), new ArrayList<>(), testUser.getId(), new ArrayList<>());
+            try {
+                ontologyService.createTraits(program.getId(), traits, user, false);
+            } catch (ValidatorException e) {
+                System.err.println(e.getErrors());
+                throw e;
+            }
+        }
+
+        return program;
+    }
+
+    private List<BrAPIGermplasm> createGermplasm(int numToCreate) {
+        List<BrAPIGermplasm> germplasm = new ArrayList<>();
+        for (int i = 0; i < numToCreate; i++) {
+            String gid = ""+(i+1);
+            BrAPIGermplasm testGermplasm = new BrAPIGermplasm();
+            testGermplasm.setGermplasmName(String.format("Germplasm %s [TEST-%s]", gid, gid));
+            testGermplasm.setSeedSource("Wild");
+            testGermplasm.setAccessionNumber(gid);
+            testGermplasm.setDefaultDisplayName(String.format("Germplasm %s", gid));
+            JsonObject additionalInfo = new JsonObject();
+            additionalInfo.addProperty("importEntryNumber", gid);
+            additionalInfo.addProperty("breedingMethod", "Allopolyploid");
+            testGermplasm.setAdditionalInfo(additionalInfo);
+            List<BrAPIExternalReference> externalRef = new ArrayList<>();
+            BrAPIExternalReference testReference = new BrAPIExternalReference();
+            testReference.setReferenceSource(BRAPI_REFERENCE_SOURCE);
+            testReference.setReferenceID(UUID.randomUUID().toString());
+            externalRef.add(testReference);
+            testGermplasm.setExternalReferences(externalRef);
+            germplasm.add(testGermplasm);
+        }
+
+        return germplasm;
+    }
+
+    private void createUploadAndVerifyFailure(Program program, Map<String, Object> base, String columnToRemove, boolean commit) throws IOException, InterruptedException {
+        Map<String, Object> invalidRow = new HashMap<>(base);
+        invalidRow.remove(columnToRemove);
+        uploadAndVerifyFailure(program, writeDataToFile(List.of(invalidRow)), columnToRemove, commit);
+    }
+
+    private JsonObject uploadAndVerifyFailure(Program program, File file, String expectedColumnError, boolean commit) throws InterruptedException, IOException {
+        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(file, Map.of(SUBMISSION_NAME, "test-"+UUID.randomUUID()), true, client, program, mappingId);
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.ACCEPTED, response.getStatus());
+
+        String importId = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").get("importId").getAsString();
+
+        HttpResponse<String> upload = importTestUtils.getUploadedFile(importId, client, program, mappingId);
+        JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
+        assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt(), "Returned data: " + result);
+
+        JsonArray rowErrors = result.getAsJsonObject("progress").getAsJsonArray("rowErrors");
+        assertEquals(1, rowErrors.size());
+        JsonArray fieldErrors = rowErrors.get(0).getAsJsonObject().getAsJsonArray("errors");
+        assertEquals(1, fieldErrors.size());
+        JsonObject error = fieldErrors.get(0).getAsJsonObject();
+        assertEquals(expectedColumnError, error.get("field").getAsString());
+        assertEquals(422, error.get("httpStatusCode").getAsInt());
+
+        return result;
+    }
+
+    public File writeDataToFile(List<Map<String, Object>> data) throws IOException {
+        File file = File.createTempFile("test", ".csv");
+
+        List<Column> columns = new ArrayList<>();
+        columns.add(Column.builder().value(Columns.PLATE_ID).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.ROW).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.COLUMN).dataType(Column.ColumnDataType.INTEGER).build());
+        columns.add(Column.builder().value(Columns.ORGANISM).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.SPECIES).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.GERMPLASM_NAME).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.GERMPLASM_GID).dataType(Column.ColumnDataType.INTEGER).build());
+        columns.add(Column.builder().value(Columns.OBS_UNIT_ID).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.TISSUE).dataType(Column.ColumnDataType.STRING).build());
+        columns.add(Column.builder().value(Columns.COMMENTS).dataType(Column.ColumnDataType.STRING).build());
+
+        ByteArrayOutputStream byteArrayOutputStream = CSVWriter.writeToCSV(columns, data);
+        FileOutputStream fos = new FileOutputStream(file);
+        fos.write(byteArrayOutputStream.toByteArray());
+
+        return file;
+    }
+
+    private String createExperiment(Program program) throws IOException, InterruptedException {
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET("/import/mappings?importName=ExperimentsTemplateMap").cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
+        );
+        HttpResponse<String> response = call.blockingFirst();
+        String expMappingId = JsonParser.parseString(response.body()).getAsJsonObject()
+                .getAsJsonObject("result")
+                .getAsJsonArray("data")
+                .get(0).getAsJsonObject().get("id").getAsString();
+
+        JsonObject importResult = importTestUtils.uploadAndFetch(
+                importTestUtils.writeExperimentDataToFile(List.of(makeExpImportRow("Env1")), null),
+                null,
+                true,
+                client,
+                program,
+                expMappingId);
+        return importResult
+                .get("preview").getAsJsonObject()
+                .get("rows").getAsJsonArray()
+                .get(0).getAsJsonObject()
+                .get("trial").getAsJsonObject()
+                .get("id").getAsString();
+    }
+
+    private Map<String, Object> makeExpImportRow(String environment) {
+        Map<String, Object> row = new HashMap<>();
+        row.put(ExperimentObservation.Columns.GERMPLASM_GID, "1");
+        row.put(ExperimentObservation.Columns.TEST_CHECK, "T");
+        row.put(ExperimentObservation.Columns.EXP_TITLE, "Test Exp");
+        row.put(ExperimentObservation.Columns.EXP_UNIT, "Plot");
+        row.put(ExperimentObservation.Columns.EXP_TYPE, "Phenotyping");
+        row.put(ExperimentObservation.Columns.ENV, environment);
+        row.put(ExperimentObservation.Columns.ENV_LOCATION, "Location A");
+        row.put(ExperimentObservation.Columns.ENV_YEAR, "2023");
+        row.put(ExperimentObservation.Columns.EXP_UNIT_ID, "a-1");
+        row.put(ExperimentObservation.Columns.REP_NUM, "1");
+        row.put(ExperimentObservation.Columns.BLOCK_NUM, "1");
+        row.put(ExperimentObservation.Columns.ROW, "1");
+        row.put(ExperimentObservation.Columns.COLUMN, "1");
+        return row;
+    }
+
+}


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1910

Defined new endpoints for creating and managing sample submissions including:
- Ability upload a new sample submission
- Ability to fetch submissions within a program
- Ability to fetch an individual submission
- Ability to update the status of a submission
- Ability to automatically submit an order to a vendor


# Dependencies
- bi-web/feature/BI-1910
- bi-docker-stack/feature/BI-1910

# Testing
See testing instructions in https://github.com/Breeding-Insight/bi-web/pull/343


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/6765876438
