### PR TITLE
BI-1915 - Export Ontology File

### DIFF
--- a/src/main/java/org/breedinginsight/api/v1/controller/TraitController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/TraitController.java
@@ -61,10 +61,10 @@ import java.util.UUID;
 @Controller("/${micronaut.bi.api.version}")
 public class TraitController {
 
-    private TraitService traitService;
-    private SecurityService securityService;
-    private TraitQueryMapper traitQueryMapper;
-    private OntologyService ontologyService;
+    private final TraitService traitService;
+    private final SecurityService securityService;
+    private final TraitQueryMapper traitQueryMapper;
+    private final OntologyService ontologyService;
 
     @Inject
     public TraitController(TraitService traitService, SecurityService securityService,
@@ -94,7 +94,7 @@ public class TraitController {
     @Get("/programs/{programId}/traits/export{?fileExtension,isActive}")
     @Produces(value = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
-    public HttpResponse<StreamedFile> getTraitsExport(
+    public HttpResponse getTraitsExport(
             @PathVariable("programId") UUID programId, @QueryValue(defaultValue = "XLSX") String fileExtension, @QueryValue(defaultValue = "true") Boolean isActive) {
         String downloadErrorMessage = "An error occurred while generating the download file. Contact the development team at bidevteam@cornell.edu.";
         try {
@@ -163,7 +163,7 @@ public class TraitController {
     @Post("/programs/{programId}/traits")
     @Produces(MediaType.APPLICATION_JSON)
     @ProgramSecured(roles = {ProgramSecuredRole.BREEDER})
-    public HttpResponse<Response<DataResponse<Trait>>> createTraits(@PathVariable UUID programId, @Body @Valid List<Trait> traits) {
+    public HttpResponse createTraits(@PathVariable UUID programId, @Body @Valid List<Trait> traits) {
         AuthenticatedUser actingUser = securityService.getUser();
         try {
             List<Trait> createdTraits = ontologyService.createTraits(programId, traits, actingUser, true);
@@ -191,7 +191,7 @@ public class TraitController {
     @Put("/programs/{programId}/traits")
     @Produces(MediaType.APPLICATION_JSON)
     @ProgramSecured(roles = {ProgramSecuredRole.BREEDER})
-    public HttpResponse<Response<DataResponse<Trait>>> updateTraits(@PathVariable UUID programId, @Body @Valid List<Trait> traits) {
+    public HttpResponse updateTraits(@PathVariable UUID programId, @Body @Valid List<Trait> traits) {
         AuthenticatedUser actingUser = securityService.getUser();
         try {
             List<Trait> updatedTraits = ontologyService.updateTraits(programId, traits, actingUser);

--- a/src/main/java/org/breedinginsight/api/v1/controller/TraitController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/TraitController.java
@@ -17,10 +17,12 @@
 
 package org.breedinginsight.api.v1.controller;
 
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.*;
+import io.micronaut.http.server.types.files.StreamedFile;
 import lombok.extern.slf4j.Slf4j;
 import org.breedinginsight.api.auth.*;
 import org.breedinginsight.api.model.v1.request.query.QueryParams;
@@ -35,6 +37,8 @@ import org.breedinginsight.api.model.v1.response.metadata.StatusCode;
 import org.breedinginsight.api.model.v1.validators.QueryValid;
 import org.breedinginsight.api.model.v1.validators.SearchValid;
 import org.breedinginsight.api.v1.controller.metadata.AddMetadata;
+import org.breedinginsight.brapps.importer.model.exports.FileType;
+import org.breedinginsight.model.DownloadFile;
 import org.breedinginsight.model.Editable;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.Trait;
@@ -52,7 +56,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
 @Controller("/${micronaut.bi.api.version}")
@@ -85,6 +88,26 @@ public class TraitController {
             return ResponseUtils.getQueryResponse(traits, traitQueryMapper, searchRequest, traitsQuery);
         } catch (DoesNotExistException e) {
             return HttpResponse.notFound();
+        }
+    }
+
+    @Get("/programs/{programId}/traits/export{?fileExtension,isActive}")
+    @Produces(value = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
+    public HttpResponse<StreamedFile> getTraitsExport(
+            @PathVariable("programId") UUID programId, @QueryValue(defaultValue = "XLSX") String fileExtension, @QueryValue(defaultValue = "true") Boolean isActive) {
+        String downloadErrorMessage = "An error occurred while generating the download file. Contact the development team at bidevteam@cornell.edu.";
+        try {
+            FileType extension = Enum.valueOf(FileType.class, fileExtension);
+            DownloadFile ontologyFile = ontologyService.exportOntology(programId, extension, isActive);
+            HttpResponse<StreamedFile> ontologyExport = HttpResponse.ok(ontologyFile.getStreamedFile()).header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename="+ontologyFile.getFileName()+extension.getExtension());
+            return ontologyExport;
+        }
+        catch (Exception e) {
+            log.info(e.getMessage(), e);
+            e.printStackTrace();
+            HttpResponse response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, downloadErrorMessage).contentType(MediaType.TEXT_PLAIN).body(downloadErrorMessage);
+            return response;
         }
     }
 

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/DataTypeTranslator.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/DataTypeTranslator.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 public class DataTypeTranslator {
 
     private static final Map<String, DataType> displayToTypeMap = Map.of(
-            "Date YYYY-MM-DD", DataType.DATE,
+            "Date", DataType.DATE,
             "Numerical", DataType.NUMERICAL,
             "Nominal", DataType.NOMINAL,
             "Ordinal", DataType.ORDINAL,

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/DataTypeTranslator.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/DataTypeTranslator.java
@@ -1,7 +1,6 @@
 package org.breedinginsight.brapps.importer.model.imports;
 
 import org.breedinginsight.dao.db.enums.DataType;
-import org.breedinginsight.dao.db.enums.TermType;
 
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/DataTypeTranslator.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/DataTypeTranslator.java
@@ -1,0 +1,35 @@
+package org.breedinginsight.brapps.importer.model.imports;
+
+import org.breedinginsight.dao.db.enums.DataType;
+import org.breedinginsight.dao.db.enums.TermType;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class DataTypeTranslator {
+
+    private static final Map<String, DataType> displayToTypeMap = Map.of(
+            "Date YYYY-MM-DD", DataType.DATE,
+            "Numerical", DataType.NUMERICAL,
+            "Nominal", DataType.NOMINAL,
+            "Ordinal", DataType.ORDINAL,
+            "Text", DataType.TEXT);
+
+
+    public static Optional<DataType> getTypeFromUserDisplayName(String displayName) {
+        return Optional.ofNullable(displayToTypeMap.get(displayName));
+    }
+
+    public static String getDisplayNameFromType(DataType type){
+        String displayName = "";
+        if(type!=null) {
+            for (String key : displayToTypeMap.keySet()) {
+                if (type == displayToTypeMap.get(key)) {
+                    displayName = key;
+                    break;
+                }
+            }
+        }
+        return displayName;
+    }
+}

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/TermTypeTranslator.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/TermTypeTranslator.java
@@ -14,4 +14,17 @@ public class TermTypeTranslator {
     public static Optional<TermType> getTermTypeFromUserDisplayName(String userDisplayName) {
         return Optional.ofNullable(userDisplayToTermTypeMap.get(userDisplayName));
     }
+
+    public static String getDisplayNameFromTermType(TermType termType){
+        String displayName = "";
+        if(termType!=null) {
+            for (String key : userDisplayToTermTypeMap.keySet()) {
+                if (termType == userDisplayToTermTypeMap.get(key)) {
+                    displayName = key;
+                    break;
+                }
+            }
+        }
+        return displayName;
+    }
 }

--- a/src/main/java/org/breedinginsight/services/parsers/trait/TraitFileColumns.java
+++ b/src/main/java/org/breedinginsight/services/parsers/trait/TraitFileColumns.java
@@ -16,46 +16,54 @@
  */
 package org.breedinginsight.services.parsers.trait;
 
+import org.breedinginsight.model.Column;
+
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public enum TraitFileColumns {
 
-    NAME("Name"),
-    SYNONYMS("Synonyms"),
-    TRAIT_ENTITY("Trait entity"),
-    TRAIT_ATTRIBUTE("Trait attribute"),
-    DESCRIPTION("Description"),
-    STATUS("Status"),
-    METHOD_DESCRIPTION("Method description"),
-    METHOD_CLASS("Method class"),
-    METHOD_FORMULA("Method formula"),
-    SCALE_NAME("Units"),
-    SCALE_CLASS("Scale class"),
-    SCALE_DECIMAL_PLACES("Scale decimal places"),
-    SCALE_LOWER_LIMIT("Scale lower limit"),
-    SCALE_UPPER_LIMIT("Scale upper limit"),
-    SCALE_CATEGORIES("Scale categories"),
-    TAGS("Tags"),
-    FULL_NAME("Full name"),
-    TERM_TYPE("Term Type");
+    NAME("Name", Column.ColumnDataType.STRING),
+    FULL_NAME("Full name", Column.ColumnDataType.STRING),
+    TERM_TYPE("Term Type", Column.ColumnDataType.STRING),
+    DESCRIPTION("Description", Column.ColumnDataType.STRING),
+    SYNONYMS("Synonyms", Column.ColumnDataType.STRING),
+    STATUS("Status",Column.ColumnDataType.STRING),
+    TAGS("Tags", Column.ColumnDataType.STRING),
+    TRAIT_ENTITY("Trait entity", Column.ColumnDataType.STRING),
+    TRAIT_ATTRIBUTE("Trait attribute", Column.ColumnDataType.STRING),
+    METHOD_DESCRIPTION("Method description", Column.ColumnDataType.STRING),
+    METHOD_CLASS("Method class", Column.ColumnDataType.STRING),
+    METHOD_FORMULA("Method formula", Column.ColumnDataType.STRING),
+    SCALE_CLASS("Scale class", Column.ColumnDataType.STRING),
+    SCALE_NAME("Units", Column.ColumnDataType.STRING),
+    SCALE_DECIMAL_PLACES("Scale decimal places", Column.ColumnDataType.INTEGER),
+    SCALE_LOWER_LIMIT("Scale lower limit", Column.ColumnDataType.INTEGER),
+    SCALE_UPPER_LIMIT("Scale upper limit", Column.ColumnDataType.INTEGER),
+    SCALE_CATEGORIES("Scale categories", Column.ColumnDataType.STRING);
 
+    private final Column column;
 
-    private String value;
-
-    TraitFileColumns(String value) {
-        this.value = value;
+    TraitFileColumns(String value, Column.ColumnDataType dataType) {
+        this.column = new Column(value, dataType);
     }
 
     @Override
     public String toString() {
-        return value;
+        return column.getValue();
     }
 
-    public static Set<String> getColumns() {
+    public static Set<String> getColumnNames() {
         return Arrays.stream(TraitFileColumns.values())
-                .map(value -> value.toString())
+                .map(value -> value.column.getValue())
                 .collect(Collectors.toSet());
+    }
+
+    public static List<Column> getOrderedColumns() {
+        return Arrays.stream(TraitFileColumns.values())
+                .map(value -> value.column)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/breedinginsight/services/parsers/trait/TraitFileParser.java
+++ b/src/main/java/org/breedinginsight/services/parsers/trait/TraitFileParser.java
@@ -65,10 +65,9 @@ public class TraitFileParser {
     private static final String TRAIT_STATUS_ACTIVE = "active";
     private static final String TRAIT_STATUS_ARCHIVED = "archived";
 
-    private final static Set TRAIT_STATUS_VALID_VALUES = Collections.unmodifiableSet(
-            Set.of(TRAIT_STATUS_ACTIVE, TRAIT_STATUS_ARCHIVED));
+    private final static Set<String> TRAIT_STATUS_VALID_VALUES = Set.of(TRAIT_STATUS_ACTIVE, TRAIT_STATUS_ARCHIVED);
 
-    private TraitFileValidatorError traitValidatorError;
+    private final TraitFileValidatorError traitValidatorError;
 
     @Inject
     public TraitFileParser(TraitFileValidatorError traitValidatorError){
@@ -103,7 +102,6 @@ public class TraitFileParser {
     // no sheets RFC4180
     public List<Trait> parseCsv(@NonNull InputStream inputStream) throws ParsingException, ValidatorException {
 
-        ArrayList<Trait> traits = new ArrayList<>();
         InputStreamReader in = new InputStreamReader(inputStream);
 
         Iterable<CSVRecord> records = null;
@@ -135,7 +133,7 @@ public class TraitFileParser {
                     .build();
 
 
-            Boolean active;
+            boolean active;
             String traitStatus = parseExcelValueAsString(record, TraitFileColumns.STATUS);
             if (traitStatus == null) {
                 active = true;
@@ -145,7 +143,7 @@ public class TraitFileParser {
                             ParsingExceptionType.INVALID_TRAIT_STATUS.toString(), HttpStatus.UNPROCESSABLE_ENTITY);
                     validationErrors.addError(traitValidatorError.getRowNumber(i), error);
                 }
-                active = !traitStatus.toLowerCase().equals(TRAIT_STATUS_ARCHIVED);
+                active = !traitStatus.equalsIgnoreCase(TRAIT_STATUS_ARCHIVED);
             }
 
             // Normalize and capitalize method class
@@ -354,7 +352,7 @@ public class TraitFileParser {
         else if (labelMeaning.length == 1) {
             category.setValue(labelMeaning[0].trim());
         } else if (labelMeaning.length > 2){
-            // The case where there are multiple category delimiters in a value. Could be cause by bad list delimeter.
+            // The case where there are multiple category delimiters in a value. Could be cause by bad list delimiter.
             throw new UnprocessableEntityException("Unable to parse categories");
         }
 

--- a/src/main/java/org/breedinginsight/services/parsers/trait/TraitFileParser.java
+++ b/src/main/java/org/breedinginsight/services/parsers/trait/TraitFileParser.java
@@ -95,7 +95,7 @@ public class TraitFileParser {
             throw new ParsingException(ParsingExceptionType.MISSING_SHEET);
         }
 
-        List<ExcelRecord> records = ExcelParser.parse(sheet, TraitFileColumns.getColumns());
+        List<ExcelRecord> records = ExcelParser.parse(sheet, TraitFileColumns.getColumnNames());
 
         return excelRecordsToTraits(records);
     }
@@ -117,7 +117,7 @@ public class TraitFileParser {
         }
 
         Sheet excelSheet = convertCsvToExcel(records);
-        List<ExcelRecord> excelRecords = ExcelParser.parse(excelSheet, TraitFileColumns.getColumns());
+        List<ExcelRecord> excelRecords = ExcelParser.parse(excelSheet, TraitFileColumns.getColumnNames());
 
         return excelRecordsToTraits(excelRecords);
     }


### PR DESCRIPTION
# Description
[BI-1915](https://breedinginsight.atlassian.net/browse/BI-1915) Export Ontology File

Additional work...
- The `Import file` option of the `Manage Ontology` pull-down is now only clickable for users that have the right to import.
- Addressed some of the preexisting code 'problems' reported by IntelleJ.

# Dependencies
bi-web: feature/BI-1915

# Testing

- Go to `Ontology` page.
- Select the `Download file` option from the `Manage Ontology` pull-down.
- Review the downloaded file;
. it should have a specified filename ( \<program name\>_ Active\_Ontology\_\<timestamp\> ).
. it should match the ontology template (including tags).
. it should include all of the active ontologies in the program.
. it should be in `Name` order.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1915]: https://breedinginsight.atlassian.net/browse/BI-1915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ