### PR TITLE
BI-1922 (Add ability to download all germplasm in a program)

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -157,6 +157,26 @@ public class GermplasmController {
         }
     }
 
+    @Get("/programs/{programId}/germplasm/export{?fileExtension}")
+    @Produces(value = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
+    public HttpResponse<StreamedFile> germplasmExport(
+            @PathVariable("programId") UUID programId, @QueryValue(defaultValue = "XLSX") String fileExtension) {
+        String downloadErrorMessage = "An error occurred while generating the download file. Contact the development team at bidevteam@cornell.edu.";
+        try {
+            FileType extension = Enum.valueOf(FileType.class, fileExtension);
+            DownloadFile germplasmListFile = germplasmService.exportGermplasm(programId, extension);
+            HttpResponse<StreamedFile> germplasmExport = HttpResponse.ok(germplasmListFile.getStreamedFile()).header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename="+germplasmListFile.getFileName()+extension.getExtension());
+            return germplasmExport;
+        }
+        catch (Exception e) {
+            log.info(e.getMessage(), e);
+            e.printStackTrace();
+            HttpResponse response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, downloadErrorMessage).contentType(MediaType.TEXT_PLAIN).body(downloadErrorMessage);
+            return response;
+        }
+    }
+
     @Get("/programs/{programId}" + BrapiVersion.BRAPI_V2 + "/germplasm/{germplasmId}")
     @Produces(MediaType.APPLICATION_JSON)
     @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})

--- a/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/GermplasmController.java
@@ -170,8 +170,7 @@ public class GermplasmController {
             return germplasmExport;
         }
         catch (Exception e) {
-            log.info(e.getMessage(), e);
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
             HttpResponse response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, downloadErrorMessage).contentType(MediaType.TEXT_PLAIN).body(downloadErrorMessage);
             return response;
         }

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -1,25 +1,21 @@
 package org.breedinginsight.brapi.v2.services;
 
 import io.micronaut.context.annotation.Property;
-import io.micronaut.http.HttpRequest;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import io.micronaut.http.server.types.files.StreamedFile;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.BrAPIExternalReference;
 import lombok.extern.slf4j.Slf4j;
-import org.brapi.v2.model.core.BrAPIListSummary;
-import org.brapi.v2.model.core.BrAPIListTypes;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.core.response.BrAPIListDetails;
 import org.brapi.v2.model.core.response.BrAPIListsSingleResponse;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
+import org.brapi.v2.model.germ.BrAPIGermplasmSynonyms;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapps.importer.daos.BrAPIListDAO;
 import org.breedinginsight.brapps.importer.model.exports.FileType;
-import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.model.Column;
 import org.breedinginsight.model.DownloadFile;
-import org.breedinginsight.model.Pedigree;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.services.ProgramService;
 import org.breedinginsight.services.exceptions.DoesNotExistException;
@@ -28,7 +24,6 @@ import org.breedinginsight.services.writers.CSVWriter;
 import org.breedinginsight.services.writers.ExcelWriter;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
-import org.breedinginsight.utilities.Utilities;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -75,39 +70,6 @@ public class BrAPIGermplasmService {
 
     public Optional<BrAPIGermplasm> getGermplasmByDBID(UUID programId, String germplasmId) throws ApiException {
         return germplasmDAO.getGermplasmByDBID(germplasmId, programId);
-    }
-
-    public List<BrAPIListSummary> getGermplasmListsByProgramId(UUID programId, HttpRequest<String> request) throws DoesNotExistException, ApiException {
-
-        if (!programService.exists(programId)) {
-            throw new DoesNotExistException("Program does not exist");
-        }
-
-        Optional<Program> optionalProgram = programService.getById(programId);
-        if(optionalProgram.isPresent()) {
-            Program program = optionalProgram.get();
-
-            List<BrAPIListSummary> germplasmLists = brAPIListDAO.getListByTypeAndExternalRef(BrAPIListTypes.GERMPLASM, programId, Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS), programId);
-
-            for (BrAPIListSummary germplasmList: germplasmLists) {
-                String listName = germplasmList.getListName();
-                String newListName = removeAppendedKey(listName, program.getKey());
-                germplasmList.setListName(newListName);
-
-                //Retrieve germplasm details to get list owner name
-                //Due to listOwnerName not being stored in breedbase
-                BrAPIListDetails listData = brAPIListDAO.getListById(germplasmList.getListDbId(), programId).getResult();
-                List<String> germplasmNames = listData.getData().subList(0,1);
-                List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
-                String createdBy = germplasm.get(0).getAdditionalInfo().getAsJsonObject("createdBy").get("userName").getAsString();
-                germplasmList.setListOwnerName(createdBy);
-            }
-
-            return germplasmLists;
-        }
-        else {
-            throw new DoesNotExistException("Program does not exist");
-        }
     }
 
     public List<Map<String, Object>> processListData(List<BrAPIGermplasm> germplasm, UUID germplasmListId){
@@ -164,7 +126,7 @@ public class BrAPIGermplasmService {
             // Synonyms
             if (germplasmEntry.getSynonyms() != null && !germplasmEntry.getSynonyms().isEmpty()) {
                 String joinedSynonyms = germplasmEntry.getSynonyms().stream()
-                        .map(synonym -> synonym.getSynonym())
+                        .map(BrAPIGermplasmSynonyms::getSynonym)
                         .collect(Collectors.joining(";"));
                 row.put("Synonyms", joinedSynonyms);
             }
@@ -201,13 +163,14 @@ public class BrAPIGermplasmService {
         // make file Name
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd:hh-mm-ssZ");
         String timestamp = formatter.format(OffsetDateTime.now());
-        String programKey = "program";
+        StringBuilder fileNameSB = new StringBuilder();
         Optional<Program> optionalProgram = programService.getById(programId);
         if (optionalProgram.isPresent()) {
-            Program program = optionalProgram. get();
-            programKey = program.getKey();
+            Program program = optionalProgram.get();
+            fileNameSB.append( program.getName() );
+            fileNameSB.append("_");
         }
-        String fileName = "germplasm[" + programKey + "]_" + timestamp;
+        String fileName = fileNameSB.append("germplasm").append("_").append(timestamp).toString();
 
         StreamedFile downloadFile;
         //Convert list data to List<Map<String, Object>> data to pass into file writer
@@ -260,7 +223,7 @@ public class BrAPIGermplasmService {
         if(Objects.nonNull(listData.getExternalReferences()) && hasListExternalReference(listData.getExternalReferences())) {
             return UUID.fromString(listData.getExternalReferences().stream()
                     .filter(e -> referenceSource.concat("/lists").equals(e.getReferenceSource()))
-                    .map(e -> e.getReferenceID()).findAny().orElse("00000000-0000-0000-000000000000"));
+                    .map(BrAPIExternalReference::getReferenceID).findAny().orElse("00000000-0000-0000-000000000000"));
         } else {
             return new UUID(0,0);
         }
@@ -270,7 +233,7 @@ public class BrAPIGermplasmService {
         if(Objects.nonNull(importList.getExternalReferences()) && hasListExternalReference(importList.getExternalReferences())) {
             return UUID.fromString(importList.getExternalReferences().stream()
                     .filter(e -> referenceSource.concat("/lists").equals(e.getReferenceSource()))
-                    .map(e -> e.getReferenceID()).findAny().orElse("00000000-0000-0000-000000000000"));
+                    .map(BrAPIExternalReference::getReferenceID).findAny().orElse("00000000-0000-0000-000000000000"));
         } else {
             return new UUID(0,0);
         }
@@ -335,11 +298,6 @@ public class BrAPIGermplasmService {
 
     public List<BrAPIGermplasm> updateBrAPIGermplasm(List<BrAPIGermplasm> putBrAPIGermplasmList, UUID programId, ImportUpload upload) {
         return germplasmDAO.updateBrAPIGermplasm(putBrAPIGermplasmList, programId, upload);
-    }
-
-    public List<BrAPIGermplasm> importBrAPIGermplasm(List<BrAPIGermplasm> postBrAPIGermplasmList, List<BrAPIGermplasm> putBrAPIGermplasmList,
-                                                     UUID programId, ImportUpload upload) throws ApiException {
-        return germplasmDAO.createBrAPIGermplasm(postBrAPIGermplasmList, programId, upload);
     }
 
     public List<BrAPIGermplasm> getRawGermplasmByAccessionNumber(ArrayList<String> germplasmAccessionNumbers, UUID programId) throws ApiException {


### PR DESCRIPTION
# Description
[BI-1922](https://breedinginsight.atlassian.net/browse/BI-1922) Add ability to download all germplasm in a program

# Dependencies
bi-web: feature/BI-1922

# Testing
see test in [bi-web PR](https://github.com/Breeding-Insight/bi-web/pull/350)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1922]: https://breedinginsight.atlassian.net/browse/BI-1922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ