### PR TITLE
[BI-1965-bugfix] - Fix Localstack And Gigwa Configurations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
         aliases:
           - localstack
     environment:
-      - HOSTNAME_EXTERNAL=localstack
+      - LOCALSTACK_HOST=localstack
 
 networks:
   backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,7 +163,7 @@ services:
           - gigwa_db
   localstack:
     container_name: "localstack"
-    image: localstack/localstack
+    image: localstack/localstack:3.0.2
     restart: always
     ports:
       - "4566:4566"

--- a/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
@@ -247,7 +247,7 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
         gigwa.start();
 
         localStackContainer = new LocalStackContainer(DockerImageName.parse("localstack/localstack")
-                                                                     .withTag("2.2.0"))
+                                                                     .withTag("3.0.2"))
                 .withServices(LocalStackContainer.Service.S3)
                 .withNetwork(super.getNetwork())
                 .withNetworkAliases("localstack")

--- a/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
@@ -251,7 +251,7 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
                 .withServices(LocalStackContainer.Service.S3)
                 .withNetwork(super.getNetwork())
                 .withNetworkAliases("localstack")
-                .withEnv("HOSTNAME_EXTERNAL", "localstack");
+                .withEnv("LOCALSTACK_HOST", "localstack");
         localStackContainer.start();
     }
 


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1965

We have been using localstack/localstack:latest, and the env var we used, [EXTERNAL_HOSTNAME, is deprecated](https://github.com/localstack/localstack/blob/fe0d056cc7f5bb291e309485b4c244400385c6ad/localstack/config.py#L1188).

- Replaced with the supported LOCALSTACK_HOST env var. 


Related PR in bi-docker-stack: https://github.com/Breeding-Insight/bi-docker-stack/pull/37

> The error we were seeing with Gigwa not allowing imports from biapi

# Dependencies
None

# Testing
1. Functional Test:
    - Checkout this branch `git checkout feature/BI-1965-bugfix`.
    - Stop your local docker containers.
    - Start your local docker containers. This will pick up the change.
    - Run bi-api and bi-web.
    - Ensure you can upload genotypic data (first upload [germplasm](https://github.com/Breeding-Insight/bi-api/files/13619712/geno_germ_import_brapi_hackathon_10-2022.xls), then [experiment](https://github.com/Breeding-Insight/bi-api/files/13619714/geno_exp_import_brapi_hackathon_10-2022.xlsx), then [vcf - you have to unzip this](https://github.com/Breeding-Insight/bi-api/files/13619718/MADC_DBlue22-6980_rename_cutadapt_Ebrahiem_filter_geno.vcf.zip)).
 2. Ensure unit tests pass



# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
