### PR TITLE
BI-2019 - Pedigree Viewer Not Rendering

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
       backend:
         aliases:
           - dbserver
+    shm_size: 2g
   brapi-server:
     image: breedinginsight/brapi-java-server:develop
     container_name: brapi-server


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2019

Increased the shared memory size for the postgres container.


# Dependencies
Related PR on bi-docker-stack: https://github.com/Breeding-Insight/bi-docker-stack/pull/38

# Testing
**Verify Configuration Change**
- `docker exec -it bidb df -h | grep shm`
    > Output will likely show the docker shared memory default of `64M`.
- `git checkout bug/BI-2019`
- `docker compose down`
- `docker compose up bidb brapi-server gigwa localstack mailhog mongo redis -d`
- `docker exec -it bidb df -h | grep shm`
    > Output should show now `2.0G`.


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
