### PR TITLE
[BI-2028] Duplicated accession names getting assigned duplicated GIDs after Exp&Obs upload

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -228,6 +228,7 @@ public class ExperimentObservation implements BrAPIImport {
             String seqVal,
             boolean commit,
             String germplasmName,
+            String gid,
             String referenceSource,
             UUID trialID,
             UUID datasetId,
@@ -250,6 +251,7 @@ public class ExperimentObservation implements BrAPIImport {
             germplasmName = getGermplasmName();
         }
         observationUnit.setGermplasmName(germplasmName);
+        observationUnit.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GID, gid);
 
         BrAPIObservationUnitPosition position = new BrAPIObservationUnitPosition();
         BrAPIObservationUnitLevelRelationship level = new BrAPIObservationUnitLevelRelationship();

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1299,8 +1299,7 @@ public class ExperimentProcessor implements Processor {
                                          .forEach(obsUnit -> obsUnit.getBrAPIObject()
                                                                     .setGermplasmDbId(germplasm.getGermplasmDbId()));
     }
-
-//obsUnit.getBrAPIObject().getAdditionalInfo().getAsJsonObject().get(BrAPIAdditionalInfoFields.GID).getAsString()
+    
     private void updateStudyDependencyValues(Map<Integer, PendingImport> mappedBrAPIImport, String programKey) {
         // update location DbIds in studies for all distinct locations
         mappedBrAPIImport.values()

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1299,7 +1299,7 @@ public class ExperimentProcessor implements Processor {
                                          .forEach(obsUnit -> obsUnit.getBrAPIObject()
                                                                     .setGermplasmDbId(germplasm.getGermplasmDbId()));
     }
-    
+
     private void updateStudyDependencyValues(Map<Integer, PendingImport> mappedBrAPIImport, String programKey) {
         // update location DbIds in studies for all distinct locations
         mappedBrAPIImport.values()

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -956,7 +956,7 @@ public class ExperimentProcessor implements Processor {
             PendingImportObject<BrAPIStudy> studyPIO = this.studyByNameNoScope.get(importRow.getEnv());
             UUID studyID = studyPIO.getId();
             UUID id = UUID.randomUUID();
-            BrAPIObservationUnit newObservationUnit = importRow.constructBrAPIObservationUnit(program, envSeqValue, commit, germplasmName, BRAPI_REFERENCE_SOURCE, trialID, datasetId, studyID, id);
+            BrAPIObservationUnit newObservationUnit = importRow.constructBrAPIObservationUnit(program, envSeqValue, commit, germplasmName, importRow.getGid(), BRAPI_REFERENCE_SOURCE, trialID, datasetId, studyID, id);
 
             // check for existing units if this is an existing study
             if (studyPIO.getBrAPIObject().getStudyDbId() != null) {
@@ -1291,16 +1291,16 @@ public class ExperimentProcessor implements Processor {
     private void updateGermplasmDbId(BrAPIGermplasm germplasm) {
         this.observationUnitByNameNoScope.values()
                                          .stream()
-                                         .filter(obsUnit -> obsUnit.getBrAPIObject()
-                                                                   .getGermplasmName() != null &&
-                                                 obsUnit.getBrAPIObject()
-                                                        .getGermplasmName()
-                                                        .equals(germplasm.getGermplasmName()))
+                                         .filter(obsUnit -> germplasm.getAccessionNumber() != null &&
+                                                 germplasm.getAccessionNumber().equals(obsUnit
+                                                         .getBrAPIObject()
+                                                         .getAdditionalInfo().getAsJsonObject()
+                                                         .get(BrAPIAdditionalInfoFields.GID).getAsString()))
                                          .forEach(obsUnit -> obsUnit.getBrAPIObject()
                                                                     .setGermplasmDbId(germplasm.getGermplasmDbId()));
     }
 
-
+//obsUnit.getBrAPIObject().getAdditionalInfo().getAsJsonObject().get(BrAPIAdditionalInfoFields.GID).getAsString()
     private void updateStudyDependencyValues(Map<Integer, PendingImport> mappedBrAPIImport, String programKey) {
         // update location DbIds in studies for all distinct locations
         mappedBrAPIImport.values()


### PR DESCRIPTION
# Description
**Story:** [BI-2028](https://breedinginsight.atlassian.net/browse/BI-2028)

During experiment import, existing germplasm dbid was being assigned to OU PIO by looking up the germplasm name stored in the OU PIO. When there are multiple germplasm with the same name, this was causing the same germplasm to be assigned to multiple OUs.

- Changed the OU PIO creation to include the germplasm GID as additional info
- mapped the germplasm to the OU PIO using the unique GID instead of the non-unique germplasm name

# Dependencies
none

# Testing
1. Import multiple germplasm with the same name
2. Import an experiment using GIDs from step 1.
3. After import successful, go to Experiment view and select the imported Experiment details
4. Verify that the correct GID is displayed.
See the card for sample import files.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2028]: https://breedinginsight.atlassian.net/browse/BI-2028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ