### PR TITLE
[BI-1265-2] Overwrite entity dataset

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1146,8 +1146,6 @@ public class ExperimentProcessor implements Processor {
         //if it is already there, don't add it.
         if(additionalInfo==null || additionalInfo.get(BrAPIAdditionalInfoFields.ENV_YEAR)==null) {
             String year = study.getSeasons().get(0);
-            //String seasonDbId = study.getSeasons().get(0);
-            //String year = seasonDbIdToYear(seasonDbId, program.getId());
             addYearToStudyAdditionalInfo(program, study, year);
         }
     }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -383,10 +383,19 @@ public class ExperimentProcessor implements Processor {
 
         mutatedObservationByDbId.forEach((id, observation) ->  {
             try {
+                if (observation == null) {
+                    throw new Exception("Null observation");
+                }
                 BrAPIObservation updatedObs = brAPIObservationDAO.updateBrAPIObservation(id, observation, program.getId());
-                if (!observation.getValue().equals(updatedObs.getValue()) || !observation.getObservationTimeStamp().isEqual(updatedObs.getObservationTimeStamp())) {
+
+                if (updatedObs == null) {
+                    throw new Exception("Null updated observation");
+                }
+
+                if (!Objects.equals(observation.getValue(), updatedObs.getValue())
+                        || !Objects.equals(observation.getObservationTimeStamp(), updatedObs.getObservationTimeStamp())) {
                     String message;
-                    if(!observation.getValue().equals(updatedObs.getValue())) {
+                    if(!Objects.equals(observation.getValue(), updatedObs.getValue())) {
                         message = String.format("Updated observation, %s, from BrAPI service does not match requested update %s.", updatedObs.getValue(), observation.getValue());
                     } else {
                         message = String.format("Updated observation timestamp, %s, from BrAPI service does not match requested update timestamp %s.", updatedObs.getObservationTimeStamp(), observation.getObservationTimeStamp());
@@ -401,9 +410,7 @@ public class ExperimentProcessor implements Processor {
                 throw new InternalServerException(e.getMessage(), e);
             }
         });
-
         log.debug("experiment import complete");
-
     }
 
     private void prepareDataForValidation(List<BrAPIImport> importRows, List<Column<?>> phenotypeCols, Map<Integer, PendingImport> mappedBrAPIImport) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1091,7 +1091,12 @@ public class ExperimentProcessor implements Processor {
         addObsVarsToDatasetDetails(pio, referencedTraits, program);
     }
 
-    private PendingImportObject<BrAPIStudy> fetchOrCreateStudyPIO(Program program, boolean commit, String expSequenceValue, ExperimentObservation importRow, Supplier<BigInteger> envNextVal) {
+    private PendingImportObject<BrAPIStudy> fetchOrCreateStudyPIO(
+            Program program,
+            boolean commit,
+            String expSequenceValue,
+            ExperimentObservation importRow,
+            Supplier<BigInteger> envNextVal) {
         PendingImportObject<BrAPIStudy> pio;
         if (studyByNameNoScope.containsKey(importRow.getEnv())) {
             pio = studyByNameNoScope.get(importRow.getEnv());
@@ -1133,8 +1138,9 @@ public class ExperimentProcessor implements Processor {
 
         //if it is already there, don't add it.
         if(additionalInfo==null || additionalInfo.get(BrAPIAdditionalInfoFields.ENV_YEAR)==null) {
-            String seasonDbId = study.getSeasons().get(0);
-            String year = seasonDbIdToYear(seasonDbId, program.getId());
+            String year = study.getSeasons().get(0);
+            //String seasonDbId = study.getSeasons().get(0);
+            //String year = seasonDbIdToYear(seasonDbId, program.getId());
             addYearToStudyAdditionalInfo(program, study, year);
         }
     }


### PR DESCRIPTION
# Description
**Story:** [BI-1265](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-1265)

During exp import processing, study season is fetched and assigned to additional info. The season value was being passed in as the season dbid and failing lookup in the database. The correct season value is now used.
Also, changes were made to avoid NPEs during update of brapi variables.



# Dependencies
bi-web release/0.9

# Testing
same as [BI-1830](https://github.com/Breeding-Insight/bi-api/pull/305) 


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1265]: https://breedinginsight.atlassian.net/browse/BI-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-1830]: https://breedinginsight.atlassian.net/browse/BI-1830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ