### PR TITLE
BI-2027 - Add More Detailed Logging Around Redis Cache

### DIFF
--- a/src/main/java/org/breedinginsight/daos/cache/ProgramCache.java
+++ b/src/main/java/org/breedinginsight/daos/cache/ProgramCache.java
@@ -56,6 +56,7 @@ public class ProgramCache<R> {
 
     public void populate(@NotNull UUID key) {
         String cacheKey = generateCacheKey(key);
+        log.debug("populate(UUID key) method called with key: " + cacheKey);
         RSemaphore semaphore = connection.getSemaphore(cacheKey+":semaphore");
         semaphore.trySetPermits(1);
 
@@ -72,7 +73,7 @@ public class ProgramCache<R> {
                 next refresh will pick up data persisted by this thread
              */
             if(queueSemaphore.tryAcquire()) {
-                log.debug("Attempting to refresh");
+                log.debug("Attempting to refresh for: " + cacheKey);
                 try {
                     // block until we get the green light to refresh the cache
                     semaphore.acquire();
@@ -139,11 +140,11 @@ public class ProgramCache<R> {
         if (!connection.getBucket(cacheKey).isExists()) {
             RSemaphore semaphore = connection.getSemaphore(cacheKey + ":semaphore");
             try {
-                log.debug("cache miss, populating");
+                log.debug("cache miss, populating for key: " + cacheKey);
                 populate(key);
                 //block until any updates are done
                 semaphore.acquire();
-                log.debug("Cache loading done!!!!");
+                log.debug("Cache loading done!!!! - key: " + cacheKey);
             } catch(Exception e){
                 throw new ApiException(e);
             } finally {

--- a/src/main/java/org/breedinginsight/daos/cache/ProgramCache.java
+++ b/src/main/java/org/breedinginsight/daos/cache/ProgramCache.java
@@ -111,6 +111,8 @@ public class ProgramCache<R> {
                         RMap<String, String> map = connection.getMap(cacheKey);
                         map.clear();
                         map.putAll(entryMap);
+                    } else {
+                        log.debug("No values to cache for key: " + cacheKey);
                     }
                     log.debug("cache loading complete for key: " + cacheKey);
                 } catch (Exception e) {

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-version=v0.9.0+644
-versionInfo=https://github.com/Breeding-Insight/bi-api/commit/dadbcf32e5d73345137ab8af5361517cf89f8b95
+version=v0.9.0+646
+versionInfo=https://github.com/Breeding-Insight/bi-api/commit/5025cd0f7f5b3abb54e0778074c48d6b1586c71b


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2027

- Added cache key to all logs.
- Added a debug log for every call to `populate(UUID key)`.


# Dependencies
None

# Testing
None


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
