### PR TITLE
[BI-1993] - Accept NA observations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <apache-poi-ooxml.version>4.1.2</apache-poi-ooxml.version>
         <javaxmail.version>1.6.2</javaxmail.version>
         <st4.version>4.3.1</st4.version>
-        <tablesaw.version>0.42.0</tablesaw.version>
+        <tablesaw.version>1.0.0-SNAPSHOT</tablesaw.version>
         <alphanumeric-comparator.version>1.4.1</alphanumeric-comparator.version>
         <cloning.version>1.10.3</cloning.version>
     </properties>
@@ -159,6 +159,13 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
+        </repository>
+        <repository>
+            <id>github-tablesaw</id>
+            <name>Tablesaw github repository</name>
+            <url>https://maven.pkg.github.com/Breeding-Insight/tablesaw</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>true</enabled></snapshots>
         </repository>
     </repositories>
 

--- a/settings.xml
+++ b/settings.xml
@@ -56,6 +56,13 @@
                     <releases><enabled>true</enabled></releases>
                     <snapshots><enabled>true</enabled></snapshots>
                 </repository>
+                <repository>
+                    <id>github-tablesaw</id>
+                    <name>Tablesaw github repository</name>
+                    <url>https://maven.pkg.github.com/Breeding-Insight/tablesaw</url>
+                    <releases><enabled>true</enabled></releases>
+                    <snapshots><enabled>true</enabled></snapshots>
+                </repository>
             </repositories>
         </profile>
     </profiles>
@@ -68,6 +75,11 @@
         </server>
         <server>
             <id>github-fannypack</id>
+            <username>${GITHUB_ACTOR}</username>
+            <password>${GITHUB_TOKEN}</password>
+        </server>
+        <server>
+            <id>github-tablesaw</id>
             <username>${GITHUB_ACTOR}</username>
             <password>${GITHUB_TOKEN}</password>
         </server>

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -390,8 +390,8 @@ public class BrAPITrialService {
             Trait var,
             Program program) {
         String varName = Utilities.removeProgramKey(obs.getObservationVariableName(), program.getKey());
-        if (var.getScale().getDataType().equals(DataType.NUMERICAL) ||
-                var.getScale().getDataType().equals(DataType.DURATION)) {
+        if (!(obs.getValue().equalsIgnoreCase("NA")) && (var.getScale().getDataType().equals(DataType.NUMERICAL) ||
+                var.getScale().getDataType().equals(DataType.DURATION))) {
             row.put(varName, Double.parseDouble(obs.getValue()));
         } else {
             row.put(varName, obs.getValue());

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1773,10 +1773,19 @@ public class ExperimentProcessor implements Processor {
 
     }
 
+    private boolean isNAObservation(String value){
+        return value.equalsIgnoreCase("NA");
+    }
+
     private void validateObservationValue(Trait variable, String value,
                                           String columnHeader, ValidationErrors validationErrors, int row) {
         if (StringUtils.isBlank(value)) {
             log.debug(String.format("skipping validation of observation because there is no value.\n\tvariable: %s\n\trow: %d", variable.getObservationVariableName(), row));
+            return;
+        }
+
+        if (isNAObservation(value)) {
+            log.debug(String.format("skipping validation of observation because it is NA.\n\tvariable: %s\n\trow: %d", variable.getObservationVariableName(), row));
             return;
         }
 

--- a/src/main/java/org/breedinginsight/services/writers/ExcelWriter.java
+++ b/src/main/java/org/breedinginsight/services/writers/ExcelWriter.java
@@ -54,7 +54,8 @@ public class ExcelWriter {
                 } else {
                     //Data values
                     if (data.get(i-1).get(column.getValue()) != null) {
-                        if (column.getDataType() == Column.ColumnDataType.STRING) {
+                        //If String or NA value, accept as is
+                        if (column.getDataType() == Column.ColumnDataType.STRING || data.get(i-1).get(column.getValue()).toString().equalsIgnoreCase("NA")) {
                             row.createCell(cellCount).setCellValue((String) data.get(i - 1).get(column.getValue()));
                         } else if (column.getDataType() == Column.ColumnDataType.INTEGER) {
                             row.createCell(cellCount).setCellValue((Integer) data.get(i - 1).get(column.getValue()));

--- a/src/main/java/org/breedinginsight/utilities/FileUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/FileUtil.java
@@ -192,17 +192,12 @@ public class FileUtil {
     }
 
     public static Table parseTableFromJson(String jsonString) throws ParsingException {
-        try {
             return Table.read()
                     .usingOptions(
                             JsonReadOptions
                                     .builderFromString(jsonString)
                                     .columnTypesToDetect(List.of(ColumnType.STRING))
                     );
-        } catch (IOException e) {
-            throw new ParsingException(ParsingExceptionType.ERROR_READING_FILE);
-        }
-
     }
 
     public static Table removeNullRows(Table table) {

--- a/src/test/java/org/breedinginsight/api/v1/controller/SampleSubmissionControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/SampleSubmissionControllerIntegrationTest.java
@@ -17,7 +17,6 @@
 
 package org.breedinginsight.api.v1.controller;
 
-import com.eclipsesource.json.Json;
 import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 import io.kowalski.fannypack.FannyPack;
@@ -41,10 +40,8 @@ import org.breedinginsight.api.model.v1.request.SpeciesRequest;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapps.importer.ImportTestUtils;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
-import org.breedinginsight.brapps.importer.model.imports.sample.SampleSubmissionImport;
 import org.breedinginsight.brapps.importer.model.imports.sample.SampleSubmissionImport.Columns;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
-import org.breedinginsight.dao.db.tables.pojos.ProgramBreedingMethodEntity;
 import org.breedinginsight.dao.db.tables.pojos.SpeciesEntity;
 import org.breedinginsight.daos.SpeciesDAO;
 import org.breedinginsight.daos.UserDAO;
@@ -58,12 +55,10 @@ import org.breedinginsight.utilities.Utilities;
 import org.jetbrains.annotations.NotNull;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.*;
-import org.testcontainers.containers.localstack.LocalStackContainer;
 import tech.tablesaw.api.Table;
 
 import javax.inject.Inject;
 import java.io.*;
-import java.time.OffsetDateTime;
 import java.util.*;
 
 import static io.micronaut.http.HttpRequest.*;
@@ -76,14 +71,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SampleSubmissionControllerIntegrationTest extends BrAPITest {
 
     private Program program;
-
     private ImportTestUtils importTestUtils;
-
-    private String experimentId;
-    private List<String> envIds = new ArrayList<>();
-    private final List<Map<String, Object>> rows = new ArrayList<>();
-    private final List<Column> columns = ExperimentFileColumns.getOrderedColumns();
-    private List<Trait> traits;
 
     @Property(name = "brapi.server.reference-source")
     private String BRAPI_REFERENCE_SOURCE;


### PR DESCRIPTION
# Description
**Story:** [BI-1993 - Accept NA Observations](https://breedinginsight.atlassian.net/browse/BI-1993)

Enables import of NA observations. Previously "NA" observations were set to blank on import due to default tablesaw behavior and "na" observations would be marked as invalid by validations for certain observation types.

Modify experiment import processing to skip observation ontology validations in the case where the entry is NA (case insensitive).

Modify pom/etc to utilize BI branch of tablesaw.

# Dependencies
This utilizes a [BI fork of tablesaw](https://github.com/Breeding-Insight/tablesaw) created as a consequence of this card due to the need to remove NA from the inbuilt missingValueString list that automatically converts cells with values on the list to empty cells.

# Testing
Create an experiment and multiple types of ontology terms
Import observations for different ontology term types with the following observation values:
- Valid value (should be displayed correctly on import and be imported properly)
- Invalid value (should get an error)
- NA (should be NA on import and be imported properly)
- na (should be na on import and be imported properly)
- n/a (should still be set to blank due to existing tablesaw functionality)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF:[ _\<please include a link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/7978533022)
