### PR TITLE
BI-2014 - unable to download experiment

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1062,11 +1062,8 @@ public class ExperimentProcessor implements Processor {
         referencedTraits.forEach(trait -> {
             String id = Utilities.appendProgramKey(trait.getObservationVariableName(), program.getKey());
 
-            // Don't append the key if connected to a brapi service operating with legacy data(no appended program key)
-            if (trait.getFullName() == null) {
-                id = trait.getObservationVariableName();
-            }
-            
+            // TODO - Don't append the key if connected to a brapi service operating with legacy data(no appended program key)
+
             if (!details.getData().contains(id) && ImportObjectState.EXISTING != pio.getState()) {
                 details.getData().add(id);
             }


### PR DESCRIPTION
[BI-2014](https://breedinginsight.atlassian.net/browse/BI-2014) - unable to download experiment

# Description
**Story:** IF an experiment was created; with at least one observation variable (ontology) that was missing a "Full Name",
THEN that experiment can not be downloaded.

NOTE: The issue of the Experiment's Phenotypes and Observations are not rendering in Experiment View has not been addressed in this code change.

# Change  made
Removed some code that was causing the observation variable to be saved without the [_program key_].  This code was originally added as defensive code that protected against legacy data.  That code may no longer be needed.


# Dependencies
bi-web: develop 

# Testing

1. Create an Ontology without a Full Name.
2. Create an Experiment with the Observation Variable defined in step 1.
3. Download the Experiment.
EXPECTED RESULT
The Experiment is downloaded.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2014]: https://breedinginsight.atlassian.net/browse/BI-2014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ