### PR TITLE
[BI-1868] - Ontology: Display full name in table and details pane

### DIFF
--- a/src/main/java/org/breedinginsight/api/model/v1/request/query/TraitsQuery.java
+++ b/src/main/java/org/breedinginsight/api/model/v1/request/query/TraitsQuery.java
@@ -50,6 +50,7 @@ public class TraitsQuery extends QueryParams {
     private String updatedByUserId;
     private String updatedByUserName;
     private String termType;
+    private String fullName;
 
     public SearchRequest constructSearchRequest() {
         List<FilterRequest> filters = new ArrayList<>();
@@ -124,6 +125,9 @@ public class TraitsQuery extends QueryParams {
         }
         if (!StringUtils.isBlank(getTermType())) {
             filters.add(constructFilterRequest("termType", getTermType()));
+        }
+        if (!StringUtils.isBlank(getFullName())) {
+            filters.add(constructFilterRequest("fullName", getFullName()));
         }
         return new SearchRequest(filters);
     }

--- a/src/main/java/org/breedinginsight/utilities/response/mappers/TraitQueryMapper.java
+++ b/src/main/java/org/breedinginsight/utilities/response/mappers/TraitQueryMapper.java
@@ -77,7 +77,8 @@ public class TraitQueryMapper extends AbstractQueryMapper {
                         trait -> trait.getUpdatedByUser() != null ? trait.getUpdatedByUser().getId() : null),
                 Map.entry("updatedByUserName",
                         trait -> trait.getUpdatedByUser() != null ? trait.getUpdatedByUser().getName() : null),
-                Map.entry("termType", Trait::getTermType)
+                Map.entry("termType", Trait::getTermType),
+                Map.entry("fullName", Trait::getFullName)
         );
     }
 


### PR DESCRIPTION
# Description
**Story:** [BI-1868 - Ontology: Display full name in table and details pane] (https://breedinginsight.atlassian.net/browse/BI-1868)

Updated backend sorting and searching to enable sorting and searching for ontology full name.

# Dependencies
bi-web: feature/BI-1868

# Testing
see bi-web

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
