### PR TITLE
BI-2045 (Failure to report error when uploading duplicated experiment name)

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1180,7 +1180,7 @@ public class ExperimentProcessor implements Processor {
             PendingImportObject<BrAPIStudy> envPio;
             trialPio = trialByNameNoScope.get(importRow.getExpTitle());
             envPio = this.studyByNameNoScope.get(importRow.getEnv());
-            if  (trialPio.getState() == ImportObjectState.EXISTING && (StringUtils.isBlank( importRow.getObsUnitID() )) && (envPio!=null && ImportObjectState.EXISTING==envPio.getState() ) ){
+            if  (trialPio!=null &&  ImportObjectState.EXISTING==trialPio.getState() && (StringUtils.isBlank( importRow.getObsUnitID() )) && (envPio!=null && ImportObjectState.EXISTING==envPio.getState() ) ){
                 throw new UnprocessableEntityException(PREEXISTING_EXPERIMENT_TITLE);
             }
         } else if (!trialByNameNoScope.isEmpty()) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -84,7 +84,7 @@ public class ExperimentProcessor implements Processor {
 
     private static final String NAME = "Experiment";
     private static final String MISSING_OBS_UNIT_ID_ERROR = "Experimental entities are missing ObsUnitIDs";
-    private static final String DUPLICATE_EXPERIMENT_TITLE = "Experiment Title already exists";
+    private static final String PREEXISTING_EXPERIMENT_TITLE = "Experiment Title already exists";
     private static final String MULTIPLE_EXP_TITLES = "File contains more than one Experiment Title";
     private static final String MIDNIGHT = "T00:00:00-00:00";
     private static final String TIMESTAMP_PREFIX = "TS:";
@@ -1179,7 +1179,7 @@ public class ExperimentProcessor implements Processor {
         if (trialByNameNoScope.containsKey(importRow.getExpTitle())) {
             pio = trialByNameNoScope.get(importRow.getExpTitle());
             if  (pio.getState() == ImportObjectState.EXISTING && StringUtils.isBlank( importRow.getObsUnitID() ) ){
-                throw new UnprocessableEntityException(DUPLICATE_EXPERIMENT_TITLE);
+                throw new UnprocessableEntityException(PREEXISTING_EXPERIMENT_TITLE);
             }
         } else if (!trialByNameNoScope.isEmpty()) {
             throw new UnprocessableEntityException(MULTIPLE_EXP_TITLES);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -84,6 +84,7 @@ public class ExperimentProcessor implements Processor {
 
     private static final String NAME = "Experiment";
     private static final String MISSING_OBS_UNIT_ID_ERROR = "Experimental entities are missing ObsUnitIDs";
+    private static final String DUPLICATE_EXPERIMENT_TITLE = "Experiment Title already exists";
     private static final String MULTIPLE_EXP_TITLES = "File contains more than one Experiment Title";
     private static final String MIDNIGHT = "T00:00:00-00:00";
     private static final String TIMESTAMP_PREFIX = "TS:";
@@ -1177,6 +1178,9 @@ public class ExperimentProcessor implements Processor {
         PendingImportObject<BrAPITrial> pio;
         if (trialByNameNoScope.containsKey(importRow.getExpTitle())) {
             pio = trialByNameNoScope.get(importRow.getExpTitle());
+            if  (pio.getState() == ImportObjectState.EXISTING && StringUtils.isBlank( importRow.getObsUnitID() ) ){
+                throw new UnprocessableEntityException(DUPLICATE_EXPERIMENT_TITLE);
+            }
         } else if (!trialByNameNoScope.isEmpty()) {
             throw new UnprocessableEntityException(MULTIPLE_EXP_TITLES);
         } else {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1175,10 +1175,12 @@ public class ExperimentProcessor implements Processor {
     }
 
     private PendingImportObject<BrAPITrial> fetchOrCreateTrialPIO(Program program, User user, boolean commit, ExperimentObservation importRow, Supplier<BigInteger> expNextVal) throws UnprocessableEntityException {
-        PendingImportObject<BrAPITrial> pio;
+        PendingImportObject<BrAPITrial> trialPio;
         if (trialByNameNoScope.containsKey(importRow.getExpTitle())) {
-            pio = trialByNameNoScope.get(importRow.getExpTitle());
-            if  (pio.getState() == ImportObjectState.EXISTING && StringUtils.isBlank( importRow.getObsUnitID() ) ){
+            PendingImportObject<BrAPIStudy> envPio;
+            trialPio = trialByNameNoScope.get(importRow.getExpTitle());
+            envPio = this.studyByNameNoScope.get(importRow.getEnv());
+            if  (trialPio.getState() == ImportObjectState.EXISTING && (StringUtils.isBlank( importRow.getObsUnitID() )) && (envPio!=null && ImportObjectState.EXISTING==envPio.getState() ) ){
                 throw new UnprocessableEntityException(PREEXISTING_EXPERIMENT_TITLE);
             }
         } else if (!trialByNameNoScope.isEmpty()) {
@@ -1190,10 +1192,10 @@ public class ExperimentProcessor implements Processor {
                 expSeqValue = expNextVal.get().toString();
             }
             BrAPITrial newTrial = importRow.constructBrAPITrial(program, user, commit, BRAPI_REFERENCE_SOURCE, id, expSeqValue);
-            pio = new PendingImportObject<>(ImportObjectState.NEW, newTrial, id);
-            this.trialByNameNoScope.put(importRow.getExpTitle(), pio);
+            trialPio = new PendingImportObject<>(ImportObjectState.NEW, newTrial, id);
+            this.trialByNameNoScope.put(importRow.getExpTitle(), trialPio);
         }
-        return pio;
+        return trialPio;
     }
 
     private void updateObservationDependencyValues(Program program) {

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -282,7 +282,7 @@ public class ExperimentFileImportTest extends BrAPITest {
 
     @Test
     @SneakyThrows
-    public void importNewEnvExistingExpErrorMessage() {
+    public void importExistingExpAndEnvErrorMessage() {
         Program program = createProgram("New Env Existing Exp", "DUPENV", "DUPENV", BRAPI_REFERENCE_SOURCE, createGermplasm(1), null);
         Map<String, Object> newExp = new HashMap<>();
         newExp.put(Columns.GERMPLASM_GID, "1");

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -216,7 +216,7 @@ public class ExperimentFileImportTest extends BrAPITest {
 
     @Test
     @SneakyThrows
-    public void importNewExpMultiNewEnvError() {
+    public void importNewExpMultiNewEnvSuccess() {
         Program program = createProgram("New Exp and Multi New Env", "MULENV", "MULENV", BRAPI_REFERENCE_SOURCE, createGermplasm(1), null);
         Map<String, Object> firstEnv = new HashMap<>();
         firstEnv.put(Columns.GERMPLASM_GID, "1");

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -290,7 +290,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         newExp.put(Columns.EXP_TITLE, "Test Exp");
         newExp.put(Columns.EXP_UNIT, "Plot");
         newExp.put(Columns.EXP_TYPE, "Phenotyping");
-        newExp.put(Columns.ENV, "New Env");
+        newExp.put(Columns.ENV, "Existing Env");
         newExp.put(Columns.ENV_LOCATION, "Location A");
         newExp.put(Columns.ENV_YEAR, "2023");
         newExp.put(Columns.EXP_UNIT_ID, "a-1");
@@ -301,22 +301,22 @@ public class ExperimentFileImportTest extends BrAPITest {
 
         JsonObject expResult = importTestUtils.uploadAndFetch(importTestUtils.writeExperimentDataToFile(List.of(newExp), null), null, true, client, program, mappingId);
 
-        Map<String, Object> newEnv = new HashMap<>();
-        newEnv.put(Columns.GERMPLASM_GID, "1");
-        newEnv.put(Columns.TEST_CHECK, "T");
-        newEnv.put(Columns.EXP_TITLE, "Test Exp");
-        newEnv.put(Columns.EXP_UNIT, "Plot");
-        newEnv.put(Columns.EXP_TYPE, "Phenotyping");
-        newEnv.put(Columns.ENV, "New Trial Existing Exp");
-        newEnv.put(Columns.ENV_LOCATION, "Location A");
-        newEnv.put(Columns.ENV_YEAR, "2023");
-        newEnv.put(Columns.EXP_UNIT_ID, "a-1");
-        newEnv.put(Columns.REP_NUM, "1");
-        newEnv.put(Columns.BLOCK_NUM, "1");
-        newEnv.put(Columns.ROW, "1");
-        newEnv.put(Columns.COLUMN, "1");
+        Map<String, Object> dupExp = new HashMap<>();
+        dupExp.put(Columns.GERMPLASM_GID, "1");
+        dupExp.put(Columns.TEST_CHECK, "T");
+        dupExp.put(Columns.EXP_TITLE, "Test Exp");
+        dupExp.put(Columns.EXP_UNIT, "Plot");
+        dupExp.put(Columns.EXP_TYPE, "Phenotyping");
+        dupExp.put(Columns.ENV, "Existing Env");
+        dupExp.put(Columns.ENV_LOCATION, "Location A");
+        dupExp.put(Columns.ENV_YEAR, "2023");
+        dupExp.put(Columns.EXP_UNIT_ID, "a-1");
+        dupExp.put(Columns.REP_NUM, "1");
+        dupExp.put(Columns.BLOCK_NUM, "1");
+        dupExp.put(Columns.ROW, "1");
+        dupExp.put(Columns.COLUMN, "1");
 
-        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(importTestUtils.writeExperimentDataToFile(List.of(newEnv), null), null, false, client, program, mappingId);
+        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(importTestUtils.writeExperimentDataToFile(List.of(dupExp), null), null, false, client, program, mappingId);
         HttpResponse<String> response = call.blockingFirst();
         assertEquals(HttpStatus.ACCEPTED, response.getStatus());
 


### PR DESCRIPTION
# Description
[BI-2045](https://breedinginsight.atlassian.net/browse/BI-2045) (Failure to report error when uploading duplicated experiment name)

# Dependencies
_Please include any dependencies to other code branches, testing configurations, scripts to be run, etc._

# Testing
Successfully import an experiment.
Attempt to import the same experiment file (with no ObsUnitIDs).
**EXPECTED RESULT**
- The banner message `Error detected in file, XXX.xls. Experiment Title already exists. Import cannot proceed.`

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2045]: https://breedinginsight.atlassian.net/browse/BI-2045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ