### PR TITLE
[BI-2046] Overwrite observations happening without reference to ObsUnitID

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
@@ -91,13 +91,4 @@ public class FileMappingUtil {
 
         return unsortedItems;
     }
-
-    public boolean isValidUUID(String id) {
-        try {
-            UUID.fromString(id);
-            return true;
-        } catch (IllegalArgumentException e) {
-            return false;
-        }
-    }
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileMappingUtil.java
@@ -27,10 +27,7 @@ import tech.tablesaw.api.Table;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Singleton
 public class FileMappingUtil {
@@ -93,5 +90,14 @@ public class FileMappingUtil {
         });
 
         return unsortedItems;
+    }
+
+    public boolean isValidUUID(String id) {
+        try {
+            UUID.fromString(id);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -2213,8 +2213,7 @@ public class ExperimentProcessor implements Processor {
     private void processAndCacheTrial(
         BrAPITrial existingTrial, 
         Program program,
-        Map<String, PendingImportObject<BrAPITrial>> trialByNameNoScope
-        ) {
+        Map<String, PendingImportObject<BrAPITrial>> trialByNameNoScope) {
 
         //get TrialId from existingTrial
         BrAPIExternalReference experimentIDRef = Utilities.getExternalReference(existingTrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()))
@@ -2227,10 +2226,12 @@ public class ExperimentProcessor implements Processor {
     }
 
     /**
-     * Sets the reference Observation Unit IDs based on the import rows.
-     * Checks for references to existing observation units and populates the
-     * referenceOUIds list.
-     * Sets flags hasAllReferenceUnitIds and hasNoReferenceUnitIds accordingly.
+     * This function collates unique ObsUnitID values from a list of BrAPIImport objects.
+     * It iterates through the list and adds non-blank ObsUnitID values to a Set. It also checks for any repeated ObsUnitIDs.
+     *
+     * @param importRows a List of BrAPIImport objects containing ExperimentObservation data
+     * @return a Set of unique ObsUnitID strings
+     * @throws IllegalStateException if a repeated ObsUnitID is encountered
      */
     private Set<String> collateReferenceOUIds(List<BrAPIImport> importRows) {
         Set<String> referenceOUIds = new HashSet<>();

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -2034,7 +2034,7 @@ public class ExperimentProcessor implements Processor {
 
         return Optional.ofNullable(this.trialByNameNoScope.get(expTitle.get()));
     }
-    
+
     private void processAndCacheObsVarDataset(BrAPIListDetails existingList, Map<String, PendingImportObject<BrAPIListDetails>> obsVarDatasetByName) {
         BrAPIExternalReference xref = Utilities.getExternalReference(existingList.getExternalReferences(),
                         String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.DATASET.getName()))
@@ -2042,10 +2042,21 @@ public class ExperimentProcessor implements Processor {
         obsVarDatasetByName.put(existingList.getListName(),
                 new PendingImportObject<BrAPIListDetails>(ImportObjectState.EXISTING, existingList, UUID.fromString(xref.getReferenceId())));
     }
+
+    /**
+     * Initializes a mapping of BrAPI Germplasm objects by Germplasm ID for existing BrAPI Observation Units.
+     * This method retrieves existing Germplasms associated with the provided Observation Units and creates a mapping
+     * using their Accession Number as the key and a PendingImportObject containing the Germplasm object and a reference ID.
+     * If no existing Germplasms are found, an empty mapping is returned.
+     *
+     * @param unitByName A mapping of Observation Units by name.
+     * @param program The BrAPI Program object to which the Germplasms belong.
+     * @return A mapping of BrAPI Germplasm objects by Germplasm ID for existing Observation Units.
+     * @throws InternalServerException If an error occurs while fetching Germplasms from the database.
+     */
     private Map<String, PendingImportObject<BrAPIGermplasm>> initializeGermplasmByGIDForExistingObservationUnits(
             Map<String, PendingImportObject<BrAPIObservationUnit>> unitByName,
-            Program program
-    ) {
+            Program program) {
         Map<String, PendingImportObject<BrAPIGermplasm>> existingGermplasmByGID = new HashMap<>();
 
         List<BrAPIGermplasm> existingGermplasms = new ArrayList<>();

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1346,6 +1346,8 @@ public class ExperimentProcessor implements Processor {
                 PendingImportObject<BrAPIStudy> envPio;
                 trialPio = trialByNameNoScope.get(importRow.getExpTitle());
                 envPio = studyByNameNoScope.get(importRow.getEnv());
+
+                // creating new units for existing experiments and environments is not possible
                 if  (trialPio!=null &&  ImportObjectState.EXISTING==trialPio.getState() &&
                         (StringUtils.isBlank( importRow.getObsUnitID() )) && (envPio!=null && ImportObjectState.EXISTING==envPio.getState() ) ){
                     throw new UnprocessableEntityException(PREEXISTING_EXPERIMENT_TITLE);
@@ -2226,7 +2228,9 @@ public class ExperimentProcessor implements Processor {
 
     /**
      * This function collates unique ObsUnitID values from a list of BrAPIImport objects.
-     * It iterates through the list and adds non-blank ObsUnitID values to a Set. It also checks for any repeated ObsUnitIDs.
+     * It iterates through the list and adds non-blank ObsUnitID values to a Set.
+     * It also checks for any repeated ObsUnitIDs. The instance variables hasAllReferenceUnitIds and
+     * hasNoReferenceUnitIds are updated.
      *
      * @param importRows a List of BrAPIImport objects containing ExperimentObservation data
      * @return a Set of unique ObsUnitID strings

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -139,8 +139,8 @@ public class ExperimentProcessor implements Processor {
     private final Map<String, PendingImportObject<BrAPIObservation>> observationByHash = new HashMap<>();
     private Map<String, BrAPIObservation> existingObsByObsHash = new HashMap<>();
     // existingGermplasmByGID is populated by getExistingBrapiData(), but not updated by the initNewBrapiData() method
-    private Map<String, PendingImportObject<BrAPIGermplasm>> existingGermplasmByGID = null;
-    private Map<String, PendingImportObject<BrAPIGermplasm>> pendingGermplasmByOUId = null;
+    private Map<String, PendingImportObject<BrAPIGermplasm>> existingGermplasmByGID = new HashMap<>();
+    private Map<String, PendingImportObject<BrAPIGermplasm>> pendingGermplasmByOUId = new HashMap<>();
 
     // Associates timestamp columns to associated phenotype column name for ease of storage
     private final Map<String, Column<?>> timeStampColByPheno = new HashMap<>();
@@ -216,7 +216,6 @@ public class ExperimentProcessor implements Processor {
                     mapGermplasmByOUId(unitId, unit, existingGermplasmByGID, pendingGermplasmByOUId);
                 }
 
-                //pendingStudyByOUId = fetchStudyByOUId(referenceOUIds, pendingObsUnitByOUId, program);
             } catch (ApiException e) {
                 log.error("Error fetching observation units: " + Utilities.generateApiExceptionLogMessage(e), e);
                 throw new InternalServerException(e.toString(), e);
@@ -1820,8 +1819,9 @@ public class ExperimentProcessor implements Processor {
             Map<String, PendingImportObject<BrAPIGermplasm>> germplasmByName,
             Map<String, PendingImportObject<BrAPIGermplasm>> germplasmByOUId
     ) {
-        //String dbId = unit.
-        //germplasmByName.values().stream().filter(pio -> pio.getBrAPIObject().getGermplasmDbId())
+        String gid = unit.getAdditionalInfo().getAsJsonObject().get(BrAPIAdditionalInfoFields.GID).getAsString();
+        germplasmByOUId.put(unitId, germplasmByName.get(gid));
+
         return germplasmByOUId;
     }
     private Map<String, PendingImportObject<BrAPIListDetails>> mapPendingObsDatasetByOUId(

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -882,8 +882,7 @@ public class ExperimentProcessor implements Processor {
             ValidationErrors validationErrors,
             Set<String> uniqueStudyAndObsUnit,
             int rowNum,
-            ExperimentObservation importRow
-    ) {
+            ExperimentObservation importRow) {
         String envIdPlusStudyId = createObservationUnitKey(importRow);
         if (uniqueStudyAndObsUnit.contains(envIdPlusStudyId)) {
             String errorMessage = String.format("The ID (%s) is not unique within the environment(%s)", importRow.getExpUnitId(), importRow.getEnv());
@@ -1568,6 +1567,24 @@ public class ExperimentProcessor implements Processor {
         }
     }
 
+    /**
+     * Maps pending locations by Observation Unit (OU) Id based on given parameters.
+     *
+     * This method takes in a unitId, BrAPIObservationUnit unit, Maps of studyByOUId, locationByName,
+     * and locationByOUId. It then associates the location of the observation unit with the respective OU Id.
+     * If the locationName is not null for the unit, it is directly added to locationByOUId.
+     * If the locationName is null, it checks the studyByOUId map for a location related to the unit.
+     * If a location related to the unit is found, it maps that location with the respective OU Id.
+     * If no location is found, it throws an IllegalStateException.
+     *
+     * @param unitId the Observation Unit Id
+     * @param unit the BrAPIObservationUnit object
+     * @param studyByOUId a Map of Study by Observation Unit Id
+     * @param locationByName a Map of Location by Name
+     * @param locationByOUId a Map of Location by Observation Unit Id
+     * @return the updated locationByOUId map after mapping the pending locations
+     * @throws IllegalStateException if the Observation Unit is missing a location
+     */
     private Map<String, PendingImportObject<ProgramLocation>> mapPendingLocationByOUId(
             String unitId,
             BrAPIObservationUnit unit,

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -128,8 +128,6 @@ public class ExperimentProcessor implements Processor {
     private Map<String, PendingImportObject<BrAPIStudy>> pendingStudyByOUId = new HashMap<>();
     private Map<String, PendingImportObject<BrAPIListDetails>> obsVarDatasetByName = null;
     private Map<String, PendingImportObject<BrAPIListDetails>> pendingObsDatasetByOUId = new HashMap<>();
-    //  It is assumed that there are no preexisting Observation Units for the given environment (so this will not be
-    // initialized by getExistingBrapiData() )
     private Map<String, PendingImportObject<BrAPIObservationUnit>> observationUnitByNameNoScope = null;
     private Map<String, PendingImportObject<BrAPIObservationUnit>> pendingObsUnitByOUId = new HashMap<>();
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -225,17 +225,17 @@ public class ExperimentProcessor implements Processor {
             }
         } else if (hasNoReferenceUnitIds) {
             observationUnitByNameNoScope = initializeObservationUnits(program, experimentImportRows);
-
+            trialByNameNoScope = initializeTrialByNameNoScope(program, experimentImportRows);
+            studyByNameNoScope = initializeStudyByNameNoScope(program, experimentImportRows);
+            locationByName = initializeUniqueLocationNames(program, experimentImportRows);
+            obsVarDatasetByName = initializeObsVarDatasetByName(program, experimentImportRows);
+            existingGermplasmByGID = initializeExistingGermplasmByGID(program, experimentImportRows);
+            
         } else {
 
             // can't proceed if you have a mix of ObsUnitId for some but not all rows
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, MISSING_OBS_UNIT_ID_ERROR);
         }
-        trialByNameNoScope = initializeTrialByNameNoScope(program, experimentImportRows);
-        studyByNameNoScope = initializeStudyByNameNoScope(program, experimentImportRows);
-        locationByName = initializeUniqueLocationNames(program, experimentImportRows);
-        obsVarDatasetByName = initializeObsVarDatasetByName(program, experimentImportRows);
-        existingGermplasmByGID = initializeExistingGermplasmByGID(program, experimentImportRows);
     }
 
     /**

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -35,7 +35,6 @@ import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.*;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.core.response.BrAPIListDetails;
-import org.brapi.v2.model.geno.BrAPIReference;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
@@ -47,8 +46,6 @@ import org.breedinginsight.api.model.v1.response.ValidationErrors;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapi.v2.dao.*;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
-import org.breedinginsight.brapps.importer.model.base.ObservationUnit;
-import org.breedinginsight.brapps.importer.model.base.Study;
 import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
 import org.breedinginsight.brapps.importer.model.imports.ChangeLogEntry;
 import org.breedinginsight.brapps.importer.model.imports.PendingImport;
@@ -471,19 +468,20 @@ public class ExperimentProcessor implements Processor {
             List<PendingImportObject<BrAPIObservation>> observations = mappedImportRow.getObservations();
             String observationHash;
             if (hasAllReferenceUnitIds) {
-                mappedImportRow.setTrial(pendingTrialByOUId.get(importRow.getObsUnitID()));
-                mappedImportRow.setLocation(pendingLocationByOUId.get(importRow.getObsUnitID()));
-                mappedImportRow.setStudy(pendingStudyByOUId.get(importRow.getObsUnitID()));
-                mappedImportRow.setObservationUnit(pendingObsUnitByOUId.get(importRow.getObsUnitID()));
-                mappedImportRow.setGermplasm(pendingGermplasmByOUId.get(importRow.getObsUnitID()));
+                String refOUId = importRow.getObsUnitID();
+                mappedImportRow.setTrial(pendingTrialByOUId.get(refOUId));
+                mappedImportRow.setLocation(pendingLocationByOUId.get(refOUId));
+                mappedImportRow.setStudy(pendingStudyByOUId.get(refOUId));
+                mappedImportRow.setObservationUnit(pendingObsUnitByOUId.get(refOUId));
+                mappedImportRow.setGermplasm(pendingGermplasmByOUId.get(refOUId));
 
                 // loop over phenotype column observation data for current row
                 for (Column<?> column : phenotypeCols) {
                     observationHash = getObservationHash(
-                            pendingStudyByOUId.get(importRow.getObsUnitID()).getBrAPIObject().getStudyName() +
-                            pendingObsUnitByOUId.get(importRow.getObsUnitID()).getBrAPIObject().getObservationUnitName(),
+                            pendingStudyByOUId.get(refOUId).getBrAPIObject().getStudyName() +
+                            pendingObsUnitByOUId.get(refOUId).getBrAPIObject().getObservationUnitName(),
                             getVariableNameFromColumn(column),
-                            pendingStudyByOUId.get(importRow.getObsUnitID()).getBrAPIObject().getStudyName()
+                            pendingStudyByOUId.get(refOUId).getBrAPIObject().getStudyName()
                     );
 
                     // if value was blank won't be entry in map for this observation
@@ -666,6 +664,17 @@ public class ExperimentProcessor implements Processor {
         return studyName + obsUnitName;
     }
 
+    /**
+     * This method is responsible for generating a hash based on the import observation unit information.
+     * It takes the observation unit name, variable name, and study name as input parameters.
+     * The observation unit key is created using the study name and observation unit name.
+     * The hash is generated based on the observation unit key, variable name, and study name.
+     *
+     * @param obsUnitName The name of the observation unit being imported.
+     * @param variableName The name of the variable associated with the observation unit.
+     * @param studyName The name of the study associated with the observation unit.
+     * @return A string representing the hash of the import observation unit information.
+     */
     private String getImportObservationHash(String obsUnitName, String variableName, String studyName) {
         return getObservationHash(createObservationUnitKey(studyName, obsUnitName), variableName, studyName);
     }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1800,17 +1800,16 @@ public class ExperimentProcessor implements Processor {
     }
 
     /**
-     * Fetches a list of BrAPI studies by studyDbIds belonging to a specific
-     * program.
-     * If not all studyDbIds are found in the database, it throws an
-     * IllegalStateException.
+     * Fetches a list of BrAPI studies by their study database IDs for a given program.
      *
-     * @param studyDbIds A set of studyDbIds to fetch studies for
-     * @param program    The program for which the studies are associated
-     * @return A list of BrAPIStudy objects representing the fetched studies
-     * @throws ApiException          if an error occurs during the database fetch
-     *                               operation
-     * @throws IllegalStateException if not all studyDbIds are found in the database
+     * This method queries the BrAPIStudyDAO to retrieve studies based on the provided study database IDs and the program.
+     * It ensures that all requested study database IDs are found in the result set, throwing an IllegalStateException if any are missing.
+     *
+     * @param studyDbIds a Set of Strings representing the study database IDs to fetch
+     * @param program the Program object representing the program context in which to fetch studies
+     * @return a List of BrAPIStudy objects matching the provided study database IDs
+     * @throws ApiException if there is an issue fetching the studies
+     * @throws IllegalStateException if any requested study database IDs are not found in the result set
      */
     private List<BrAPIStudy> fetchStudiesByDbId(Set<String> studyDbIds, Program program) throws ApiException {
         List<BrAPIStudy> studies = brAPIStudyDAO.getStudiesByStudyDbId(studyDbIds, program);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -480,6 +480,7 @@ public class ExperimentProcessor implements Processor {
                 // loop over phenotype column observation data for current row
                 for (Column<?> column : phenotypeCols) {
                     observationHash = getObservationHash(
+                            pendingStudyByOUId.get(importRow.getObsUnitID()).getBrAPIObject().getStudyName() +
                             pendingObsUnitByOUId.get(importRow.getObsUnitID()).getBrAPIObject().getObservationUnitName(),
                             getVariableNameFromColumn(column),
                             pendingStudyByOUId.get(importRow.getObsUnitID()).getBrAPIObject().getStudyName()
@@ -1130,7 +1131,7 @@ public class ExperimentProcessor implements Processor {
         if (hasAllReferenceUnitIds) {
             String unitName = obsUnitPIO.getBrAPIObject().getObservationUnitName();
             String studyName = studyPIO.getBrAPIObject().getStudyName();
-            key = getObservationHash(unitName, variableName, studyName);
+            key = getObservationHash(studyName + unitName, variableName, studyName);
         } else {
             key = getImportObservationHash(importRow, variableName);
         }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -209,6 +209,7 @@ public class ExperimentProcessor implements Processor {
                     mapPendingTrialByOUId(unitId, unit, trialByNameNoScope, studyByNameNoScope, pendingTrialByOUId, program);
                     mapPendingStudyByOUId(unitId, unit, studyByNameNoScope, pendingStudyByOUId, program);
                     mapPendingLocationByOUId(unitId, unit, pendingStudyByOUId, locationByName, pendingLocationByOUId);
+                    mapPendingObsDatasetByOUId(unitId, pendingTrialByOUId, obsVarDatasetByName, pendingObsDatasetByOUId, program);
                 }
 
                 pendingStudyByOUId = fetchStudyByOUId(referenceOUIds, pendingObsUnitByOUId, program);
@@ -1809,6 +1810,20 @@ public class ExperimentProcessor implements Processor {
         return locationByName;
     }
 
+    private Map<String, PendingImportObject<BrAPIListDetails>> mapPendingObsDatasetByOUId(
+            String unitId,
+            Map<String, PendingImportObject<BrAPITrial>> trialByOUId,
+            Map<String, PendingImportObject<BrAPIListDetails>> obsVarDatasetByName,
+            Map<String, PendingImportObject<BrAPIListDetails>> obsVarDatasetByOUId,
+            Program program
+    ) {
+        if (!trialByOUId.isEmpty() && !obsVarDatasetByName.isEmpty() &&
+                trialByOUId.values().iterator().next().getBrAPIObject().getAdditionalInfo().has(BrAPIAdditionalInfoFields.OBSERVATION_DATASET_ID)) {
+            obsVarDatasetByOUId.put(unitId, obsVarDatasetByName.values().iterator().next());
+        }
+
+        return obsVarDatasetByOUId;
+    }
     private Map<String, PendingImportObject<BrAPIListDetails>> initializeObsVarDatasetForExistingObservationUnits(
             Map<String, PendingImportObject<BrAPITrial>> pendingTrialByOUId,
             Program program

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -2034,14 +2034,7 @@ public class ExperimentProcessor implements Processor {
 
         return Optional.ofNullable(this.trialByNameNoScope.get(expTitle.get()));
     }
-
-    private void processAndCacheObsVarDatasetByOUId(BrAPIListDetails existingList, String unitId, Map<String, PendingImportObject<BrAPIListDetails>> obsVarDatasetByOUId) {
-        BrAPIExternalReference xref = Utilities.getExternalReference(existingList.getExternalReferences(),
-                        String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.DATASET.getName()))
-                .orElseThrow(() -> new IllegalStateException("External references wasn't found for list (dbid): " + existingList.getListDbId()));
-        obsVarDatasetByOUId.put(unitId,
-                new PendingImportObject<BrAPIListDetails>(ImportObjectState.EXISTING, existingList, UUID.fromString(xref.getReferenceId())));
-    }
+    
     private void processAndCacheObsVarDataset(BrAPIListDetails existingList, Map<String, PendingImportObject<BrAPIListDetails>> obsVarDatasetByName) {
         BrAPIExternalReference xref = Utilities.getExternalReference(existingList.getExternalReferences(),
                         String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.DATASET.getName()))

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1144,7 +1144,7 @@ public class ExperimentProcessor implements Processor {
         }
 
         if (existingObsByObsHash.containsKey(key)) {
-            if (StringUtils.isNotBlank(value) && !isObservationMatched(key, value, column, rowNum)){
+            if (!isObservationMatched(key, value, column, rowNum)){
 
                 // prior observation with updated value
                 newObservation = gson.fromJson(gson.toJson(existingObsByObsHash.get(key)), BrAPIObservation.class);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1666,14 +1666,13 @@ public class ExperimentProcessor implements Processor {
     }
 
     /**
-     * Retrieves a list of pending Observation Units based on their IDs.
+     * Retrieves reference Observation Units based on a set of reference Observation Unit IDs and a Program.
+     * Constructs DeltaBreed observation unit source for external references and sets up pending Observation Units.
      *
-     * This function retrieves Observation Units based on a list of reference Observation Unit IDs
-     * and the associated program. It then sets pending Observation Units for each ID.
-     *
-     * @return List of BrAPIObservationUnit: The list of reference Observation Units retrieved.
-     *
-     * @throws InternalServerException if an error occurs during the process.
+     * @param referenceOUIds A set of reference Observation Unit IDs to retrieve
+     * @param program The Program associated with the Observation Units
+     * @return A Map containing pending Observation Units by their ID
+     * @throws ApiException if an error occurs during the process
      */
     private Map<String, PendingImportObject<BrAPIObservationUnit>> fetchReferenceObservationUnits(
             Set<String> referenceOUIds,

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1822,10 +1822,21 @@ public class ExperimentProcessor implements Processor {
         return studies;
     }
 
+    /**
+     * Initializes a map of ProgramLocation objects by their names using the given Program and a map of BrAPIStudy objects by their names.
+     *
+     * This method takes a Program object and a map of BrAPIStudy objects by their names, retrieves the location database IDs from the studies,
+     * and fetches existing ProgramLocation objects based on the database IDs. It then creates a map of ProgramLocation objects by their names
+     * with PendingImportObject wrappers that indicate the state of the object as existing.
+     *
+     * @param program the Program object to associate with the locations
+     * @param studyByName a map of BrAPIStudy objects by their names
+     * @return a map of ProgramLocation objects by their names with PendingImportObject wrappers
+     * @throws InternalServerException if an error occurs during the location retrieval process
+     */
     Map<String, PendingImportObject<ProgramLocation>> initializeLocationByName(
             Program program,
-            Map<String, PendingImportObject<BrAPIStudy>> studyByName
-    ) {
+            Map<String, PendingImportObject<BrAPIStudy>> studyByName) {
         Map<String, PendingImportObject<ProgramLocation>> locationByName = new HashMap<>();
 
         List<ProgramLocation> existingLocations = new ArrayList<>();

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1345,8 +1345,9 @@ public class ExperimentProcessor implements Processor {
             if (trialByNameNoScope.containsKey(importRow.getExpTitle())) {
                 PendingImportObject<BrAPIStudy> envPio;
                 trialPio = trialByNameNoScope.get(importRow.getExpTitle());
-                envPio = this.studyByNameNoScope.get(importRow.getEnv());
-                if  (trialPio!=null &&  ImportObjectState.EXISTING==trialPio.getState() && (StringUtils.isBlank( importRow.getObsUnitID() )) && (envPio!=null && ImportObjectState.EXISTING==envPio.getState() ) ){
+                envPio = studyByNameNoScope.get(importRow.getEnv());
+                if  (trialPio!=null &&  ImportObjectState.EXISTING==trialPio.getState() &&
+                        (StringUtils.isBlank( importRow.getObsUnitID() )) && (envPio!=null && ImportObjectState.EXISTING==envPio.getState() ) ){
                     throw new UnprocessableEntityException(PREEXISTING_EXPERIMENT_TITLE);
                 }
             } else if (!trialByNameNoScope.isEmpty()) {
@@ -1359,7 +1360,7 @@ public class ExperimentProcessor implements Processor {
                 }
                 BrAPITrial newTrial = importRow.constructBrAPITrial(program, user, commit, BRAPI_REFERENCE_SOURCE, id, expSeqValue);
                 trialPio = new PendingImportObject<>(ImportObjectState.NEW, newTrial, id);
-                this.trialByNameNoScope.put(importRow.getExpTitle(), trialPio);
+                trialByNameNoScope.put(importRow.getExpTitle(), trialPio);
             }
         }
         return trialPio;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -2418,6 +2418,14 @@ public class ExperimentProcessor implements Processor {
         return (yearInt == null) ? "" : yearInt.toString();
     }
 
+    /**
+     * Returns the single value from the given map, throwing an UnprocessableEntityException if the map does not contain exactly one entry.
+     *
+     * @param map The map from which to retrieve the single value.
+     * @param message The error message to include in the UnprocessableEntityException if the map does not contain exactly one entry.
+     * @return The single value from the map.
+     * @throws UnprocessableEntityException if the map does not contain exactly one entry.
+     */
     private <K, V> V getSingleEntryValue(Map<K, V> map, String message) throws UnprocessableEntityException {
         if (map.size() != 1) {
             throw new UnprocessableEntityException(message);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -84,7 +84,7 @@ import java.util.stream.Collectors;
 public class ExperimentProcessor implements Processor {
 
     private static final String NAME = "Experiment";
-    private static final String MISSING_OBS_UNIT_ID_ERROR = "Experimental entities are missing ObsUnitIDs. Import cannot proceed";
+    private static final String MISSING_OBS_UNIT_ID_ERROR = "Experimental entities are missing ObsUnitIDs";
     private static final String PREEXISTING_EXPERIMENT_TITLE = "Experiment Title already exists";
     private static final String MULTIPLE_EXP_TITLES = "File contains more than one Experiment Title";
     private static final String MIDNIGHT = "T00:00:00-00:00";

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1162,7 +1162,6 @@ public class ExperimentProcessor implements Processor {
                     getSingleEntryValue(trialByNameNoScope, MULTIPLE_EXP_TITLES) : trialByNameNoScope.get(importRow.getExpTitle());
 
             UUID trialID = trialPIO.getId();
-            //PendingImportObject<BrAPIStudy> studyPIO = this.studyByNameNoScope.get(importRow.getEnv());
             UUID studyID = studyPIO.getId();
             UUID id = UUID.randomUUID();
             newObservation = importRow.constructBrAPIObservation(value, variableName, seasonDbId, obsUnitPIO.getBrAPIObject(), commit, program, user, BRAPI_REFERENCE_SOURCE, trialID, studyID, obsUnitPIO.getId(), id);
@@ -1172,7 +1171,7 @@ public class ExperimentProcessor implements Processor {
                 newObservation.setObservationTimeStamp(OffsetDateTime.parse(timeStampValue));
             }
 
-            newObservation.setStudyDbId(this.studyByNameNoScope.get(pendingObsUnitByOUId.get(importRow.getObsUnitID()).getBrAPIObject().getStudyName()).getId().toString()); //set as the BI ID to facilitate looking up studies when saving new observations
+            newObservation.setStudyDbId(studyPIO.getId().toString()); //set as the BI ID to facilitate looking up studies when saving new observations
 
             pio = new PendingImportObject<>(ImportObjectState.NEW, newObservation);
             this.observationByHash.put(key, pio);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -2227,36 +2227,6 @@ public class ExperimentProcessor implements Processor {
     }
 
     /**
-     * Cache pending trial with reference to observation unit.
-     *
-     * This method processes the given existing trial, associates it with the
-     * specified
-     * program, retrieves the experiment ID from the trial's external references,
-     * then caches it with the provided organizational unit reference ID.
-     *
-     * @param existingTrial  The existing trial to process and cache.
-     * @param trialRefSource The source to retrieve the trial's reference.
-     * @param referenceOUId  The ID of the reference observation unit.
-     */
-    private void processAndCachePendingTrial(
-            BrAPITrial existingTrial,
-            String trialRefSource,
-            String referenceOUId) {
-
-        // Retrieve experiment ID from existingTrial
-        BrAPIExternalReference experimentIDRef = Utilities
-                .getExternalReference(existingTrial.getExternalReferences(), trialRefSource)
-                .orElseThrow(() -> new InternalServerException(
-                        "An Experiment ID was not found in any of the external references"));
-        UUID experimentId = UUID.fromString(experimentIDRef.getReferenceId());
-
-        // Cache pending trial by observation unit ID
-        pendingTrialByOUId.put(
-                referenceOUId,
-                new PendingImportObject<>(ImportObjectState.EXISTING, existingTrial, experimentId));
-    }
-
-    /**
      * Sets the reference Observation Unit IDs based on the import rows.
      * Checks for references to existing observation units and populates the
      * referenceOUIds list.

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -207,6 +207,8 @@ public class ExperimentProcessor implements Processor {
                     BrAPIObservationUnit unit = unitEntry.getValue().getBrAPIObject();
                     mapPendingTrialByOUId(unitId, unit, trialByNameNoScope, studyByNameNoScope, pendingTrialByOUId, program);
                     mapPendingStudyByOUId(unitId, unit, studyByNameNoScope, pendingStudyByOUId, program);
+                    mapPendingLocationByOUId(unitId, unit, pendingStudyByOUId, locationByName, pendingLocationByOUId);
+
                 }
 
                 pendingStudyByOUId = fetchStudyByOUId(referenceOUIds, pendingObsUnitByOUId, program);
@@ -1503,6 +1505,27 @@ public class ExperimentProcessor implements Processor {
             log.error("Error fetching observation units: " + Utilities.generateApiExceptionLogMessage(e), e);
             throw new InternalServerException(e.toString(), e);
         }
+    }
+
+    private Map<String, PendingImportObject<ProgramLocation>> mapPendingLocationByOUId(
+            String unitId,
+            BrAPIObservationUnit unit,
+            Map<String, PendingImportObject<BrAPIStudy>> studyByOUId,
+            Map<String, PendingImportObject<ProgramLocation>> locationByName,
+            Map<String, PendingImportObject<ProgramLocation>> locationByOUId
+    ) {
+        if (unit.getLocationName() != null) {
+            locationByOUId.put(unitId, locationByName.get(unit.getLocationName()));
+        } else if (studyByOUId.get(unitId) != null && studyByOUId.get(unitId).getBrAPIObject().getLocationName() != null) {
+            locationByOUId.put(
+                    unitId,
+                    locationByName.get(studyByOUId.get(unitId).getBrAPIObject().getLocationName())
+            );
+        } else {
+            throw new IllegalStateException("Observation unit missing location: " + unitId);
+        }
+
+        return locationByOUId;
     }
 
     private Map<String, PendingImportObject<BrAPIStudy>> mapPendingStudyByOUId(

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -706,7 +706,7 @@ public class ExperimentFileImportTest extends BrAPITest {
     @SneakyThrows
     public void importNewObsVarByObsUnitId() {
         List<Trait> traits = importTestUtils.createTraits(2);
-        Program program = createProgram("New ObsVar Existing OU", "OUVAR", "OUVAR", BRAPI_REFERENCE_SOURCE, createGermplasm(1), traits);
+        Program program = createProgram("New ObsVar Referring to OU by ID", "OUVAR", "VAROU", BRAPI_REFERENCE_SOURCE, createGermplasm(1), traits);
         Map<String, Object> newExp = new HashMap<>();
         newExp.put(Columns.GERMPLASM_GID, "1");
         newExp.put(Columns.TEST_CHECK, "T");

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -361,7 +361,6 @@ public class ExperimentFileImportTest extends BrAPITest {
         assertRowSaved(newEnv, program, null);
     }
 
-
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @SneakyThrows
@@ -599,50 +598,49 @@ public class ExperimentFileImportTest extends BrAPITest {
         uploadAndVerifyFailure(program, importTestUtils.writeExperimentDataToFile(List.of(newExp), traits), traits.get(0).getObservationVariableName(), commit);
     }
 
-    // NO Longer needed, but may be needed in the future.
-//    @ParameterizedTest
-//    @ValueSource(booleans = {true, false})
-//    @SneakyThrows
-//    public void verifyFailureNewOuExistingEnv(boolean commit) {
-//        Program program = createProgram("New OU Exising Env "+(commit ? "C" : "P"), "FLOU"+(commit ? "C" : "P"), "FLOU"+(commit ? "C" : "P"), BRAPI_REFERENCE_SOURCE, createGermplasm(1), null);
-//        Map<String, Object> newExp = new HashMap<>();
-//        newExp.put(Columns.GERMPLASM_GID, "1");
-//        newExp.put(Columns.TEST_CHECK, "T");
-//        newExp.put(Columns.EXP_TITLE, "Test Exp");
-//        newExp.put(Columns.EXP_UNIT, "Plot");
-//        newExp.put(Columns.EXP_TYPE, "Phenotyping");
-//        newExp.put(Columns.ENV, "New Env");
-//        newExp.put(Columns.ENV_LOCATION, "Location A");
-//        newExp.put(Columns.ENV_YEAR, "2023");
-//        newExp.put(Columns.EXP_UNIT_ID, "a-1");
-//        newExp.put(Columns.REP_NUM, "1");
-//        newExp.put(Columns.BLOCK_NUM, "1");
-//        newExp.put(Columns.ROW, "1");
-//        newExp.put(Columns.COLUMN, "1");
-//
-//        importTestUtils.uploadAndFetch(importTestUtils.writeExperimentDataToFile(List.of(newExp), null), null, true, client, program, mappingId);
-//
-//        Map<String, Object> newOU = new HashMap<>(newExp);
-//        newOU.put(Columns.EXP_UNIT_ID, "a-2");
-//        newOU.put(Columns.ROW, "1");
-//        newOU.put(Columns.COLUMN, "2");
-//
-//        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(importTestUtils.writeExperimentDataToFile(List.of(newOU), null), null, commit, client, program, mappingId);
-//        HttpResponse<String> response = call.blockingFirst();
-//        assertEquals(HttpStatus.ACCEPTED, response.getStatus());
-//
-//        String importId = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").get("importId").getAsString();
-//
-//        HttpResponse<String> upload = importTestUtils.getUploadedFile(importId, client, program, mappingId);
-//        JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
-//        assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt(), "Returned data: " + result);
-//
-//        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Experimental entities are missing ObsUnitIDs"));
-//    }
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @SneakyThrows
+    public void verifyFailureNewOuExistingEnv(boolean commit) {
+        Program program = createProgram("New OU Existing Env "+(commit ? "C" : "P"), "FLOU"+(commit ? "C" : "P"), "FLOU"+(commit ? "C" : "P"), BRAPI_REFERENCE_SOURCE, createGermplasm(1), null);
+        Map<String, Object> newExp = new HashMap<>();
+        newExp.put(Columns.GERMPLASM_GID, "1");
+        newExp.put(Columns.TEST_CHECK, "T");
+        newExp.put(Columns.EXP_TITLE, "Test Exp");
+        newExp.put(Columns.EXP_UNIT, "Plot");
+        newExp.put(Columns.EXP_TYPE, "Phenotyping");
+        newExp.put(Columns.ENV, "New Env");
+        newExp.put(Columns.ENV_LOCATION, "Location A");
+        newExp.put(Columns.ENV_YEAR, "2023");
+        newExp.put(Columns.EXP_UNIT_ID, "a-1");
+        newExp.put(Columns.REP_NUM, "1");
+        newExp.put(Columns.BLOCK_NUM, "1");
+        newExp.put(Columns.ROW, "1");
+        newExp.put(Columns.COLUMN, "1");
+
+        importTestUtils.uploadAndFetch(importTestUtils.writeExperimentDataToFile(List.of(newExp), null), null, true, client, program, mappingId);
+
+        Map<String, Object> newOU = new HashMap<>(newExp);
+        newOU.put(Columns.EXP_UNIT_ID, "a-2");
+        newOU.put(Columns.ROW, "1");
+        newOU.put(Columns.COLUMN, "2");
+
+        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(importTestUtils.writeExperimentDataToFile(List.of(newOU), null), null, commit, client, program, mappingId);
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.ACCEPTED, response.getStatus());
+
+        String importId = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").get("importId").getAsString();
+
+        HttpResponse<String> upload = importTestUtils.getUploadedFile(importId, client, program, mappingId);
+        JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
+        assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt(), "Returned data: " + result);
+
+        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Experimental entities are missing ObsUnitIDs"));
+    }
 
     @Test
     @SneakyThrows
-    public void importNewObsVarExisingOu() {
+    public void importNewObsVarExistingOu() {
         List<Trait> traits = importTestUtils.createTraits(2);
         Program program = createProgram("New ObsVar Existing OU", "OUVAR", "OUVAR", BRAPI_REFERENCE_SOURCE, createGermplasm(1), traits);
         Map<String, Object> newExp = new HashMap<>();
@@ -708,7 +706,7 @@ public class ExperimentFileImportTest extends BrAPITest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @SneakyThrows
-    public void importNewObsExisingOu(boolean commit) {
+    public void importNewObsExistingOu(boolean commit) {
         List<Trait> traits = importTestUtils.createTraits(1);
         Program program = createProgram("New Obs Existing OU "+(commit ? "C" : "P"), "OUOBS"+(commit ? "C" : "P"), "OUOBS"+(commit ? "C" : "P"), BRAPI_REFERENCE_SOURCE, createGermplasm(1), traits);
         Map<String, Object> newExp = new HashMap<>();
@@ -774,7 +772,7 @@ public class ExperimentFileImportTest extends BrAPITest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @SneakyThrows
-    public void verifyFailureImportNewObsExisingOuWithExistingObs(boolean commit) {
+    public void verifyFailureImportNewObsExistingOuWithExistingObs(boolean commit) {
         List<Trait> traits = importTestUtils.createTraits(1);
         Program program = createProgram("New Obs Existing Obs "+(commit ? "C" : "P"), "FEXOB"+(commit ? "C" : "P"), "FEXOB"+(commit ? "C" : "P"), BRAPI_REFERENCE_SOURCE, createGermplasm(1), traits);
         Map<String, Object> newExp = new HashMap<>();

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -816,7 +816,6 @@ public class ExperimentFileImportTest extends BrAPITest {
         assertEquals("EXISTING", row.getAsJsonObject("study").get("state").getAsString());
         assertEquals("EXISTING", row.getAsJsonObject("observationUnit").get("state").getAsString());
         if(commit) {
-            //assertRowReferencedByOUIdSaved(newObsVar, program, traits);
             assertRowSaved(newObsVar, program, traits);
         } else {
             assertValidPreviewRow(newObsVar, row, program, traits);
@@ -1155,7 +1154,6 @@ public class ExperimentFileImportTest extends BrAPITest {
         assertEquals("EXISTING", row.getAsJsonObject("study").get("state").getAsString());
         assertEquals("EXISTING", row.getAsJsonObject("observationUnit").get("state").getAsString());
 
-        //newObservation.put(traits.get(0).getObservationVariableName(), "1");
         if(commit) {
             assertRowSaved(newObservation, program, traits);
         } else {
@@ -1172,15 +1170,10 @@ public class ExperimentFileImportTest extends BrAPITest {
         List<BrAPIObservation> observations = null;
         if(traits != null) {
             observations = observationDAO.getObservationsByStudyName(List.of(units.get(0).getStudyName()), program);
-//            observations = observationDAO.getObservationsByObservationUnitsAndVariables(
-//                    units.stream().map(BrAPIObservationUnit::getObservationUnitDbId).collect(Collectors.toList()),
-//                    traits.stream().map(Trait::getObservationVariableDbId).collect(Collectors.toList()),
-//                    program
-//            );
             if (expected.get(traits.get(0).getObservationVariableName()) == null) {
                 assertTrue(observations.isEmpty());
             } else {
-                //assertFalse(observations.isEmpty());
+                assertFalse(observations.isEmpty());
                 List<String> expectedVariableObservation = new ArrayList<>();
                 List<String> actualVariableObservation = new ArrayList<>();
                 observations.forEach(observation -> actualVariableObservation.add(String.format("%s:%s", Utilities.removeProgramKey(observation.getObservationVariableName(), program.getKey()), observation.getValue())));

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -666,7 +666,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceID()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
 
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
@@ -686,7 +686,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         newObsVar.put(Columns.BLOCK_NUM, "1");
         newObsVar.put(Columns.ROW, "1");
         newObsVar.put(Columns.COLUMN, "1");
-        newObsVar.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceID());
+        newObsVar.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceId());
         newObsVar.put(traits.get(1).getObservationVariableName(), null);
 
         JsonObject result = importTestUtils.uploadAndFetch(importTestUtils.writeExperimentDataToFile(List.of(newObsVar), traits), null, true, client, program, mappingId);
@@ -731,7 +731,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceID()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
 
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
@@ -751,7 +751,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         newObservation.put(Columns.BLOCK_NUM, "1");
         newObservation.put(Columns.ROW, "1");
         newObservation.put(Columns.COLUMN, "1");
-        newObservation.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceID());
+        newObservation.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceId());
         newObservation.put(traits.get(0).getObservationVariableName(), "1");
 
         JsonObject result = importTestUtils.uploadAndFetch(importTestUtils.writeExperimentDataToFile(List.of(newObservation), traits), null, commit, client, program, mappingId);
@@ -798,7 +798,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceID()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
 
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
@@ -818,7 +818,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         newObservation.put(Columns.BLOCK_NUM, "1");
         newObservation.put(Columns.ROW, "1");
         newObservation.put(Columns.COLUMN, "1");
-        newObservation.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceID());
+        newObservation.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceId());
         newObservation.put(traits.get(0).getObservationVariableName(), "2");
 
         uploadAndVerifyFailure(program, importTestUtils.writeExperimentDataToFile(List.of(newObservation), traits), traits.get(0).getObservationVariableName(), commit);
@@ -925,7 +925,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceID()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
 
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
@@ -945,7 +945,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         newObservation.put(Columns.BLOCK_NUM, "1");
         newObservation.put(Columns.ROW, "1");
         newObservation.put(Columns.COLUMN, "1");
-        newObservation.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceID());
+        newObservation.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceId());
         newObservation.put(traits.get(0).getObservationVariableName(), "1");
         newObservation.put(traits.get(1).getObservationVariableName(), "2");
 
@@ -999,7 +999,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceID()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
 
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
@@ -1021,7 +1021,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         newObservation.put(Columns.BLOCK_NUM, "1");
         newObservation.put(Columns.ROW, "1");
         newObservation.put(Columns.COLUMN, "1");
-        newObservation.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceID());
+        newObservation.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceId());
         newObservation.put(traits.get(0).getObservationVariableName(), "");
         newObservation.put(traits.get(1).getObservationVariableName(), "2");
 
@@ -1053,7 +1053,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(trial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
 
-        List<BrAPIStudy> studies = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceID()), program);
+        List<BrAPIStudy> studies = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program);
         assertFalse(studies.isEmpty());
         BrAPIStudy study = null;
         for(BrAPIStudy s : studies) {

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -702,6 +702,70 @@ public class ExperimentFileImportTest extends BrAPITest {
         assertRowSaved(newObsVar, program, traits);
     }
 
+    @Test
+    @SneakyThrows
+    public void importNewObsVarByObsUnitId() {
+        List<Trait> traits = importTestUtils.createTraits(2);
+        Program program = createProgram("New ObsVar Existing OU", "OUVAR", "OUVAR", BRAPI_REFERENCE_SOURCE, createGermplasm(1), traits);
+        Map<String, Object> newExp = new HashMap<>();
+        newExp.put(Columns.GERMPLASM_GID, "1");
+        newExp.put(Columns.TEST_CHECK, "T");
+        newExp.put(Columns.EXP_TITLE, "Test Exp");
+        newExp.put(Columns.EXP_UNIT, "Plot");
+        newExp.put(Columns.EXP_TYPE, "Phenotyping");
+        newExp.put(Columns.ENV, "New Env");
+        newExp.put(Columns.ENV_LOCATION, "Location A");
+        newExp.put(Columns.ENV_YEAR, "2023");
+        newExp.put(Columns.EXP_UNIT_ID, "a-1");
+        newExp.put(Columns.REP_NUM, "1");
+        newExp.put(Columns.BLOCK_NUM, "1");
+        newExp.put(Columns.ROW, "1");
+        newExp.put(Columns.COLUMN, "1");
+        newExp.put(traits.get(0).getObservationVariableName(), null);
+
+        importTestUtils.uploadAndFetch(importTestUtils.writeExperimentDataToFile(List.of(newExp), null), null, true, client, program, mappingId);
+
+        BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
+        Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
+        assertTrue(trialIdXref.isPresent());
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
+
+        BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
+        Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
+        assertTrue(ouIdXref.isPresent());
+
+        Map<String, Object> newObsVar = new HashMap<>();
+//        newObsVar.put(Columns.GERMPLASM_GID, "1");
+//        newObsVar.put(Columns.TEST_CHECK, "T");
+//        newObsVar.put(Columns.EXP_TITLE, "Test Exp");
+//        newObsVar.put(Columns.EXP_UNIT, "Plot");
+//        newObsVar.put(Columns.EXP_TYPE, "Phenotyping");
+//        newObsVar.put(Columns.ENV, "New Env");
+//        newObsVar.put(Columns.ENV_LOCATION, "Location A");
+//        newObsVar.put(Columns.ENV_YEAR, "2023");
+//        newObsVar.put(Columns.EXP_UNIT_ID, "a-1");
+//        newObsVar.put(Columns.REP_NUM, "1");
+//        newObsVar.put(Columns.BLOCK_NUM, "1");
+//        newObsVar.put(Columns.ROW, "1");
+//        newObsVar.put(Columns.COLUMN, "1");
+        newObsVar.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceId());
+        newObsVar.put(traits.get(1).getObservationVariableName(), null);
+
+        JsonObject result = importTestUtils.uploadAndFetch(importTestUtils.writeExperimentDataToFile(List.of(newObsVar), traits), null, true, client, program, mappingId);
+
+        JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
+        assertEquals(1, previewRows.size());
+        JsonObject row = previewRows.get(0).getAsJsonObject();
+
+        assertEquals("EXISTING", row.getAsJsonObject("trial").get("state").getAsString());
+        assertTrue(row.getAsJsonObject("trial").get("brAPIObject").getAsJsonObject().get("additionalInfo").getAsJsonObject().has("observationDatasetId"));
+        assertTrue(importTestUtils.UUID_REGEX.matcher(row.getAsJsonObject("trial").get("brAPIObject").getAsJsonObject().get("additionalInfo").getAsJsonObject().get("observationDatasetId").getAsString()).matches());
+        assertEquals("EXISTING", row.getAsJsonObject("location").get("state").getAsString());
+        assertEquals("EXISTING", row.getAsJsonObject("study").get("state").getAsString());
+        assertEquals("EXISTING", row.getAsJsonObject("observationUnit").get("state").getAsString());
+        assertRowSaved(newObsVar, program, traits);
+    }
+
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -635,7 +635,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
         assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt(), "Returned data: " + result);
 
-        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Experimental entities are missing ObsUnitIDs"));
+        assertTrue(result.getAsJsonObject("progress").get("message").getAsString().startsWith("Experiment Title already exists"));
     }
 
     @Test


### PR DESCRIPTION
# Description
**Story:** [BI-2046](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2046)

Validation errors are now returned for display in the experiment import preview for any rows referring to an existing environment and with the ObsUnitID blank.

# Dependencies
bi-web release/0.9

# Testing
Verify all tests pass in ExperimentFileImportTest
1) import an experiment with observations
2) download the exp data with ObsUnitId populated
3) select multiple observations for updating and change phenotype values
4) import and verify updates by viewing experiment details

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2046]: https://breedinginsight.atlassian.net/browse/BI-2046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ