### PR TITLE
[BI-1867] - Ontology: Increase name length to 16 characters

### DIFF
--- a/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
@@ -147,7 +147,7 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
 
     @Override
     public ValidationError getCharLimitObsVarNameMsg() {
-        return new ValidationError("Name", "Name exceeds 12 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ValidationError("Name", "Name exceeds 16 character limit", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
@@ -184,7 +184,7 @@ public class TraitValidatorService {
 
             Trait trait = traits.get(i);
             Method method = trait.getMethod();
-            int shortCharLimit = 12;
+            int shortCharLimit = 16;
             int longCharLimit = 30;
 
             if ((trait.getObservationVariableName() != null) && (trait.getObservationVariableName().length() > shortCharLimit)) {

--- a/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
@@ -298,7 +298,7 @@ public class TraitValidatorUnitTest {
     public void charLimitExceeded() {
 
         Trait trait = new Trait();
-        trait.setObservationVariableName("OverTwelveChar");
+        trait.setObservationVariableName("IsOverSixteenChar");
         trait.setProgramObservationLevel(ProgramObservationLevel.builder().name("Plant").build());
         Scale scale = new Scale();
         scale.setScaleName("Test Scale");


### PR DESCRIPTION
# Description
**Story:**  [ BI-1867 - Ontology: Increase name length to 16 characters ](https://breedinginsight.atlassian.net/browse/BI-1867)

Modified backend logic and error text to increase the max permitted ontology name length from 12 to 16 characters.

# Dependencies
[bi-web: feature/BI-1867](https://github.com/Breeding-Insight/bi-web/pull/354)

# Testing
see bi-web

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have tested that my code works with both the brapi-java-server and BreedBase
- [X] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
