### PR TITLE
BI-2038 BrAPI endpoint overrides for crops and programs to support MrBean

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/CropController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/CropController.java
@@ -1,0 +1,78 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapi.v2;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.*;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.rules.SecurityRule;
+import lombok.extern.slf4j.Slf4j;
+import org.breedinginsight.api.auth.ProgramSecured;
+import org.breedinginsight.api.auth.ProgramSecuredRoleGroup;
+import org.breedinginsight.api.model.v1.response.DataResponse;
+import org.breedinginsight.brapi.v1.controller.BrapiVersion;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.services.ProgramService;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.breedinginsight.utilities.response.ResponseUtils.getBrapiSingleResponse;
+
+@Slf4j
+@Controller("/${micronaut.bi.api.version}")
+@Secured(SecurityRule.IS_AUTHENTICATED)
+public class CropController {
+
+    private final ProgramService programService;
+
+    @Inject
+    public CropController(ProgramService programService) {
+        this.programService = programService;
+    }
+
+    /**
+     * Retrieves the common crop names associated with a program. No query parameters as paging will always be the same.
+     *
+     * @param programId The ID of the program.
+     * @return An HttpResponse that contains the list of common crop names wrapped in a Response object.
+     */
+    @Get("/programs/{programId}" + BrapiVersion.BRAPI_V2 + "/commoncropnames")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
+    public HttpResponse<org.breedinginsight.api.model.v1.response.Response<DataResponse<List<String>>>> getCommonCropNames(
+            @PathVariable("programId") UUID programId) {
+
+        Optional<Program> optProgram = programService.getById(programId);
+        if (optProgram.isEmpty()) {
+            return HttpResponse.status(HttpStatus.NOT_FOUND, "Program not found");
+        }
+
+        Program program = optProgram.get();
+        List<String> crops = List.of(program.getSpecies().getCommonName());
+
+        // Will only ever return one crop name because only going to be one crop associated with program so
+        // set pagination info accordingly
+        return getBrapiSingleResponse(crops);
+    }
+
+}

--- a/src/main/java/org/breedinginsight/brapi/v2/ProgramController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/ProgramController.java
@@ -1,0 +1,80 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapi.v2;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.*;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.rules.SecurityRule;
+import lombok.extern.slf4j.Slf4j;
+import org.brapi.v2.model.core.BrAPIProgram;
+import org.breedinginsight.api.auth.ProgramSecured;
+import org.breedinginsight.api.auth.ProgramSecuredRoleGroup;
+import org.breedinginsight.api.model.v1.response.DataResponse;
+import org.breedinginsight.brapi.v1.controller.BrapiVersion;
+import org.breedinginsight.model.Program;
+import org.breedinginsight.services.ProgramService;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.breedinginsight.utilities.response.ResponseUtils.getBrapiSingleResponse;
+
+@Slf4j
+@Controller("/${micronaut.bi.api.version}")
+@Secured(SecurityRule.IS_AUTHENTICATED)
+public class ProgramController {
+
+    private final ProgramService programService;
+
+    @Inject
+    public ProgramController(ProgramService programService) {
+        this.programService = programService;
+    }
+
+    /**
+     * Retrieves a list of programs by programId. Query parameters not implemented, will only ever return one program.
+     *
+     * @param programId The ID of the program.
+     * @return HttpResponse containing a Response object with a DataResponse object that wraps a list of programs.
+     * Returns HttpResponse.NOT_FOUND if the program is not found.
+     */
+    @Get("/programs/{programId}" + BrapiVersion.BRAPI_V2 + "/programs")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.ALL})
+    public HttpResponse<org.breedinginsight.api.model.v1.response.Response<DataResponse<List<String>>>> getPrograms(
+            @PathVariable("programId") UUID programId) {
+
+        Optional<Program> optProgram = programService.getById(programId);
+        if (optProgram.isEmpty()) {
+            return HttpResponse.status(HttpStatus.NOT_FOUND, "Program not found");
+        }
+
+        Program program = optProgram.get();
+        BrAPIProgram brapiProgram = program.getBrapiProgram();
+        // Use name as in DeltaBreed remove program key
+        brapiProgram.setProgramName(program.getName());
+        List<BrAPIProgram> programs = List.of(brapiProgram);
+        return getBrapiSingleResponse(programs);
+    }
+
+}

--- a/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
+++ b/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
@@ -71,6 +71,19 @@ public class ResponseUtils {
         return processBrapiResponse(data, null, queryParams, mapper, new Metadata());
     }
 
+    public static <T> HttpResponse<Response<DataResponse<T>>> getBrapiSingleResponse(
+            List data) {
+
+        Pagination pagination = new Pagination();
+        pagination.setCurrentPage(0);
+        pagination.setPageSize(1);
+        pagination.setTotalPages(1);
+        pagination.setTotalCount(1);
+        Metadata metadata = constructMetadata(new Metadata(), pagination);
+
+        return HttpResponse.ok(new Response(metadata, new DataResponse(data)));
+    }
+
     // All
     public static HttpResponse<Response<ProgramUpload>> getUploadQueryResponse(
             ProgramUpload upload, AbstractQueryMapper mapper, SearchRequest searchRequest, QueryParams queryParams) {


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2038?atlOrigin=eyJpIjoiODdlMTQ1NmE4MjVhNDUxZWIxYzdkNGRhZjEyYjFjNDIiLCJwIjoiaiJ9

- Added brapi v2 endpoint overrides for /commoncropnames and /programs

# Dependencies
- None

# Testing
- Verify that /commoncropnames only returns the name of the crop for the programId in the path
- Verify that /programs only returns the program for the programId in the path and that the program key has been stripped from the name


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
