### PR TITLE
[BI-1960-2] Exp import proceeds with multiple exp names & error message improvement

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -59,6 +59,7 @@ import org.breedinginsight.services.OntologyService;
 import org.breedinginsight.services.ProgramLocationService;
 import org.breedinginsight.services.exceptions.DoesNotExistException;
 import org.breedinginsight.services.exceptions.MissingRequiredInfoException;
+import org.breedinginsight.services.exceptions.UnprocessableEntityException;
 import org.breedinginsight.services.exceptions.ValidatorException;
 import org.breedinginsight.utilities.Utilities;
 import org.jooq.DSLContext;
@@ -477,7 +478,12 @@ public class ExperimentProcessor implements Processor {
         for (int rowNum = 0; rowNum < importRows.size(); rowNum++) {
             ExperimentObservation importRow = (ExperimentObservation) importRows.get(rowNum);
 
-            PendingImportObject<BrAPITrial> trialPIO = fetchOrCreateTrialPIO(program, user, commit, importRow, expNextVal);
+            PendingImportObject<BrAPITrial> trialPIO = null;
+            try {
+                trialPIO = fetchOrCreateTrialPIO(program, user, commit, importRow, expNextVal);
+            } catch (UnprocessableEntityException e) {
+                throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());
+            }
 
             String expSeqValue = null;
             if (commit) {


### PR DESCRIPTION
# Description
**Story:** [BI-1960](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-1960)

An additional check for multiple unique experiment titles in the same import file was put in place when creating the trial PIO during experiment import. An exception is thrown if multiple exp titles detected.



# Dependencies
none

# Testing

1. create an experiment import file containing multiple rows with at least two distinct experiment titles listed: for example, EXP-A and EXP-B.
2. attempt to import the experiments

A red error banner should appear citing "File contains more than one Experiment Title"


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1960]: https://breedinginsight.atlassian.net/browse/BI-1960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ