### PR TITLE
[BI-1960] Exp import proceeds with multiple exp names & error message improvement

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
@@ -47,5 +47,6 @@ public final class BrAPIAdditionalInfoFields {
     public static final String MALE_PARENT_UNKNOWN = "maleParentUnknown";
 	public static final String TREATMENTS = "treatments";
     public static final String GID = "gid";
+    public static final String CHANGELOG = "changeLog";
     public static final String ENV_YEAR = "envYear";
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/config/ImportFieldTypeEnum.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/config/ImportFieldTypeEnum.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 
 @Getter
 public enum ImportFieldTypeEnum {
+    BOOLEAN("BOOLEAN"),
     TEXT("TEXT"),
     NUMERICAL("NUMERICAL"),
     INTEGER("INTEGER"),

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
@@ -49,5 +49,5 @@ public abstract class BrAPIImportService {
         return String.format("User input, \"%s\" must be an %s", fieldName, typeName);
     }
     public ImportPreviewResponse process(List<BrAPIImport> brAPIImports, Table data, Program program, ImportUpload upload, User user, Boolean commit)
-            throws UnprocessableEntityException, DoesNotExistException, ValidatorException, ApiException, MissingRequiredInfoException {return null;}
+            throws Exception {return null;}
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/BrAPIImportService.java
@@ -17,15 +17,10 @@
 
 package org.breedinginsight.brapps.importer.model.imports;
 
-import org.brapi.client.v2.model.exceptions.ApiException;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.response.ImportPreviewResponse;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
-import org.breedinginsight.services.exceptions.DoesNotExistException;
-import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
-import org.breedinginsight.services.exceptions.UnprocessableEntityException;
-import org.breedinginsight.services.exceptions.ValidatorException;
 import tech.tablesaw.api.Table;
 
 import java.util.List;

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/ChangeLogEntry.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/ChangeLogEntry.java
@@ -1,0 +1,39 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapps.importer.model.imports;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+public class ChangeLogEntry {
+    private String originalValue;
+    private String reasonForChange;
+    private UUID changedBy;
+    private String dateOfChange;
+
+    public ChangeLogEntry(String originalValue, String reasonForChange, UUID changedBy, String dateOfChange) {
+        this.originalValue = originalValue;
+        this.reasonForChange = reasonForChange;
+        this.changedBy = changedBy;
+        this.dateOfChange = dateOfChange;
+    }
+}

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentImportService.java
@@ -70,7 +70,7 @@ public class ExperimentImportService extends BrAPIImportService {
 
     @Override
     public ImportPreviewResponse process(List<BrAPIImport> brAPIImports, Table data, Program program, ImportUpload upload, User user, Boolean commit)
-            throws UnprocessableEntityException {
+            throws Exception {
 
         ImportPreviewResponse response = null;
         List<Processor> processors = List.of(experimentProcessorProvider.get());

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentImportService.java
@@ -70,7 +70,7 @@ public class ExperimentImportService extends BrAPIImportService {
 
     @Override
     public ImportPreviewResponse process(List<BrAPIImport> brAPIImports, Table data, Program program, ImportUpload upload, User user, Boolean commit)
-            throws UnprocessableEntityException, ValidatorException, ApiException, MissingRequiredInfoException {
+            throws UnprocessableEntityException {
 
         ImportPreviewResponse response = null;
         List<Processor> processors = List.of(experimentProcessorProvider.get());

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentImportService.java
@@ -18,18 +18,15 @@
 package org.breedinginsight.brapps.importer.model.imports.experimentObservation;
 
 import lombok.extern.slf4j.Slf4j;
-import org.brapi.client.v2.model.exceptions.ApiException;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImportService;
-import org.breedinginsight.brapps.importer.model.imports.germplasm.GermplasmImport;
 import org.breedinginsight.brapps.importer.model.response.ImportPreviewResponse;
-import org.breedinginsight.brapps.importer.services.processors.*;
+import org.breedinginsight.brapps.importer.services.processors.ExperimentProcessor;
+import org.breedinginsight.brapps.importer.services.processors.Processor;
+import org.breedinginsight.brapps.importer.services.processors.ProcessorManager;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
-import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
-import org.breedinginsight.services.exceptions.UnprocessableEntityException;
-import org.breedinginsight.services.exceptions.ValidatorException;
 import tech.tablesaw.api.Table;
 
 import javax.inject.Inject;

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -47,9 +47,9 @@ import java.util.function.Supplier;
 @ImportConfigMetadata(id = "ExperimentImport", name = "Experiment Import",
         description = "This import is used to create Observation Unit and Experiment data")
 public class ExperimentObservation implements BrAPIImport {
-    @ImportFieldType(type = ImportFieldTypeEnum.BOOLEAN)
+    @ImportFieldType(type = ImportFieldTypeEnum.BOOLEAN, collectTime = ImportCollectTimeEnum.UPLOAD)
     @ImportFieldMetadata(id = "overwrite", name = "Overwrite", description = "Boolean flag to overwrite existing observation")
-    private boolean overwrite;
+    private String overwrite;
 
     @ImportFieldType(type = ImportFieldTypeEnum.TEXT, collectTime = ImportCollectTimeEnum.UPLOAD)
     @ImportFieldMetadata(id="overwriteReason", name="Overwrite Reason", description="Description of the reason for overwriting existing observations")

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -47,6 +47,13 @@ import java.util.function.Supplier;
 @ImportConfigMetadata(id = "ExperimentImport", name = "Experiment Import",
         description = "This import is used to create Observation Unit and Experiment data")
 public class ExperimentObservation implements BrAPIImport {
+    @ImportFieldType(type = ImportFieldTypeEnum.BOOLEAN)
+    @ImportFieldMetadata(id = "overwrite", name = "Overwrite", description = "Boolean flag to overwrite existing observation")
+    private boolean overwrite;
+
+    @ImportFieldType(type = ImportFieldTypeEnum.TEXT, collectTime = ImportCollectTimeEnum.UPLOAD)
+    @ImportFieldMetadata(id="overwriteReason", name="Overwrite Reason", description="Description of the reason for overwriting existing observations")
+    private String overwriteReason;
 
     @ImportFieldType(type = ImportFieldTypeEnum.TEXT)
     @ImportFieldMetadata(id = "germplasmName", name = Columns.GERMPLASM_NAME, description = "Name of germplasm")

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/germplasm/GermplasmImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/germplasm/GermplasmImportService.java
@@ -66,7 +66,7 @@ public class GermplasmImportService extends BrAPIImportService {
 
     @Override
     public ImportPreviewResponse process(List<BrAPIImport> brAPIImports, Table data, Program program, ImportUpload upload, User user, Boolean commit)
-            throws UnprocessableEntityException, DoesNotExistException, ValidatorException, ApiException, MissingRequiredInfoException {
+            throws Exception {
 
         ImportPreviewResponse response = null;
         List<Processor> processors = List.of(germplasmProcessorProvider.get());

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/germplasm/GermplasmImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/germplasm/GermplasmImportService.java
@@ -18,24 +18,21 @@
 package org.breedinginsight.brapps.importer.model.imports.germplasm;
 
 import lombok.extern.slf4j.Slf4j;
-import org.brapi.client.v2.model.exceptions.ApiException;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImportService;
 import org.breedinginsight.brapps.importer.model.response.ImportPreviewResponse;
-import org.breedinginsight.brapps.importer.services.processors.*;
+import org.breedinginsight.brapps.importer.services.processors.GermplasmProcessor;
+import org.breedinginsight.brapps.importer.services.processors.Processor;
+import org.breedinginsight.brapps.importer.services.processors.ProcessorManager;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
-import org.breedinginsight.services.exceptions.DoesNotExistException;
-import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
-import org.breedinginsight.services.exceptions.UnprocessableEntityException;
-import org.breedinginsight.services.exceptions.ValidatorException;
 import tech.tablesaw.api.Table;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-import java.util.*;
+import java.util.List;
 
 @Singleton
 @Slf4j

--- a/src/main/java/org/breedinginsight/brapps/importer/services/MappingManager.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/MappingManager.java
@@ -351,7 +351,7 @@ public class MappingManager {
         else if (required != null && userInput.containsKey(fieldId) && userInput.get(fieldId).toString().isBlank()) {
             throw new UnprocessableEntityException(importService.getMissingUserInputMsg(metadata.name()));
         }
-        else if (userInput.containsKey(fieldId)) {
+        else if (userInput != null && userInput.containsKey(fieldId)) {
             String value = userInput.get(fieldId).toString();
             if (!isCorrectType(type.type(), value)) {
                 throw new UnprocessableEntityException(importService.getWrongUserInputDataTypeMsg(metadata.name(), type.type().toString().toLowerCase()));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/MappingManager.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/MappingManager.java
@@ -53,6 +53,12 @@ public class MappingManager {
 
     private ImportConfigManager configManager;
 
+    public static String wrongDataTypeMsg = "Column name \"%s\" must be integer type, but non-integer type provided.";
+    public static String blankRequiredField = "Required field \"%s\" cannot contain empty values";
+    public static String missingColumn = "Column name \"%s\" does not exist in file";
+    public static String missingUserInput = "User input, \"%s\" is required";
+    public static String wrongUserInputDataType = "User input, \"%s\" must be an %s";
+
     @Inject
     MappingManager(ImportConfigManager configManager) {
         this.configManager = configManager;
@@ -339,7 +345,7 @@ public class MappingManager {
 
         // Only supports user input at the top level of an object at the moment. No nested objects. Map<String, String>
         String fieldId = metadata.id();
-        if (!userInput.containsKey(fieldId) && required != null) {
+        if ((userInput == null || !userInput.containsKey(fieldId)) && required != null) {
             throw new UnprocessableEntityException(importService.getMissingUserInputMsg(metadata.name()));
         }
         else if (required != null && userInput.containsKey(fieldId) && userInput.get(fieldId).toString().isBlank()) {
@@ -369,12 +375,15 @@ public class MappingManager {
 
     private Boolean isCorrectType(ImportFieldTypeEnum expectedType, String value) {
         if (!value.isBlank()) {
-            if (expectedType == ImportFieldTypeEnum.INTEGER) {
-                try {
+            try {
+                if (expectedType == ImportFieldTypeEnum.INTEGER) {
                     Integer d = Integer.parseInt(value);
-                } catch (NumberFormatException nfe) {
-                    return false;
                 }
+                if (expectedType == ImportFieldTypeEnum.BOOLEAN) {
+                    Boolean b = Boolean.parseBoolean(value);
+                }
+            } catch (NumberFormatException nfe) {
+                return false;
             }
         }
         return true;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/MappingManager.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/MappingManager.java
@@ -375,14 +375,14 @@ public class MappingManager {
 
     private Boolean isCorrectType(ImportFieldTypeEnum expectedType, String value) {
         if (!value.isBlank()) {
-            try {
-                if (expectedType == ImportFieldTypeEnum.INTEGER) {
-                    Integer d = Integer.parseInt(value);
+            if (expectedType == ImportFieldTypeEnum.INTEGER) {
+                try {
+                    Integer.parseInt(value);
+                } catch (NumberFormatException nfe) {
+                    return false;
                 }
-                if (expectedType == ImportFieldTypeEnum.BOOLEAN) {
-                    Boolean b = Boolean.parseBoolean(value);
-                }
-            } catch (NumberFormatException nfe) {
+            }
+            if (expectedType == ImportFieldTypeEnum.BOOLEAN && !String.valueOf(Boolean.parseBoolean(value)).equals(value)) {
                 return false;
             }
         }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -28,8 +28,8 @@ import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.JSON;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.BrAPIExternalReference;
@@ -64,7 +64,7 @@ import org.breedinginsight.model.*;
 import org.breedinginsight.services.OntologyService;
 import org.breedinginsight.services.ProgramLocationService;
 import org.breedinginsight.services.exceptions.DoesNotExistException;
-import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
+import org.breedinginsight.services.exceptions.UnprocessableEntityException;
 import org.breedinginsight.services.exceptions.ValidatorException;
 import org.breedinginsight.utilities.Utilities;
 import org.checkerframework.checker.nullness.Opt;
@@ -90,6 +90,7 @@ import static org.breedinginsight.brapps.importer.services.FileMappingUtil.EXPER
 public class ExperimentProcessor implements Processor {
 
     private static final String NAME = "Experiment";
+    private static final String EXISTING_ENV = "Cannot create a new observation unit for existing environment: ";
     private static final String MISSING_OBS_UNIT_ID_ERROR = "Experiment Units are missing Observation Unit Id.<br/><br/>" +
             "If you’re trying to add these units to the experiment, please create a new environment" +
             " with all appropriate experiment units (NOTE: this will generate new Observation Unit Ids " +
@@ -214,7 +215,7 @@ public class ExperimentProcessor implements Processor {
             Table data,
             Program program,
             User user,
-            boolean commit) throws ValidatorException, MissingRequiredInfoException, ApiException {
+            boolean commit) throws UnprocessableEntityException, ApiException, ValidatorException {
         log.debug("processing experiment import");
 
         ValidationErrors validationErrors = new ValidationErrors();
@@ -488,7 +489,7 @@ public class ExperimentProcessor implements Processor {
         return column.name();
     }
 
-    private void initNewBrapiData(List<BrAPIImport> importRows, List<Column<?>> phenotypeCols, Program program, User user, List<Trait> referencedTraits, boolean commit) throws ApiException {
+    private void initNewBrapiData(List<BrAPIImport> importRows, List<Column<?>> phenotypeCols, Program program, User user, List<Trait> referencedTraits, boolean commit) throws UnprocessableEntityException, ApiException {
 
         String expSequenceName = program.getExpSequence();
         if (expSequenceName == null) {
@@ -665,7 +666,7 @@ public class ExperimentProcessor implements Processor {
             var importHash = getImportObservationHash(importRow, phenoCol.name());
 
             // error if import observation data already exists and user has not selected to overwrite
-            if(commit && importRow.getOverwrite().equals("false") &&
+            if(commit && "false".equals(importRow.getOverwrite() == null ? "false" : importRow.getOverwrite()) &&
                     this.existingObsByObsHash.containsKey(importHash) &&
                     StringUtils.isNotBlank(phenoCol.getString(rowNum)) &&
                     !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(rowNum))) {
@@ -909,7 +910,7 @@ public class ExperimentProcessor implements Processor {
         return null;
     }
 
-    private PendingImportObject<BrAPIObservationUnit> fetchOrCreateObsUnitPIO(Program program, boolean commit, String envSeqValue, ExperimentObservation importRow) throws ApiException {
+    private PendingImportObject<BrAPIObservationUnit> fetchOrCreateObsUnitPIO(Program program, boolean commit, String envSeqValue, ExperimentObservation importRow) throws UnprocessableEntityException, ApiException {
         PendingImportObject<BrAPIObservationUnit> pio;
         String key = createObservationUnitKey(importRow);
         if (this.observationUnitByNameNoScope.containsKey(key)) {
@@ -938,7 +939,11 @@ public class ExperimentProcessor implements Processor {
             if (studyPIO.getBrAPIObject().getStudyDbId() != null) {
                 List<BrAPIObservationUnit> existingOUs = brAPIObservationUnitDAO.getObservationUnitsForStudyDbId(studyPIO.getBrAPIObject().getStudyDbId(), program);
                 List<BrAPIObservationUnit> matchingOU = existingOUs.stream().filter(ou -> importRow.getExpUnitId().equals(Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getObservationUnitName(), program.getKey()))).collect(Collectors.toList());
-                pio = !matchingOU.isEmpty() ? new PendingImportObject<>(ImportObjectState.EXISTING, matchingOU.get(0)) : new PendingImportObject<>(ImportObjectState.NEW, newObservationUnit, id);
+                if (matchingOU.isEmpty()) {
+                    throw new UnprocessableEntityException(EXISTING_ENV + Utilities.removeProgramKeyAndUnknownAdditionalData(studyPIO.getBrAPIObject().getStudyName(), program.getKey()));
+                } else {
+                    pio = new PendingImportObject<>(ImportObjectState.EXISTING, matchingOU.get(0));
+                }
             } else {
                 pio = new PendingImportObject<>(ImportObjectState.NEW, newObservationUnit, id);
             }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -278,6 +278,7 @@ public class ExperimentProcessor implements Processor {
                 .getMutationsByObjectId(obsVarDatasetByName, BrAPIListSummary::getListDbId);
 
         List<BrAPIObservationUnit> newObservationUnits = ProcessorData.getNewObjects(this.observationUnitByNameNoScope);
+
         // filter out observations with no 'value' so they will not be saved
         List<BrAPIObservation> newObservations = ProcessorData.getNewObjects(this.observationByHash)
                                                               .stream()
@@ -648,7 +649,8 @@ public class ExperimentProcessor implements Processor {
             } else if (this.existingObsByObsHash.containsKey(importHash) &&
                     StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum -1)) &&
                     !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1))) {
-                observationByHash.get(importHash).setState(ImportObjectState.EXISTING);
+                observationByHash.get(importHash).getBrAPIObject().setValue(phenoCol.getString(numRows - rowNum -1));
+                observationByHash.get(importHash).setState(ImportObjectState.MUTATED);
 
             // preview case where observation has already been committed and import ObsVar data is either empty or the
             // same as has been committed prior to import
@@ -780,7 +782,7 @@ public class ExperimentProcessor implements Processor {
         int numExistingObservations = Math.toIntExact(
                 this.observationByHash.values()
                         .stream()
-                        .filter(preview -> preview != null && preview.getState() == ImportObjectState.EXISTING &&
+                        .filter(preview -> preview != null && (preview.getState() == ImportObjectState.EXISTING || preview.getState() == ImportObjectState.MUTATED) &&
                                 !StringUtils.isBlank(preview.getBrAPIObject()
                                         .getValue()))
                         .count()

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -677,7 +677,7 @@ public class ExperimentProcessor implements Processor {
             } else if (this.existingObsByObsHash.containsKey(importHash) &&
                     StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum -1)) &&
                     !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1))) {
-                observationByHash.get(importHash).getBrAPIObject().setValue(phenoCol.getString(numRows - rowNum -1));
+                //observationByHash.get(importHash).getBrAPIObject().setValue(phenoCol.getString(numRows - rowNum -1));
                 observationByHash.get(importHash).setState(ImportObjectState.MUTATED);
 
                 // add a change log entry when updating the value of an observation
@@ -837,11 +837,21 @@ public class ExperimentProcessor implements Processor {
         int numExistingObservations = Math.toIntExact(
                 this.observationByHash.values()
                         .stream()
-                        .filter(preview -> preview != null && (preview.getState() == ImportObjectState.EXISTING || preview.getState() == ImportObjectState.MUTATED) &&
+                        .filter(preview -> preview != null && preview.getState() == ImportObjectState.EXISTING &&
                                 !StringUtils.isBlank(preview.getBrAPIObject()
                                         .getValue()))
                         .count()
         );
+
+        int numMutatedObservations = Math.toIntExact(
+                this.observationByHash.values()
+                        .stream()
+                        .filter(preview -> preview != null && preview.getState() == ImportObjectState.MUTATED &&
+                                !StringUtils.isBlank(preview.getBrAPIObject()
+                                        .getValue()))
+                        .count()
+        );
+
 
         ImportPreviewStatistics environmentStats = ImportPreviewStatistics.builder()
                                                                           .newObjectCount(environmentNameCounter.size())
@@ -858,13 +868,17 @@ public class ExperimentProcessor implements Processor {
         ImportPreviewStatistics existingObservationStats = ImportPreviewStatistics.builder()
                 .newObjectCount(numExistingObservations)
                 .build();
+        ImportPreviewStatistics mutatedObservationStats = ImportPreviewStatistics.builder()
+                .newObjectCount(numMutatedObservations)
+                .build();
 
         return Map.of(
                 "Environments", environmentStats,
                 "Observation_Units", obdUnitStats,
                 "GIDs", gidStats,
                 "Observations", observationStats,
-                "Existing Observations", existingObservationStats
+                "Existing Observations", existingObservationStats,
+                "Mutated Observations", mutatedObservationStats
         );
     }
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -662,7 +662,7 @@ public class ExperimentProcessor implements Processor {
             var importHash = getImportObservationHash(importRow, phenoCol.name());
 
             // error if import observation data already exists and user has not selected to overwrite
-            if(commit && !importRow.isOverwrite() &&
+            if(commit && importRow.getOverwrite().equals("false") &&
                     this.existingObsByObsHash.containsKey(importHash) &&
                     StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum - 1)) &&
                     !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum - 1))) {
@@ -678,6 +678,7 @@ public class ExperimentProcessor implements Processor {
                     StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum -1)) &&
                     !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1))) {
                 //observationByHash.get(importHash).getBrAPIObject().setValue(phenoCol.getString(numRows - rowNum -1));
+                //this.existingObsByObsHash.get(importHash).setObservationVariableName(phenoCol.name());
                 observationByHash.get(importHash).setState(ImportObjectState.MUTATED);
 
                 // add a change log entry when updating the value of an observation

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -268,6 +268,9 @@ public class ExperimentProcessor implements Processor {
         Map<String, BrAPITrial> mutatedTrialsById = ProcessorData
                 .getMutationsByObjectId(trialByNameNoScope, BrAPITrial::getTrialDbId);
 
+        Map<String, BrAPIObservation> mutatedObservationByDbId = ProcessorData
+                .getMutationsByObjectId(observationByHash, observation -> observation.getObservationDbId());
+
         List<ProgramLocationRequest> newLocations = ProcessorData.getNewObjects(this.locationByName)
                                                                  .stream()
                                                                  .map(location -> ProgramLocationRequest.builder()
@@ -386,6 +389,19 @@ public class ExperimentProcessor implements Processor {
                 throw new InternalServerException(e.getMessage(), e);
             }
         });
+
+        mutatedObservationByDbId.forEach((id, observation) ->  {
+            try {
+                brAPIObservationDAO.updateBrAPIObservation(id, observation, program.getId());
+            } catch (ApiException e) {
+                log.error("Error updating observation: " + Utilities.generateApiExceptionLogMessage(e), e);
+                throw new InternalServerException("Error saving experiment import", e);
+            } catch (Exception e) {
+                log.error("Error updating observation: ", e);
+                throw new InternalServerException(e.getMessage(), e);
+            }
+        });
+
         log.debug("experiment import complete");
 
     }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -69,7 +69,6 @@ import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 
 import javax.inject.Inject;
-import javax.validation.Valid;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.OffsetDateTime;
@@ -92,6 +91,7 @@ public class ExperimentProcessor implements Processor {
             "If you’re trying to add these units to the experiment, please create a new environment" +
             " with all appropriate experiment units (NOTE: this will generate new Observation Unit Ids " +
             "for each experiment unit).";
+    private static final String MULTIPLE_EXP_TITLES = "File contains more than one Experiment Title";
     private static final String MIDNIGHT = "T00:00:00-00:00";
     private static final String TIMESTAMP_PREFIX = "TS:";
     private static final String TIMESTAMP_REGEX = "^"+TIMESTAMP_PREFIX+"\\s*";
@@ -588,7 +588,6 @@ public class ExperimentProcessor implements Processor {
         for (int rowNum = 0; rowNum < importRows.size(); rowNum++) {
             ExperimentObservation importRow = (ExperimentObservation) importRows.get(rowNum);
             PendingImport mappedImportRow = mappedBrAPIImport.get(rowNum);
-
             if (StringUtils.isNotBlank(importRow.getGid())) { // if GID is blank, don't bother to check if it is valid.
                 validateGermplasm(importRow, validationErrors, rowNum, mappedImportRow.getGermplasm());
             }
@@ -1163,10 +1162,12 @@ public class ExperimentProcessor implements Processor {
         }
     }
 
-    private PendingImportObject<BrAPITrial> fetchOrCreateTrialPIO(Program program, User user, boolean commit, ExperimentObservation importRow, Supplier<BigInteger> expNextVal) {
+    private PendingImportObject<BrAPITrial> fetchOrCreateTrialPIO(Program program, User user, boolean commit, ExperimentObservation importRow, Supplier<BigInteger> expNextVal) throws UnprocessableEntityException {
         PendingImportObject<BrAPITrial> pio;
         if (trialByNameNoScope.containsKey(importRow.getExpTitle())) {
             pio = trialByNameNoScope.get(importRow.getExpTitle());
+        } else if (!trialByNameNoScope.isEmpty()) {
+            throw new UnprocessableEntityException(MULTIPLE_EXP_TITLES);
         } else {
             UUID id = UUID.randomUUID();
             String expSeqValue = null;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -19,8 +19,6 @@ package org.breedinginsight.brapps.importer.services.processors;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.http.HttpStatus;
@@ -48,7 +46,6 @@ import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapps.importer.daos.*;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
-import org.breedinginsight.brapps.importer.model.base.AdditionalInfo;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
 import org.breedinginsight.brapps.importer.model.imports.ChangeLogEntry;
 import org.breedinginsight.brapps.importer.model.imports.PendingImport;
@@ -67,31 +64,26 @@ import org.breedinginsight.services.exceptions.DoesNotExistException;
 import org.breedinginsight.services.exceptions.UnprocessableEntityException;
 import org.breedinginsight.services.exceptions.ValidatorException;
 import org.breedinginsight.utilities.Utilities;
-import org.checkerframework.checker.nullness.Opt;
 import org.jooq.DSLContext;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 
 import javax.inject.Inject;
-import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.*;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import static org.breedinginsight.brapps.importer.services.FileMappingUtil.EXPERIMENT_TEMPLATE_NAME;
 
 @Slf4j
 @Prototype
 public class ExperimentProcessor implements Processor {
 
     private static final String NAME = "Experiment";
-    private static final String EXISTING_ENV = "Cannot create new observation unit %s for existing environment %s." +
+    private static final String EXISTING_ENV = "Cannot create new observation unit %s for existing environment %s.<br/><br/>" +
             "If you’re trying to add these units to the experiment, please create a new environment" +
             " with all appropriate experiment units (NOTE: this will generate new Observation Unit Ids " +
             "for each experiment unit).";
@@ -103,7 +95,6 @@ public class ExperimentProcessor implements Processor {
     private static final String TIMESTAMP_PREFIX = "TS:";
     private static final String TIMESTAMP_REGEX = "^"+TIMESTAMP_PREFIX+"\\s*";
     private static final String COMMA_DELIMITER = ",";
-    private static final String BLANK_FIELD = "Required field is blank";
     private static final String BLANK_FIELD_EXPERIMENT = "Field is blank when creating a new experiment";
     private static final String BLANK_FIELD_ENV = "Field is blank when creating a new environment";
     private static final String BLANK_FIELD_OBS = "Field is blank when creating new observations";
@@ -397,7 +388,16 @@ public class ExperimentProcessor implements Processor {
 
         mutatedObservationByDbId.forEach((id, observation) ->  {
             try {
-                brAPIObservationDAO.updateBrAPIObservation(id, observation, program.getId());
+                BrAPIObservation updatedObs = brAPIObservationDAO.updateBrAPIObservation(id, observation, program.getId());
+                if (!observation.getValue().equals(updatedObs.getValue()) || !observation.getObservationTimeStamp().equals(updatedObs.getObservationTimeStamp())) {
+                    String message;
+                    if(!observation.getValue().equals(updatedObs.getValue())) {
+                        message = String.format("Updated observation, %s, from BrAPI service does not match requested update %s.", updatedObs.getValue(), observation.getValue());
+                    } else {
+                        message = String.format("Updated observation timestamp, %s, from BrAPI service does not match requested update timestamp %s.", updatedObs.getObservationTimeStamp(), observation.getObservationTimeStamp());
+                    }
+                    throw new Exception(message);
+                }
             } catch (ApiException e) {
                 log.error("Error updating observation: " + Utilities.generateApiExceptionLogMessage(e), e);
                 throw new InternalServerException("Error saving experiment import", e);
@@ -663,7 +663,7 @@ public class ExperimentProcessor implements Processor {
                                       int rowNum,
                                       ExperimentObservation importRow,
                                       List<Column<?>> phenotypeCols,
-                                      Map<String, Trait> colVarMap,
+                                      CaseInsensitiveMap<String, Trait> colVarMap,
                                       boolean commit,
                                       User user) {
         phenotypeCols.forEach(phenoCol -> {
@@ -697,6 +697,8 @@ public class ExperimentProcessor implements Processor {
                             user.getId(),
                             timestamp
                     );
+
+                    // create the changelog field in additonalinfo if it does not already exist
                     if (pendingObservation.getAdditionalInfo().isJsonNull()) {
                         pendingObservation.setAdditionalInfo(new JsonObject());
                         pendingObservation.getAdditionalInfo().add(BrAPIAdditionalInfoFields.CHANGELOG, new JsonArray());
@@ -705,6 +707,8 @@ public class ExperimentProcessor implements Processor {
                     if (pendingObservation.getAdditionalInfo() != null && !pendingObservation.getAdditionalInfo().has(BrAPIAdditionalInfoFields.CHANGELOG)) {
                         pendingObservation.getAdditionalInfo().add(BrAPIAdditionalInfoFields.CHANGELOG, new JsonArray());
                     }
+
+                    // add a new entry to the changelog
                     pendingObservation.getAdditionalInfo().get(BrAPIAdditionalInfoFields.CHANGELOG).getAsJsonArray().add(gson.toJsonTree(change).getAsJsonObject());
                 }
 
@@ -973,13 +977,20 @@ public class ExperimentProcessor implements Processor {
         BrAPIObservation newObservation;
         String key = getImportObservationHash(importRow, variableName);
         existingObsByObsHash = fetchExistingObservations(referencedTraits, program);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        String formattedTimeStampValue = formatter.format(OffsetDateTime.parse(timeStampValue));
         if (existingObsByObsHash.containsKey(key)) {
             if (StringUtils.isNotBlank(value) &&
-                    !existingObsByObsHash.get(key).getValue().equals(value)) {
+                    (!existingObsByObsHash.get(key).getValue().equals(value) ||
+                    !existingObsByObsHash.get(key).getObservationTimeStamp().equals(formattedTimeStampValue))){
 
                 // prior observation with updated value
                 newObservation = gson.fromJson(gson.toJson(existingObsByObsHash.get(key)), BrAPIObservation.class);
-                newObservation.setValue(value);
+                if (!existingObsByObsHash.get(key).getValue().equals(value)){
+                    newObservation.setValue(value);
+                } else if (!existingObsByObsHash.get(key).getObservationTimeStamp().equals(formattedTimeStampValue)) {
+                    newObservation.setObservationTimeStamp(OffsetDateTime.parse(formattedTimeStampValue));
+                }
                 pio = new PendingImportObject<>(ImportObjectState.MUTATED, (BrAPIObservation) Utilities.formatBrapiObjForDisplay(newObservation, BrAPIObservation.class, program));
             } else {
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -69,6 +69,7 @@ import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 
 import javax.inject.Inject;
+import javax.validation.Valid;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.OffsetDateTime;
@@ -389,7 +390,7 @@ public class ExperimentProcessor implements Processor {
         mutatedObservationByDbId.forEach((id, observation) ->  {
             try {
                 BrAPIObservation updatedObs = brAPIObservationDAO.updateBrAPIObservation(id, observation, program.getId());
-                if (!observation.getValue().equals(updatedObs.getValue()) || !observation.getObservationTimeStamp().equals(updatedObs.getObservationTimeStamp())) {
+                if (!observation.getValue().equals(updatedObs.getValue()) || !observation.getObservationTimeStamp().isEqual(updatedObs.getObservationTimeStamp())) {
                     String message;
                     if(!observation.getValue().equals(updatedObs.getValue())) {
                         message = String.format("Updated observation, %s, from BrAPI service does not match requested update %s.", updatedObs.getValue(), observation.getValue());
@@ -667,7 +668,9 @@ public class ExperimentProcessor implements Processor {
                                       boolean commit,
                                       User user) {
         phenotypeCols.forEach(phenoCol -> {
-            var importHash = getImportObservationHash(importRow, phenoCol.name());
+            String importHash = getImportObservationHash(importRow, phenoCol.name());
+            String importObsValue = phenoCol.getString(rowNum);
+            String importObsTimestamp = timeStampColByPheno.get(phenoCol.name()).getString(rowNum);
 
             // error if import observation data already exists and user has not selected to overwrite
             if(commit && "false".equals(importRow.getOverwrite() == null ? "false" : importRow.getOverwrite()) &&
@@ -682,9 +685,7 @@ public class ExperimentProcessor implements Processor {
 
             // preview case where observation has already been committed and the import row ObsVar data differs from what
             // had been saved prior to import
-            } else if (this.existingObsByObsHash.containsKey(importHash) &&
-                    StringUtils.isNotBlank(phenoCol.getString(rowNum)) &&
-                    !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(rowNum))) {
+            } else if (existingObsByObsHash.containsKey(importHash) && !isObservationMatched(importHash, importObsValue, importObsTimestamp)) {
 
                 // add a change log entry when updating the value of an observation
                 if (commit) {
@@ -692,13 +693,21 @@ public class ExperimentProcessor implements Processor {
                     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd:hh-mm-ssZ");
                     String timestamp = formatter.format(OffsetDateTime.now());
                     String reason = importRow.getOverwriteReason() != null ? importRow.getOverwriteReason() : "";
-                    ChangeLogEntry change = new ChangeLogEntry(existingObsByObsHash.get(importHash).getValue(),
+                    String prior = "";
+                    if (isValueMatched(importHash, importObsValue)) {
+                        prior.concat(existingObsByObsHash.get(importHash).getValue());
+                    }
+                    if (isTimestampMatched(importHash, importObsTimestamp)) {
+                        prior = prior.isEmpty() ? prior : prior.concat(" ");
+                        prior.concat(existingObsByObsHash.get(importHash).getObservationTimeStamp().toString());
+                    }
+                    ChangeLogEntry change = new ChangeLogEntry(prior,
                             reason,
                             user.getId(),
                             timestamp
                     );
 
-                    // create the changelog field in additonalinfo if it does not already exist
+                    // create the changelog field in additional info if it does not already exist
                     if (pendingObservation.getAdditionalInfo().isJsonNull()) {
                         pendingObservation.setAdditionalInfo(new JsonObject());
                         pendingObservation.getAdditionalInfo().add(BrAPIAdditionalInfoFields.CHANGELOG, new JsonArray());
@@ -714,9 +723,8 @@ public class ExperimentProcessor implements Processor {
 
             // preview case where observation has already been committed and import ObsVar data is either empty or the
             // same as has been committed prior to import
-            } else if(this.existingObsByObsHash.containsKey(importHash) &&
-                    (StringUtils.isBlank(phenoCol.getString(rowNum)) ||
-                            this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(rowNum)))) {
+            } else if(existingObsByObsHash.containsKey(importHash) && (StringUtils.isBlank(phenoCol.getString(rowNum)) ||
+                            isObservationMatched(importHash, importObsValue, importObsTimestamp))) {
                 BrAPIObservation existingObs = this.existingObsByObsHash.get(importHash);
                 existingObs.setObservationVariableName(phenoCol.name());
                 observationByHash.get(importHash).setState(ImportObjectState.EXISTING);
@@ -961,7 +969,24 @@ public class ExperimentProcessor implements Processor {
         return pio;
     }
 
+    boolean isTimestampMatched(String observationHash, String timeStamp) {
+        OffsetDateTime priorStamp = existingObsByObsHash.get(observationHash).getObservationTimeStamp();
+        if (priorStamp == null) {
+            return timeStamp == null;
+        }
+        return priorStamp.isEqual(OffsetDateTime.parse(timeStamp));
+    }
 
+    boolean isValueMatched(String observationHash, String value) {
+        if (existingObsByObsHash.get(observationHash).getValue() == null) {
+            return value == null;
+        }
+        return existingObsByObsHash.get(observationHash).getValue().equals(value);
+    }
+
+    boolean isObservationMatched(String observationHash, String value, String timeStamp) {
+        return isTimestampMatched(observationHash, timeStamp) && isValueMatched(observationHash, value);
+    }
 
     private void fetchOrCreateObservationPIO(Program program,
                                              User user,
@@ -977,18 +1002,16 @@ public class ExperimentProcessor implements Processor {
         BrAPIObservation newObservation;
         String key = getImportObservationHash(importRow, variableName);
         existingObsByObsHash = fetchExistingObservations(referencedTraits, program);
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
         String formattedTimeStampValue = formatter.format(OffsetDateTime.parse(timeStampValue));
         if (existingObsByObsHash.containsKey(key)) {
-            if (StringUtils.isNotBlank(value) &&
-                    (!existingObsByObsHash.get(key).getValue().equals(value) ||
-                    !existingObsByObsHash.get(key).getObservationTimeStamp().equals(formattedTimeStampValue))){
+            if (StringUtils.isNotBlank(value) && !isObservationMatched(key, value, timeStampValue)){
 
                 // prior observation with updated value
                 newObservation = gson.fromJson(gson.toJson(existingObsByObsHash.get(key)), BrAPIObservation.class);
-                if (!existingObsByObsHash.get(key).getValue().equals(value)){
+                if (!isValueMatched(key, value)){
                     newObservation.setValue(value);
-                } else if (!existingObsByObsHash.get(key).getObservationTimeStamp().equals(formattedTimeStampValue)) {
+                } else if (!isTimestampMatched(key, timeStampValue)) {
                     newObservation.setObservationTimeStamp(OffsetDateTime.parse(formattedTimeStampValue));
                 }
                 pio = new PendingImportObject<>(ImportObjectState.MUTATED, (BrAPIObservation) Utilities.formatBrapiObjForDisplay(newObservation, BrAPIObservation.class, program));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -16,8 +16,8 @@
  */
 package org.breedinginsight.brapps.importer.services.processors;
 
-import com.google.gson.JsonArray;
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -67,6 +67,7 @@ import org.breedinginsight.services.exceptions.DoesNotExistException;
 import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
 import org.breedinginsight.services.exceptions.ValidatorException;
 import org.breedinginsight.utilities.Utilities;
+import org.checkerframework.checker.nullness.Opt;
 import org.jooq.DSLContext;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
@@ -143,7 +144,6 @@ public class ExperimentProcessor implements Processor {
     // Associates timestamp columns to associated phenotype column name for ease of storage
     private final Map<String, Column<?>> timeStampColByPheno = new HashMap<>();
     private final Gson gson;
-
 
     @Inject
     public ExperimentProcessor(DSLContext dsl,
@@ -488,7 +488,7 @@ public class ExperimentProcessor implements Processor {
         return column.name();
     }
 
-    private void initNewBrapiData(List<BrAPIImport> importRows, List<Column<?>> phenotypeCols, Program program, User user, List<Trait> referencedTraits, boolean commit) {
+    private void initNewBrapiData(List<BrAPIImport> importRows, List<Column<?>> phenotypeCols, Program program, User user, List<Trait> referencedTraits, boolean commit) throws ApiException {
 
         String expSequenceName = program.getExpSequence();
         if (expSequenceName == null) {
@@ -547,7 +547,7 @@ public class ExperimentProcessor implements Processor {
                 }
                 //column.name() gets phenotype name
                 String seasonDbId = this.yearToSeasonDbId(importRow.getEnvYear(), program.getId());
-                fetchOrCreateObservationPIO(program, user, importRow, column.name(), column.getString(rowNum), dateTimeValue, commit, seasonDbId, obsUnitPIO);
+                fetchOrCreateObservationPIO(program, user, importRow, column.name(), column.getString(rowNum), dateTimeValue, commit, seasonDbId, obsUnitPIO, referencedTraits);
             }
         }
     }
@@ -574,7 +574,6 @@ public class ExperimentProcessor implements Processor {
     private ValidationErrors validateFields(List<BrAPIImport> importRows, ValidationErrors validationErrors, Map<Integer, PendingImport> mappedBrAPIImport, List<Trait> referencedTraits, Program program,
                                 List<Column<?>> phenotypeCols, boolean commit, User user) throws MissingRequiredInfoException, ApiException {
         //fetching any existing observations for any OUs in the import
-        this.existingObsByObsHash = fetchExistingObservations(referencedTraits, program);
         CaseInsensitiveMap<String, Trait> colVarMap = new CaseInsensitiveMap<>();
         for ( Trait trait: referencedTraits) {
             colVarMap.put(trait.getObservationVariableName(),trait);
@@ -590,10 +589,10 @@ public class ExperimentProcessor implements Processor {
             validateTestOrCheck(importRow, validationErrors, rowNum);
 
             //Check if existing environment. If so, ObsUnitId must be assigned
-            if ((mappedImportRow.getStudy().getState() == ImportObjectState.EXISTING)
-                    && (StringUtils.isBlank(importRow.getObsUnitID()))) {
-                throw new MissingRequiredInfoException(MISSING_OBS_UNIT_ID_ERROR);
-            }
+//            if ((mappedImportRow.getStudy().getState() == ImportObjectState.EXISTING)
+//                    && (StringUtils.isBlank(importRow.getObsUnitID()))) {
+//                throw new MissingRequiredInfoException(MISSING_OBS_UNIT_ID_ERROR);
+//            }
 
             validateConditionallyRequired(validationErrors, rowNum, importRow, program, commit);
             validateObservationUnits(validationErrors, uniqueStudyAndObsUnit, rowNum, importRow);
@@ -623,12 +622,24 @@ public class ExperimentProcessor implements Processor {
                                                                 .map(PendingImportObject::getBrAPIObject)
                                                                 .collect(Collectors.toMap(BrAPIStudy::getStudyDbId, brAPIStudy -> Utilities.removeProgramKeyAndUnknownAdditionalData(brAPIStudy.getStudyName(), program.getKey())));
 
-        observationUnitByNameNoScope.values().forEach(ou -> {
-            if(StringUtils.isNotBlank(ou.getBrAPIObject().getObservationUnitDbId())) {
-                ouDbIds.add(ou.getBrAPIObject().getObservationUnitDbId());
+        studyNameByDbId.keySet().stream().forEach(studyDbId -> {
+            try {
+                brAPIObservationUnitDAO.getObservationUnitsForStudyDbId(studyDbId, program).forEach(ou -> {
+                    if(StringUtils.isNotBlank(ou.getObservationUnitDbId())) {
+                        ouDbIds.add(ou.getObservationUnitDbId());
+                    }
+                    ouNameByDbId.put(ou.getObservationUnitDbId(), Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getObservationUnitName(), program.getKey()));
+                });
+            } catch (ApiException e) {
+                throw new RuntimeException(e);
             }
-            ouNameByDbId.put(ou.getBrAPIObject().getObservationUnitDbId(), Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getBrAPIObject().getObservationUnitName(), program.getKey()));
         });
+//        observationUnitByNameNoScope.values().forEach(ou -> {
+//            if(StringUtils.isNotBlank(ou.getBrAPIObject().getObservationUnitDbId())) {
+//                ouDbIds.add(ou.getBrAPIObject().getObservationUnitDbId());
+//            }
+//            ouNameByDbId.put(ou.getBrAPIObject().getObservationUnitDbId(), Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getBrAPIObject().getObservationUnitName(), program.getKey()));
+//        });
 
         for (Trait referencedTrait : referencedTraits) {
             variableDbIds.add(referencedTrait.getObservationVariableDbId());
@@ -679,7 +690,7 @@ public class ExperimentProcessor implements Processor {
                     !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1))) {
                 //observationByHash.get(importHash).getBrAPIObject().setValue(phenoCol.getString(numRows - rowNum -1));
                 //this.existingObsByObsHash.get(importHash).setObservationVariableName(phenoCol.name());
-                observationByHash.get(importHash).setState(ImportObjectState.MUTATED);
+                //observationByHash.get(importHash).setState(ImportObjectState.MUTATED);
 
                 // add a change log entry when updating the value of an observation
                 if (commit) {
@@ -789,7 +800,7 @@ public class ExperimentProcessor implements Processor {
                 addRowError(Columns.OBS_UNIT_ID, "ObsUnitID cannot be specified when creating a new environment", validationErrors, rowNum);
             }
         } else {
-            validateRequiredCell(importRow.getObsUnitID(), Columns.OBS_UNIT_ID, errorMessage, validationErrors, rowNum);
+            //validateRequiredCell(importRow.getObsUnitID(), Columns.OBS_UNIT_ID, errorMessage, validationErrors, rowNum);
         }
     }
 
@@ -908,7 +919,7 @@ public class ExperimentProcessor implements Processor {
         return null;
     }
 
-    private PendingImportObject<BrAPIObservationUnit> fetchOrCreateObsUnitPIO(Program program, boolean commit, String envSeqValue, ExperimentObservation importRow) {
+    private PendingImportObject<BrAPIObservationUnit> fetchOrCreateObsUnitPIO(Program program, boolean commit, String envSeqValue, ExperimentObservation importRow) throws ApiException {
         PendingImportObject<BrAPIObservationUnit> pio;
         String key = createObservationUnitKey(importRow);
         if (this.observationUnitByNameNoScope.containsKey(key)) {
@@ -929,10 +940,17 @@ public class ExperimentProcessor implements Processor {
                         .get(BrAPIAdditionalInfoFields.OBSERVATION_DATASET_ID).getAsString());
             }
             PendingImportObject<BrAPIStudy> studyPIO = this.studyByNameNoScope.get(importRow.getEnv());
-            UUID studyID = studyPIO.getId();
-            UUID id = UUID.randomUUID();
-            BrAPIObservationUnit newObservationUnit = importRow.constructBrAPIObservationUnit(program, envSeqValue, commit, germplasmName, BRAPI_REFERENCE_SOURCE, trialID, datasetId, studyID, id);
-            pio = new PendingImportObject<>(ImportObjectState.NEW, newObservationUnit, id);
+
+            List<BrAPIObservationUnit> existingOUs = brAPIObservationUnitDAO.getObservationUnitsForStudyDbId(studyPIO.getBrAPIObject().getStudyDbId(), program);
+            List<BrAPIObservationUnit> matchingOU = existingOUs.stream().filter(ou -> importRow.getExpUnitId().equals(Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getObservationUnitName(), program.getKey()))).collect(Collectors.toList());
+            if (!matchingOU.isEmpty()) {
+                pio = new PendingImportObject<>(ImportObjectState.EXISTING, matchingOU.get(0));
+            } else {
+                UUID studyID = studyPIO.getId();
+                UUID id = UUID.randomUUID();
+                BrAPIObservationUnit newObservationUnit = importRow.constructBrAPIObservationUnit(program, envSeqValue, commit, germplasmName, BRAPI_REFERENCE_SOURCE, trialID, datasetId, studyID, id);
+                pio = new PendingImportObject<>(ImportObjectState.NEW, newObservationUnit, id);
+            }
             this.observationUnitByNameNoScope.put(key, pio);
         }
         return pio;
@@ -940,23 +958,43 @@ public class ExperimentProcessor implements Processor {
 
 
     private void fetchOrCreateObservationPIO(Program program,
-                                             User user,
-                                             ExperimentObservation importRow,
-                                             String variableName,
-                                             String value,
-                                             String timeStampValue,
-                                             boolean commit,
-                                             String seasonDbId,
-                                             PendingImportObject<BrAPIObservationUnit> obsUnitPIO) {
+                                                                              User user,
+                                                                              ExperimentObservation importRow,
+                                                                              String variableName,
+                                                                              String value,
+                                                                              String timeStampValue,
+                                                                              boolean commit,
+                                                                              String seasonDbId,
+                                                                              PendingImportObject<BrAPIObservationUnit> obsUnitPIO,
+                                                                              List<Trait> referencedTraits) throws ApiException {
         PendingImportObject<BrAPIObservation> pio;
+        BrAPIObservation newObservation;
         String key = getImportObservationHash(importRow, variableName);
-        if (!this.observationByHash.containsKey(key)) {
+        existingObsByObsHash = fetchExistingObservations(referencedTraits, program);
+        if (existingObsByObsHash.containsKey(key)) {
+            if (StringUtils.isNotBlank(value) &&
+                    !existingObsByObsHash.get(key).getValue().equals(value)) {
+
+                // prior observation with updated value
+                newObservation = gson.fromJson(gson.toJson(existingObsByObsHash.get(key)), BrAPIObservation.class);
+                newObservation.setValue(value);
+                pio = new PendingImportObject<>(ImportObjectState.MUTATED, newObservation);
+            } else {
+
+                // prior observation
+                pio = new PendingImportObject<>(ImportObjectState.EXISTING, existingObsByObsHash.get(key));
+            }
+
+            observationByHash.put(key, pio);
+        } else if (!this.observationByHash.containsKey(key)){
+
+            // new observation
             PendingImportObject<BrAPITrial> trialPIO = this.trialByNameNoScope.get(importRow.getExpTitle());
             UUID trialID = trialPIO.getId();
             PendingImportObject<BrAPIStudy> studyPIO = this.studyByNameNoScope.get(importRow.getEnv());
             UUID studyID = studyPIO.getId();
             UUID id = UUID.randomUUID();
-            BrAPIObservation newObservation = importRow.constructBrAPIObservation(value, variableName, seasonDbId, obsUnitPIO.getBrAPIObject(), commit, program, user, BRAPI_REFERENCE_SOURCE, trialID, studyID, obsUnitPIO.getId(), id);
+            newObservation = importRow.constructBrAPIObservation(value, variableName, seasonDbId, obsUnitPIO.getBrAPIObject(), commit, program, user, BRAPI_REFERENCE_SOURCE, trialID, studyID, obsUnitPIO.getId(), id);
             //NOTE: Can't parse invalid timestamp value, so have to skip if invalid.
             // Validation error should be thrown for offending value, but that doesn't happen until later downstream
             if (timeStampValue != null && !timeStampValue.isBlank() && (validDateValue(timeStampValue) || validDateTimeValue(timeStampValue))) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -688,9 +688,6 @@ public class ExperimentProcessor implements Processor {
             } else if (this.existingObsByObsHash.containsKey(importHash) &&
                     StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum -1)) &&
                     !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1))) {
-                //observationByHash.get(importHash).getBrAPIObject().setValue(phenoCol.getString(numRows - rowNum -1));
-                //this.existingObsByObsHash.get(importHash).setObservationVariableName(phenoCol.name());
-                //observationByHash.get(importHash).setState(ImportObjectState.MUTATED);
 
                 // add a change log entry when updating the value of an observation
                 if (commit) {
@@ -711,7 +708,7 @@ public class ExperimentProcessor implements Processor {
                     if (pendingObservation.getAdditionalInfo() != null && !pendingObservation.getAdditionalInfo().has(BrAPIAdditionalInfoFields.CHANGELOG)) {
                         pendingObservation.getAdditionalInfo().add(BrAPIAdditionalInfoFields.CHANGELOG, new JsonArray());
                     }
-                    pendingObservation.getAdditionalInfo().get(BrAPIAdditionalInfoFields.CHANGELOG).getAsJsonArray().add(gson.toJson(change));
+                    pendingObservation.getAdditionalInfo().get(BrAPIAdditionalInfoFields.CHANGELOG).getAsJsonArray().add(gson.toJsonTree(change).getAsJsonObject());
                 }
 
             // preview case where observation has already been committed and import ObsVar data is either empty or the

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -685,8 +685,9 @@ public class ExperimentProcessor implements Processor {
                     BrAPIObservation pendingObservation = observationByHash.get(importHash).getBrAPIObject();
                     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd:hh-mm-ssZ");
                     String timestamp = formatter.format(OffsetDateTime.now());
+                    String reason = importRow.getOverwriteReason() != null ? importRow.getOverwriteReason() : "";
                     ChangeLogEntry change = new ChangeLogEntry(existingObsByObsHash.get(importHash).getValue(),
-                            importRow.getOverwriteReason(),
+                            reason,
                             user.getId(),
                             timestamp
                     );

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -596,7 +596,7 @@ public class ExperimentProcessor implements Processor {
 
             validateConditionallyRequired(validationErrors, rowNum, importRow, program, commit);
             validateObservationUnits(validationErrors, uniqueStudyAndObsUnit, rowNum, importRow);
-            validateObservations(validationErrors, rowNum, importRows.size(), importRow, phenotypeCols, colVarMap, commit, user);
+            validateObservations(validationErrors, rowNum, importRow, phenotypeCols, colVarMap, commit, user);
         }
     }
 
@@ -656,7 +656,6 @@ public class ExperimentProcessor implements Processor {
 
     private void validateObservations(ValidationErrors validationErrors,
                                       int rowNum,
-                                      int numRows,
                                       ExperimentObservation importRow,
                                       List<Column<?>> phenotypeCols,
                                       Map<String, Trait> colVarMap,
@@ -668,8 +667,8 @@ public class ExperimentProcessor implements Processor {
             // error if import observation data already exists and user has not selected to overwrite
             if(commit && importRow.getOverwrite().equals("false") &&
                     this.existingObsByObsHash.containsKey(importHash) &&
-                    StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum - 1)) &&
-                    !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum - 1))) {
+                    StringUtils.isNotBlank(phenoCol.getString(rowNum)) &&
+                    !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(rowNum))) {
                 addRowError(
                         phenoCol.name(),
                         String.format("Value already exists for ObsUnitId: %s, Phenotype: %s", importRow.getObsUnitID(), phenoCol.name()),
@@ -679,8 +678,8 @@ public class ExperimentProcessor implements Processor {
             // preview case where observation has already been committed and the import row ObsVar data differs from what
             // had been saved prior to import
             } else if (this.existingObsByObsHash.containsKey(importHash) &&
-                    StringUtils.isNotBlank(phenoCol.getString(numRows - rowNum -1)) &&
-                    !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1))) {
+                    StringUtils.isNotBlank(phenoCol.getString(rowNum)) &&
+                    !this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(rowNum))) {
 
                 // add a change log entry when updating the value of an observation
                 if (commit) {
@@ -707,14 +706,14 @@ public class ExperimentProcessor implements Processor {
             // preview case where observation has already been committed and import ObsVar data is either empty or the
             // same as has been committed prior to import
             } else if(this.existingObsByObsHash.containsKey(importHash) &&
-                    (StringUtils.isBlank(phenoCol.getString(numRows - rowNum -1)) ||
-                            this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(numRows - rowNum -1)))) {
+                    (StringUtils.isBlank(phenoCol.getString(rowNum)) ||
+                            this.existingObsByObsHash.get(importHash).getValue().equals(phenoCol.getString(rowNum)))) {
                 BrAPIObservation existingObs = this.existingObsByObsHash.get(importHash);
                 existingObs.setObservationVariableName(phenoCol.name());
                 observationByHash.get(importHash).setState(ImportObjectState.EXISTING);
                 observationByHash.get(importHash).setBrAPIObject(existingObs);
             } else {
-                validateObservationValue(colVarMap.get(phenoCol.name()), phenoCol.getString(numRows - rowNum -1), phenoCol.name(), validationErrors, rowNum);
+                validateObservationValue(colVarMap.get(phenoCol.name()), phenoCol.getString(rowNum), phenoCol.name(), validationErrors, rowNum);
 
                 //Timestamp validation
                 if(timeStampColByPheno.containsKey(phenoCol.name())) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -320,7 +320,7 @@ public class ExperimentProcessor implements Processor {
             }
 
             List<ProgramLocation> createdLocations = new ArrayList<>(locationService.create(actingUser, program.getId(), newLocations));
-            // set the DbId to the for each newly created trial
+            // set the DbId to the for each newly created location
             for (ProgramLocation createdLocation : createdLocations) {
                 String createdLocationName = createdLocation.getName();
                 this.locationByName.get(createdLocationName)
@@ -1560,6 +1560,12 @@ public class ExperimentProcessor implements Processor {
     private void processAndCacheStudy(BrAPIStudy existingStudy, Program program, Map<String, PendingImportObject<BrAPIStudy>> studyByName) {
         BrAPIExternalReference xref = Utilities.getExternalReference(existingStudy.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.STUDIES.getName()))
                                                .orElseThrow(() -> new IllegalStateException("External references wasn't found for study (dbid): " + existingStudy.getStudyDbId()));
+        // map season dbid to year
+        String seasonDbId = existingStudy.getSeasons().get(0); // It is assumed that the study has only one season
+        if(StringUtils.isNotBlank(seasonDbId)) {
+            String seasonYear = this.seasonDbIdToYear(seasonDbId, program.getId());
+            existingStudy.setSeasons(Collections.singletonList(seasonYear));
+        }
         studyByName.put(
                 Utilities.removeProgramKeyAndUnknownAdditionalData(existingStudy.getStudyName(), program.getKey()),
                 new PendingImportObject<>(ImportObjectState.EXISTING, (BrAPIStudy) Utilities.formatBrapiObjForDisplay(existingStudy, BrAPIStudy.class, program), UUID.fromString(xref.getReferenceID())));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -940,15 +940,16 @@ public class ExperimentProcessor implements Processor {
                         .get(BrAPIAdditionalInfoFields.OBSERVATION_DATASET_ID).getAsString());
             }
             PendingImportObject<BrAPIStudy> studyPIO = this.studyByNameNoScope.get(importRow.getEnv());
+            UUID studyID = studyPIO.getId();
+            UUID id = UUID.randomUUID();
+            BrAPIObservationUnit newObservationUnit = importRow.constructBrAPIObservationUnit(program, envSeqValue, commit, germplasmName, BRAPI_REFERENCE_SOURCE, trialID, datasetId, studyID, id);
 
-            List<BrAPIObservationUnit> existingOUs = brAPIObservationUnitDAO.getObservationUnitsForStudyDbId(studyPIO.getBrAPIObject().getStudyDbId(), program);
-            List<BrAPIObservationUnit> matchingOU = existingOUs.stream().filter(ou -> importRow.getExpUnitId().equals(Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getObservationUnitName(), program.getKey()))).collect(Collectors.toList());
-            if (!matchingOU.isEmpty()) {
-                pio = new PendingImportObject<>(ImportObjectState.EXISTING, matchingOU.get(0));
+            // check for existing units if this is an existing study
+            if (studyPIO.getBrAPIObject().getStudyDbId() != null) {
+                List<BrAPIObservationUnit> existingOUs = brAPIObservationUnitDAO.getObservationUnitsForStudyDbId(studyPIO.getBrAPIObject().getStudyDbId(), program);
+                List<BrAPIObservationUnit> matchingOU = existingOUs.stream().filter(ou -> importRow.getExpUnitId().equals(Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getObservationUnitName(), program.getKey()))).collect(Collectors.toList());
+                pio = !matchingOU.isEmpty() ? new PendingImportObject<>(ImportObjectState.EXISTING, matchingOU.get(0)) : new PendingImportObject<>(ImportObjectState.NEW, newObservationUnit, id);
             } else {
-                UUID studyID = studyPIO.getId();
-                UUID id = UUID.randomUUID();
-                BrAPIObservationUnit newObservationUnit = importRow.constructBrAPIObservationUnit(program, envSeqValue, commit, germplasmName, BRAPI_REFERENCE_SOURCE, trialID, datasetId, studyID, id);
                 pio = new PendingImportObject<>(ImportObjectState.NEW, newObservationUnit, id);
             }
             this.observationUnitByNameNoScope.put(key, pio);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/Processor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/Processor.java
@@ -55,7 +55,7 @@ public interface Processor {
     Map<String, ImportPreviewStatistics> process(ImportUpload upload, List<BrAPIImport> importRows,
                                                  Map<Integer, PendingImport> mappedBrAPIImport, Table data,
                                                  Program program, User user, boolean commit)
-            throws ValidatorException, MissingRequiredInfoException, ApiException;
+            throws Exception;
 
     /**
      * Given mapped brapi import with updates from prior dependencies, check if have everything needed

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/Processor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/Processor.java
@@ -23,7 +23,6 @@ import org.breedinginsight.brapps.importer.model.imports.PendingImport;
 import org.breedinginsight.brapps.importer.model.response.ImportPreviewStatistics;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
-import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
 import org.breedinginsight.services.exceptions.ValidatorException;
 import tech.tablesaw.api.Table;
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ProcessorManager.java
@@ -18,7 +18,6 @@ package org.breedinginsight.brapps.importer.services.processors;
 
 import io.micronaut.context.annotation.Prototype;
 import lombok.extern.slf4j.Slf4j;
-import org.brapi.client.v2.model.exceptions.ApiException;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
 import org.breedinginsight.brapps.importer.model.imports.PendingImport;
@@ -27,7 +26,6 @@ import org.breedinginsight.brapps.importer.model.response.ImportPreviewStatistic
 import org.breedinginsight.brapps.importer.services.ImportStatusService;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.User;
-import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
 import org.breedinginsight.services.exceptions.ValidatorException;
 import tech.tablesaw.api.Table;
 
@@ -53,7 +51,7 @@ public class ProcessorManager {
         this.statusService = statusService;
     }
 
-    public ImportPreviewResponse process(List<BrAPIImport> importRows, List<Processor> processors, Table data, Program program, ImportUpload upload, User user, boolean commit) throws ValidatorException, ApiException, MissingRequiredInfoException {
+    public ImportPreviewResponse process(List<BrAPIImport> importRows, List<Processor> processors, Table data, Program program, ImportUpload upload, User user, boolean commit) throws Exception {
 
         this.processors = processors;
 

--- a/src/main/java/org/breedinginsight/utilities/Utilities.java
+++ b/src/main/java/org/breedinginsight/utilities/Utilities.java
@@ -139,11 +139,11 @@ public class Utilities {
                 try {
                     field.setAccessible(true);
 
-                    // remove key of form [%s-%s]
+                    // remove either of possible key formats, [%s-%s] and [%s]
                     String valueSansKeyAndInfo = removeProgramKeyAndUnknownAdditionalData((String) field.get(brapiInstance), program.getKey());
-
-                    //remove key of form [%s]
                     String valueSansKey = removeProgramKey(valueSansKeyAndInfo, program.getKey());
+
+                    // set the value without key or additional info
                     field.set(brapiInstance, valueSansKey);
                 } catch (IllegalAccessException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/org/breedinginsight/utilities/Utilities.java
+++ b/src/main/java/org/breedinginsight/utilities/Utilities.java
@@ -20,7 +20,6 @@ package org.breedinginsight.utilities;
 import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.BrAPIExternalReference;
-import org.brapi.v2.model.pheno.BrAPIObservationUnit;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.model.Program;
 import org.flywaydb.core.api.migration.Context;

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -91,6 +91,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ExperimentFileImportTest extends BrAPITest {
+    private static final String OVERWRITE = "overwrite";
 
     private FannyPack securityFp;
     private String mappingId;
@@ -199,7 +200,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         validRow.put(Columns.COLUMN, "1");
         validRow.put(Columns.TREATMENT_FACTORS, "Test treatment factors");
 
-        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(importTestUtils.writeDataToFile(List.of(validRow), null), null, true, client, program, mappingId);
+        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(importTestUtils.writeDataToFile(List.of(validRow), null), Map.of(OVERWRITE, "false"), true, client, program, mappingId);
         HttpResponse<String> response = call.blockingFirst();
         assertEquals(HttpStatus.ACCEPTED, response.getStatus());
         String importId = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").get("importId").getAsString();
@@ -257,7 +258,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         secondEnv.put(Columns.COLUMN, "1");
         secondEnv.put(Columns.TREATMENT_FACTORS, "Test treatment factors");
 
-        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(importTestUtils.writeDataToFile(List.of(firstEnv, secondEnv), null), null, true, client, program, mappingId);
+        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(importTestUtils.writeDataToFile(List.of(firstEnv, secondEnv), null), Map.of(OVERWRITE, "false"), true, client, program, mappingId);
         HttpResponse<String> response = call.blockingFirst();
         assertEquals(HttpStatus.ACCEPTED, response.getStatus());
         String importId = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").get("importId").getAsString();
@@ -598,7 +599,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         newOU.put(Columns.ROW, "1");
         newOU.put(Columns.COLUMN, "2");
 
-        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(importTestUtils.writeDataToFile(List.of(newOU), null), null, commit, client, program, mappingId);
+        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(importTestUtils.writeDataToFile(List.of(newOU), null), Map.of(OVERWRITE, "false"), commit, client, program, mappingId);
         HttpResponse<String> response = call.blockingFirst();
         assertEquals(HttpStatus.ACCEPTED, response.getStatus());
 
@@ -608,7 +609,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
         assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt(), "Returned data: " + result);
 
-        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Experiment Units are missing Observation Unit Id."));
+        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Cannot create a new observation unit for existing environment:"));
     }
 
     @Test
@@ -1327,7 +1328,7 @@ public class ExperimentFileImportTest extends BrAPITest {
     }
 
     private JsonObject uploadAndVerifyFailure(Program program, File file, String expectedColumnError, boolean commit) throws InterruptedException, IOException {
-        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(file, null, true, client, program, mappingId);
+        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(file, Map.of(OVERWRITE, "false"), true, client, program, mappingId);
         HttpResponse<String> response = call.blockingFirst();
         assertEquals(HttpStatus.ACCEPTED, response.getStatus());
 

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -609,7 +609,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
         assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt(), "Returned data: " + result);
 
-        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Cannot create a new observation unit"));
+        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Cannot create new observation unit"));
     }
 
     @Test

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -609,7 +609,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
         assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt(), "Returned data: " + result);
 
-        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Cannot create a new observation unit for existing environment:"));
+        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Cannot create a new observation unit"));
     }
 
     @Test


### PR DESCRIPTION
# Description
**Story:** [BI-1960](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-1960)

An additional check for multiple unique experiment titles in the same import file was put in place when creating the trial PIO during experiment import. An exception is thrown if multiple exp titles detected.



# Dependencies
none

# Testing

1. create an experiment import file containing multiple rows with at least two distinct experiment titles listed: for example, EXP-A and EXP-B.
2. attempt to import the experiments

A red error banner should appear citing "File contains more than one Experiment Title"


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
