### PR TITLE
[BI-1945-hotfix] - updated bind mount paths

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       - ${BRAPI_SERVER_PORT}:8080
     volumes:
       - ./src/main/resources/brapi/properties/application.properties:/home/brapi/properties/application.properties
-      - ./src/main/resources/brapi/sql/:/home/brapi/db/sql/
+      - ./src/main/resources/brapi/sql:/home/brapi/db/sql
     networks:
       backend:
         aliases:


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1945

The bind mount wasn't overwriting the files in the container with the files on the host. I updated the paths to fix this, I guess trailing slashes don't have the desired effect for bind mounts.
