### PR TITLE
BI-2058 - Add Observations and ObservationUnits to Redis Cache

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -294,15 +294,15 @@ public class BrAPIGermplasmDAO {
     public List<BrAPIGermplasm> createBrAPIGermplasm(List<BrAPIGermplasm> postBrAPIGermplasmList, UUID programId, ImportUpload upload) {
         GermplasmApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), GermplasmApi.class);
         var program = programDAO.fetchOneById(programId);
-        Callable<Map<String, BrAPIGermplasm>> postFunction = null;
         try {
             if (!postBrAPIGermplasmList.isEmpty()) {
-                postFunction = () -> {
+                Callable<Map<String, BrAPIGermplasm>> postFunction = () -> {
                     List<BrAPIGermplasm> postResponse = brAPIDAOUtil.post(postBrAPIGermplasmList, upload, api::germplasmPost, importDAO::update);
                     return processGermplasmForDisplay(postResponse, program.getKey());
                 };
+                return programGermplasmCache.post(programId, postFunction);
             }
-            return programGermplasmCache.post(programId, postFunction);
+            return new ArrayList<>();
         } catch (Exception e) {
             throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
         }
@@ -311,15 +311,15 @@ public class BrAPIGermplasmDAO {
     public List<BrAPIGermplasm> updateBrAPIGermplasm(List<BrAPIGermplasm> putBrAPIGermplasmList, UUID programId, ImportUpload upload) {
         GermplasmApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), GermplasmApi.class);
         var program = programDAO.fetchOneById(programId);
-        Callable<Map<String, BrAPIGermplasm>> postFunction = null;
         try {
             if (!putBrAPIGermplasmList.isEmpty()) {
-                postFunction = () -> {
+                Callable<Map<String, BrAPIGermplasm>> postFunction = () -> {
                     List<BrAPIGermplasm> putResponse = putGermplasm(putBrAPIGermplasmList, api);
                     return processGermplasmForDisplay(putResponse, program.getKey());
                 };
+                return programGermplasmCache.post(programId, postFunction);
             }
-            return programGermplasmCache.post(programId, postFunction);
+            return new ArrayList<>();
         } catch (Exception e) {
             throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
         }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -212,20 +212,9 @@ public class BrAPIObservationDAO {
         if(ouDbIds.isEmpty() || variableDbIds.isEmpty()) {
             return Collections.emptyList();
         }
-//        return getProgramObservations(program.getId()).values().stream()
-//                .filter(o -> ouDbIds.contains(o.getObservationDbId()) && variableDbIds.contains(o.getObservationVariableDbId()))
-//                .collect(Collectors.toList());
-
-        BrAPIObservationSearchRequest observationSearchRequest = new BrAPIObservationSearchRequest();
-        observationSearchRequest.setProgramDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
-        observationSearchRequest.setObservationUnitDbIds(new ArrayList<>(ouDbIds));
-        observationSearchRequest.setObservationVariableDbIds(new ArrayList<>(variableDbIds));
-        ObservationsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), ObservationsApi.class);
-        return brAPIDAOUtil.search(
-                api::searchObservationsPost,
-                (brAPIWSMIMEDataTypes, searchResultsDbId, page, pageSize) -> searchObservationsSearchResultsDbIdGet(program.getId(), searchResultsDbId, page, pageSize),
-                observationSearchRequest
-        );
+        return getProgramObservations(program.getId()).values().stream()
+                .filter(o -> ouDbIds.contains(o.getObservationUnitDbId()) && variableDbIds.contains(o.getObservationVariableDbId()))
+                .collect(Collectors.toList());
     }
 
     @NotNull

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -135,7 +135,7 @@ public class BrAPIObservationDAO {
                     .stream()
                     .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.OBSERVATIONS.getName()).equals(reference.getReferenceSource()))
                     .findFirst().orElseThrow(() -> new IllegalStateException("No BI external reference found"));
-            programObservationsMap.put(xref.getReferenceID(), observation);
+            programObservationsMap.put(xref.getReferenceId(), observation);
         }
         return programObservationsMap;
     }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -27,7 +27,6 @@ import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.phenotype.ObservationsApi;
 import org.brapi.v2.model.BrAPIAcceptedSearchResponse;
 import org.brapi.v2.model.BrAPIExternalReference;
-import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.brapi.v2.model.pheno.request.BrAPIObservationSearchRequest;
 import org.brapi.v2.model.pheno.response.BrAPIObservationListResponse;
@@ -156,6 +155,9 @@ public class BrAPIObservationDAO {
         }
     }
 
+    /**
+     * Get all observations for a program from the cache.
+     */
     private Map<String, BrAPIObservation> getProgramObservations(UUID programId) throws ApiException {
         return programObservationCache.get(programId);
     }
@@ -235,10 +237,9 @@ public class BrAPIObservationDAO {
     public List<BrAPIObservation> createBrAPIObservations(List<BrAPIObservation> brAPIObservationList, UUID programId, ImportUpload upload) throws ApiException {
         ObservationsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ObservationsApi.class);
         var program = programDAO.fetchOneById(programId);
-        Callable<Map<String, BrAPIObservation>> postFunction = null;
         try {
             if (!brAPIObservationList.isEmpty()) {
-                postFunction = () -> {
+                Callable<Map<String, BrAPIObservation>> postFunction = () -> {
                     List<BrAPIObservation> postResponse = brAPIDAOUtil.post(brAPIObservationList, upload, api::observationsPost, importDAO::update);
                     return processObservationsForCache(postResponse, program.getKey());
                 };
@@ -253,10 +254,8 @@ public class BrAPIObservationDAO {
     public BrAPIObservation updateBrAPIObservation(String dbId, BrAPIObservation observation, UUID programId) throws ApiException {
         ObservationsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ObservationsApi.class);
         var program = programDAO.fetchOneById(programId);
-        Callable<Map<String, BrAPIObservation>> postFunction = null;
-
         try {
-            postFunction = () -> {
+            Callable<Map<String, BrAPIObservation>> postFunction = () -> {
                 ApiResponse<BrAPIObservationSingleResponse> response = api.observationsObservationDbIdPut(dbId, observation);
                     if (response == null)
                     {

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -16,19 +16,28 @@
  */
 package org.breedinginsight.brapi.v2.dao;
 
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.server.exceptions.InternalServerException;
+import io.micronaut.scheduling.annotation.Scheduled;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.phenotype.ObservationsApi;
 import org.brapi.v2.model.BrAPIAcceptedSearchResponse;
+import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.brapi.v2.model.pheno.request.BrAPIObservationSearchRequest;
 import org.brapi.v2.model.pheno.response.BrAPIObservationListResponse;
 import org.brapi.v2.model.pheno.response.BrAPIObservationSingleResponse;
 import org.breedinginsight.brapps.importer.daos.ImportDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
+import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.daos.ProgramDAO;
+import org.breedinginsight.daos.cache.ProgramCache;
+import org.breedinginsight.daos.cache.ProgramCacheProvider;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.services.brapi.BrAPIEndpointProvider;
 import org.breedinginsight.utilities.BrAPIDAOUtil;
@@ -38,6 +47,8 @@ import org.jetbrains.annotations.NotNull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import static org.brapi.v2.model.BrAPIWSMIMEDataTypes.APPLICATION_JSON;
 
@@ -49,19 +60,117 @@ public class BrAPIObservationDAO {
     private ImportDAO importDAO;
     private final BrAPIDAOUtil brAPIDAOUtil;
     private final BrAPIEndpointProvider brAPIEndpointProvider;
+    private final String referenceSource;
+    private boolean runScheduledTasks;
+    private final ProgramCache<BrAPIObservation> programObservationCache;
 
     @Inject
-    public BrAPIObservationDAO(ProgramDAO programDAO, ImportDAO importDAO, BrAPIDAOUtil brAPIDAOUtil, BrAPIEndpointProvider brAPIEndpointProvider) {
+    public BrAPIObservationDAO(ProgramDAO programDAO,
+                               ImportDAO importDAO,
+                               BrAPIDAOUtil brAPIDAOUtil,
+                               BrAPIEndpointProvider brAPIEndpointProvider,
+                               @Property(name = "brapi.server.reference-source") String referenceSource,
+                               @Property(name = "micronaut.bi.api.run-scheduled-tasks") boolean runScheduledTasks,
+                               ProgramCacheProvider programCacheProvider) {
         this.programDAO = programDAO;
         this.importDAO = importDAO;
         this.brAPIDAOUtil = brAPIDAOUtil;
         this.brAPIEndpointProvider = brAPIEndpointProvider;
+        this.referenceSource = referenceSource;
+        this.runScheduledTasks = runScheduledTasks;
+        this.programObservationCache = programCacheProvider.getProgramCache(this::fetchProgramObservations, BrAPIObservation.class);
+    }
+
+    @Scheduled(initialDelay = "3s")
+    public void setup() {
+        if(!runScheduledTasks) {
+            return;
+        }
+        // Populate the observation cache for all programs on startup.
+        log.debug("populating observation cache");
+        List<Program> programs = programDAO.getActive();
+        if (programs != null) {
+            programObservationCache.populate(programs.stream().map(Program::getId).collect(Collectors.toList()));
+        }
+    }
+
+    /**
+     * Fetch formatted observations for this program.
+     */
+    private Map<String, BrAPIObservation> fetchProgramObservations(UUID programId) throws ApiException {
+        ObservationsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ObservationsApi.class);
+        // Get the program.
+        List<Program> programs = programDAO.get(programId);
+        if (programs.size() != 1) {
+            throw new InternalServerException("Program was not found for given id");
+        }
+        Program program = programs.get(0);
+
+        // Set query params and make call.
+        BrAPIObservationSearchRequest observationSearch = new BrAPIObservationSearchRequest();
+        observationSearch.externalReferenceIds(List.of(programId.toString()));
+        observationSearch.externalReferenceSources(List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS)));
+        return processObservationsForCache(brAPIDAOUtil.search(
+                api::searchObservationsPost,
+                api::searchObservationsSearchResultsDbIdGet,
+                observationSearch
+        ), program.getKey());
+    }
+
+    /**
+     * Process a list of observations for insertion into the cache.
+     */
+    private Map<String, BrAPIObservation> processObservationsForCache(List<BrAPIObservation> programObservations, String programKey) {
+        // Process programObservations in place (strip program key, etc.).
+        processObservations(programKey, programObservations);
+        // Build map.
+        Map<String, BrAPIObservation> programObservationsMap = new HashMap<>();
+        log.trace("processing observationUnits for cache: " + programObservations);
+        for (BrAPIObservation observation: programObservations) {
+            BrAPIExternalReference xref = observation
+                    .getExternalReferences()
+                    .stream()
+                    .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.OBSERVATIONS.getName()).equals(reference.getReferenceSource()))
+                    .findFirst().orElseThrow(() -> new IllegalStateException("No BI external reference found"));
+            programObservationsMap.put(xref.getReferenceID(), observation);
+        }
+        return programObservationsMap;
+    }
+
+    /**
+     * Process BrAPIObservations for use in DeltaBreed (e.g. strip program key).
+     */
+    private void processObservations(String programKey, List<BrAPIObservation> observations) {
+        for (BrAPIObservation obs: observations) {
+            // Strip program key from observationVariableName.
+            if (StringUtils.isNotBlank(obs.getObservationVariableName())) {
+                obs.setObservationVariableName(Utilities.removeProgramKey(obs.getObservationVariableName(), programKey));
+            }
+            // Strip program key and unknown info from germplasmName and observationUnitName.
+            if (StringUtils.isNotBlank(obs.getGermplasmName())) {
+                obs.setGermplasmName(Utilities.removeProgramKeyAndUnknownAdditionalData(obs.getGermplasmName(), programKey));
+            }
+            if (StringUtils.isNotBlank(obs.getObservationUnitName())) {
+                obs.setObservationUnitName(Utilities.removeProgramKeyAndUnknownAdditionalData(obs.getObservationUnitName(), programKey));
+            }
+        }
+    }
+
+    private Map<String, BrAPIObservation> getProgramObservations(UUID programId) throws ApiException {
+        return programObservationCache.get(programId);
     }
 
     public List<BrAPIObservation> getObservationsByStudyName(List<String> studyNames, Program program) throws ApiException {
         if(studyNames.isEmpty()) {
             return Collections.emptyList();
         }
+//        // Strip program key and unknown additional data from studyNames.
+//        List<String> cleanedStudyNames = studyNames.stream()
+//                .map(n -> Utilities.removeProgramKeyAndUnknownAdditionalData(n, program.getKey()))
+//                .collect(Collectors.toList());
+//        return getProgramObservations(program.getId()).values().stream()
+//                .filter(o -> cleanedStudyNames.contains(o.getAdditionalInfo().get("studyName").getAsString()))
+//                .collect(Collectors.toList());
 
         BrAPIObservationSearchRequest observationSearchRequest = new BrAPIObservationSearchRequest();
         observationSearchRequest.setProgramDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
@@ -79,6 +188,12 @@ public class BrAPIObservationDAO {
             return Collections.emptyList();
         }
 
+        // TODO: get all observationUnits, then observation.
+//        return getProgramObservations(program.getId()).values().stream()
+//                .filter(o -> )
+//                .collect(Collectors.toList());
+
+        // TODO: remove old code ------
         BrAPIObservationSearchRequest observationSearchRequest = new BrAPIObservationSearchRequest();
         observationSearchRequest.setProgramDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
         observationSearchRequest.setTrialDbIds(new ArrayList<>(trialDbIds));
@@ -88,12 +203,16 @@ public class BrAPIObservationDAO {
                 (brAPIWSMIMEDataTypes, searchResultsDbId, page, pageSize) -> searchObservationsSearchResultsDbIdGet(program.getId(), searchResultsDbId, page, pageSize),
                 observationSearchRequest
         );
+        // TODO: end old code ------
     }
 
     public List<BrAPIObservation> getObservationsByObservationUnitsAndVariables(Collection<String> ouDbIds, Collection<String> variableDbIds, Program program) throws ApiException {
         if(ouDbIds.isEmpty() || variableDbIds.isEmpty()) {
             return Collections.emptyList();
         }
+//        return getProgramObservations(program.getId()).values().stream()
+//                .filter(o -> ouDbIds.contains(o.getObservationDbId()) && variableDbIds.contains(o.getObservationVariableDbId()))
+//                .collect(Collectors.toList());
 
         BrAPIObservationSearchRequest observationSearchRequest = new BrAPIObservationSearchRequest();
         observationSearchRequest.setProgramDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
@@ -115,28 +234,50 @@ public class BrAPIObservationDAO {
 
     public List<BrAPIObservation> createBrAPIObservations(List<BrAPIObservation> brAPIObservationList, UUID programId, ImportUpload upload) throws ApiException {
         ObservationsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ObservationsApi.class);
-        return brAPIDAOUtil.post(brAPIObservationList, upload, api::observationsPost, importDAO::update);
+        var program = programDAO.fetchOneById(programId);
+        Callable<Map<String, BrAPIObservation>> postFunction = null;
+        try {
+            if (!brAPIObservationList.isEmpty()) {
+                postFunction = () -> {
+                    List<BrAPIObservation> postResponse = brAPIDAOUtil.post(brAPIObservationList, upload, api::observationsPost, importDAO::update);
+                    return processObservationsForCache(postResponse, program.getKey());
+                };
+                return programObservationCache.post(programId, postFunction);
+            }
+            return new ArrayList<>();
+        } catch (Exception e) {
+            throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
+        }
     }
 
     public BrAPIObservation updateBrAPIObservation(String dbId, BrAPIObservation observation, UUID programId) throws ApiException {
         ObservationsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ObservationsApi.class);
-        ApiResponse<BrAPIObservationSingleResponse> response;
-        BrAPIObservation updatedObservation = null;
+        var program = programDAO.fetchOneById(programId);
+        Callable<Map<String, BrAPIObservation>> postFunction = null;
+
         try {
-            response = api.observationsObservationDbIdPut(dbId, observation);
-            if (response != null) {
-                BrAPIObservationSingleResponse body = response.getBody();
-                if (body == null) {
-                    throw new ApiException("Response is missing body", 0, response.getHeaders(), null);
-                }
-                updatedObservation = body.getResult();
-                if (updatedObservation == null) {
-                    throw new ApiException("Response body is missing result", 0, response.getHeaders(), response.getBody().toString());
-                }
-            }
+            postFunction = () -> {
+                ApiResponse<BrAPIObservationSingleResponse> response = api.observationsObservationDbIdPut(dbId, observation);
+                    if (response == null)
+                    {
+                        throw new ApiException("Response is null", 0, null, null);
+                    }
+                    BrAPIObservationSingleResponse body = response.getBody();
+                    if (body == null) {
+                        throw new ApiException("Response is missing body", 0, response.getHeaders(), null);
+                    }
+                    BrAPIObservation updatedObservation = body.getResult();
+                    if (updatedObservation == null) {
+                        throw new ApiException("Response body is missing result", 0, response.getHeaders(), response.getBody().toString());
+                    }
+                    return processObservationsForCache(List.of(updatedObservation), program.getKey());
+            };
+            return programObservationCache.post(programId, postFunction).get(0);
         } catch (ApiException e) {
             log.error(Utilities.generateApiExceptionLogMessage(e));
+            throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
+        } catch (Exception e) {
+            throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
         }
-        return updatedObservation;
     }
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
@@ -224,7 +224,7 @@ public class BrAPIObservationUnitDAO {
         String datasetReferenceSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.DATASET);
         return getProgramObservationUnits(program.getId()).values().stream()
                 .filter(ou -> {
-                    Optional<BrAPIExternalReference> exRef = Utilities.getExternalReference(ou.getExternalReferences(), referenceSource + ExternalReferenceSource.DATASET);
+                    Optional<BrAPIExternalReference> exRef = Utilities.getExternalReference(ou.getExternalReferences(), datasetReferenceSource);
                     return exRef.map(brAPIExternalReference -> brAPIExternalReference.getReferenceId().equals(datasetId)).orElse(false);
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
@@ -216,11 +216,7 @@ public class BrAPIObservationUnitDAO {
                 .collect(Collectors.toList());
     }
 
-    public List<BrAPIObservationUnit> getObservationUnitsForTrialDbId(@NotNull UUID programId, @NotNull String trialDbId) throws ApiException, DoesNotExistException {
-        return getObservationUnitsForTrialDbId(programId, trialDbId, false);
-    }
-
-    public List<BrAPIObservationUnit> getObservationUnitsForTrialDbId(@NotNull UUID programId, @NotNull String trialDbId, boolean withGID) throws ApiException, DoesNotExistException {
+    public List<BrAPIObservationUnit> getObservationUnitsForTrialDbId(@NotNull UUID programId, @NotNull String trialDbId) throws ApiException {
         return getProgramObservationUnits(programId).values().stream()
                 .filter(ou -> ou.getTrialDbId().equals(trialDbId))
                 .collect(Collectors.toList());
@@ -236,6 +232,7 @@ public class BrAPIObservationUnitDAO {
                 .collect(Collectors.toList());
     }
 
+    // Note: does not use cache, impractical to implement all search parameters client-side.
     public List<BrAPIObservationUnit> getObservationUnits(Program program,
                                                           Optional<String> observationUnitId,
                                                           Optional<String> observationUnitName,

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
@@ -69,7 +69,7 @@ public class BrAPIObservationUnitDAO {
     private final BrAPIGermplasmService germplasmService;
 
     private final String referenceSource;
-    private boolean runScheduledTasks;
+    private final boolean runScheduledTasks;
 
     private final Gson gson = new JSON().getGson();
     private final Type treatmentlistType = new TypeToken<ArrayList<BrAPIObservationTreatment>>(){}.getType();
@@ -148,7 +148,7 @@ public class BrAPIObservationUnitDAO {
                 .stream()
                 .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.OBSERVATION_UNITS.getName()).equals(reference.getReferenceSource()))
                 .findFirst().orElseThrow(() -> new IllegalStateException("No BI external reference found"));
-            programObservationUnitsMap.put(xref.getReferenceID(), observationUnit);
+            programObservationUnitsMap.put(xref.getReferenceId(), observationUnit);
         }
         return programObservationUnitsMap;
     }
@@ -296,15 +296,15 @@ public class BrAPIObservationUnitDAO {
             //xref search does an OR, so we need to convert the searching for ouId/expId/envId to be an AND
             boolean matches = observationUnitId.map(id -> id.equals(Utilities.getExternalReference(ou.getExternalReferences(), Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.OBSERVATION_UNITS))
                                                                                  .get()
-                                                                                 .getReferenceID()))
+                                                                                 .getReferenceId()))
                                                    .orElse(true);
             matches = matches && experimentId.map(id -> id.equals(Utilities.getExternalReference(ou.getExternalReferences(), Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.TRIALS))
                                                                                    .get()
-                                                                                   .getReferenceID()))
+                                                                                   .getReferenceId()))
                                                      .orElse(true);
             matches = matches && environmentId.map(id -> id.equals(Utilities.getExternalReference(ou.getExternalReferences(), Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.STUDIES))
                                                                              .get()
-                                                                             .getReferenceID()))
+                                                                             .getReferenceId()))
                                                .orElse(true);
 
             //adding filter for germplasmDbId because we can't easily search that in the stored data object
@@ -372,7 +372,7 @@ public class BrAPIObservationUnitDAO {
                     ou.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_UUID,
                                              Utilities.getExternalReference(germplasm.getExternalReferences(), referenceSource)
                                                       .orElseThrow(() -> new IllegalStateException("Germplasm UUID not found"))
-                                                      .getReferenceID());
+                                                      .getReferenceId());
                 }
             }
             ou.setObservationUnitName(Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getObservationUnitName(), program.getKey()));

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
@@ -132,15 +132,12 @@ public class BrAPIObservationUnitDAO {
                 api::searchObservationunitsPost,
                 api::searchObservationunitsSearchResultsDbIdGet,
                 observationUnitSearch
-        ), program);
+        ), program, true);
     }
 
     /**
      * Process a list of observation units for insertion into the cache.
      */
-    private Map<String, BrAPIObservationUnit> processObservationUnitsForCache(List<BrAPIObservationUnit> programObservationUnits, Program program) throws ApiException {
-        return processObservationUnitsForCache(programObservationUnits, program, true);
-    }
     private Map<String, BrAPIObservationUnit> processObservationUnitsForCache(List<BrAPIObservationUnit> programObservationUnits, Program program, boolean withGID) throws ApiException {
         // Process programObservationUnits in place (strip program key, etc.).
         processObservationUnits(program, programObservationUnits, withGID);

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
@@ -98,7 +98,6 @@ public class BrAPIObservationUnitDAO {
         this.programObservationUnitCache = programCacheProvider.getProgramCache(this::fetchProgramObservationUnits, BrAPIObservationUnit.class);
     }
 
-    // TODO: 2s? 3s?
     @Scheduled(initialDelay = "3s")
     public void setup() {
         if(!runScheduledTasks) {

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
@@ -207,6 +207,15 @@ public class BrAPIObservationUnitDAO {
                 .collect(Collectors.toList());
     }
 
+    public List<BrAPIObservationUnit> getObservationUnitsForTrialDbIds(@NotNull UUID programId, List<String> trialDbIds) throws ApiException {
+        if (trialDbIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return getProgramObservationUnits(programId).values().stream()
+                .filter(ou -> trialDbIds.contains(ou.getTrialDbId()))
+                .collect(Collectors.toList());
+    }
+
     public List<BrAPIObservationUnit> getObservationUnitsForTrialDbId(@NotNull UUID programId, @NotNull String trialDbId) throws ApiException, DoesNotExistException {
         return getObservationUnitsForTrialDbId(programId, trialDbId, false);
     }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIStudyDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIStudyDAO.java
@@ -189,7 +189,7 @@ public class BrAPIStudyDAO {
             BrAPIExternalReference xref = environment
                     .getExternalReferences()
                     .stream()
-                    .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.STUDIES).equalsIgnoreCase(reference.getReferenceSource()))
+                    .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.STUDIES.getName()).equals(reference.getReferenceSource()))
                     .findFirst().orElseThrow(() -> new IllegalStateException("No BI external reference found"));
             environmentById.put(xref.getReferenceID(), environment);
         }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -124,7 +124,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
             BrAPIExternalReference xref = experiment
                     .getExternalReferences()
                     .stream()
-                    .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.TRIALS).equalsIgnoreCase(reference.getReferenceSource()))
+                    .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.TRIALS.getName()).equals(reference.getReferenceSource()))
                     .findFirst().orElseThrow(() -> new IllegalStateException("No BI external reference found"));
             experimentById.put(xref.getReferenceID(), experiment);
         }

--- a/src/main/java/org/breedinginsight/daos/ObservationDAO.java
+++ b/src/main/java/org/breedinginsight/daos/ObservationDAO.java
@@ -16,31 +16,31 @@
  */
 package org.breedinginsight.daos;
 
+import io.micronaut.context.annotation.Property;
 import io.micronaut.http.server.exceptions.InternalServerException;
+import io.micronaut.scheduling.annotation.Scheduled;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.BrAPIClient;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.model.queryParams.phenotype.ObservationQueryParams;
 import org.brapi.client.v2.modules.phenotype.ObservationsApi;
-import org.brapi.v2.model.BrAPIAcceptedSearchResponse;
+import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.brapi.v2.model.pheno.request.BrAPIObservationSearchRequest;
 import org.brapi.v2.model.pheno.response.BrAPIObservationListResponse;
-import org.breedinginsight.services.brapi.BrAPIClientType;
+import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.daos.cache.ProgramCache;
+import org.breedinginsight.daos.cache.ProgramCacheProvider;
+import org.breedinginsight.model.Program;
 import org.breedinginsight.services.brapi.BrAPIEndpointProvider;
-import org.breedinginsight.services.brapi.BrAPIProvider;
 import org.breedinginsight.utilities.BrAPIDAOUtil;
 import org.breedinginsight.utilities.Utilities;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
-import static org.brapi.v2.model.BrAPIWSMIMEDataTypes.APPLICATION_JSON;
+import java.util.*;
+import java.util.stream.Collectors;
 
 
 @Singleton
@@ -49,12 +49,84 @@ public class ObservationDAO {
     private final BrAPIDAOUtil brAPIDAOUtil;
     private ProgramDAO programDAO;
     private final BrAPIEndpointProvider brAPIEndpointProvider;
+    private final String referenceSource;
+    private boolean runScheduledTasks;
+    private final ProgramCache<BrAPIObservation> programObservationCache;
 
     @Inject
-    public ObservationDAO(BrAPIDAOUtil brAPIDAOUtil, ProgramDAO programDAO, BrAPIEndpointProvider brAPIEndpointProvider) {
+    public ObservationDAO(BrAPIDAOUtil brAPIDAOUtil,
+                          ProgramDAO programDAO,
+                          BrAPIEndpointProvider brAPIEndpointProvider,
+                          @Property(name = "brapi.server.reference-source") String referenceSource,
+                          @Property(name = "micronaut.bi.api.run-scheduled-tasks") boolean runScheduledTasks,
+                          ProgramCacheProvider programCacheProvider) {
         this.brAPIDAOUtil = brAPIDAOUtil;
         this.programDAO = programDAO;
         this.brAPIEndpointProvider = brAPIEndpointProvider;
+        this.referenceSource = referenceSource;
+        this.runScheduledTasks = runScheduledTasks;
+        this.programObservationCache = programCacheProvider.getProgramCache(this::fetchProgramObservations, BrAPIObservation.class);
+    }
+
+    @Scheduled(initialDelay = "2s")
+    public void setup() {
+        if(!runScheduledTasks) {
+            return;
+        }
+        // Populate the observation cache for all programs on startup.
+        log.debug("populating observation cache");
+        List<Program> programs = programDAO.getActive();
+        if (programs != null) {
+            programObservationCache.populate(programs.stream().map(Program::getId).collect(Collectors.toList()));
+        }
+    }
+
+    /**
+     * Fetch formatted observation for this program.
+     * @param programId
+     * @return Map<Key = string representing observation UUID, value = formatted BrAPIObservation>
+     * @throws ApiException
+     */
+    private Map<String, BrAPIObservation> fetchProgramObservations(UUID programId) throws ApiException {
+        ObservationsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ObservationsApi.class);
+        // Get the program key.
+        List<Program> programs = programDAO.get(programId);
+        if (programs.size() != 1) {
+            throw new InternalServerException("Program was not found for given key");
+        }
+        Program program = programs.get(0);
+
+        // Set query params and make call.
+        BrAPIObservationSearchRequest observationSearch = new BrAPIObservationSearchRequest();
+        observationSearch.externalReferenceIds(List.of(programId.toString()));
+        observationSearch.externalReferenceSources(List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS)));
+        return processObservationsForCache(brAPIDAOUtil.search(
+                api::searchObservationsPost,
+                api::searchObservationsSearchResultsDbIdGet,
+                observationSearch
+        ), program.getKey());
+    }
+
+    // TODO: use program key, strip from observationUnitName, etc.
+    /**
+     * Process a list of observations for insertion into the cache.
+     * @param programObservations
+     * @param programKey
+     * @return
+     */
+    private Map<String, BrAPIObservation> processObservationsForCache(List<BrAPIObservation> programObservations, String programKey) {
+        // Build map.
+        Map<String, BrAPIObservation> programObservationsMap = new HashMap<>();
+        log.trace("processing observationUnits for cache: " + programObservations);
+        for (BrAPIObservation observation: programObservations) {
+            BrAPIExternalReference xref = observation
+                    .getExternalReferences()
+                    .stream()
+                    .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.OBSERVATIONS.getName()).equals(reference.getReferenceSource()))
+                    .findFirst().orElseThrow(() -> new IllegalStateException("No BI external reference found"));
+            programObservationsMap.put(xref.getReferenceID(), observation);
+        }
+        return programObservationsMap;
     }
 
     public List<BrAPIObservation> getObservationsByVariableDbId(String observationVariableDbId, UUID programId) {

--- a/src/main/java/org/breedinginsight/daos/ObservationDAO.java
+++ b/src/main/java/org/breedinginsight/daos/ObservationDAO.java
@@ -16,31 +16,25 @@
  */
 package org.breedinginsight.daos;
 
-import io.micronaut.context.annotation.Property;
 import io.micronaut.http.server.exceptions.InternalServerException;
-import io.micronaut.scheduling.annotation.Scheduled;
 import lombok.extern.slf4j.Slf4j;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.BrAPIClient;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.model.queryParams.phenotype.ObservationQueryParams;
 import org.brapi.client.v2.modules.phenotype.ObservationsApi;
-import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.brapi.v2.model.pheno.request.BrAPIObservationSearchRequest;
 import org.brapi.v2.model.pheno.response.BrAPIObservationListResponse;
-import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
-import org.breedinginsight.daos.cache.ProgramCache;
-import org.breedinginsight.daos.cache.ProgramCacheProvider;
-import org.breedinginsight.model.Program;
 import org.breedinginsight.services.brapi.BrAPIEndpointProvider;
 import org.breedinginsight.utilities.BrAPIDAOUtil;
 import org.breedinginsight.utilities.Utilities;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 
 @Singleton

--- a/src/main/java/org/breedinginsight/utilities/FileUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/FileUtil.java
@@ -199,7 +199,7 @@ public class FileUtil {
                                     .builderFromString(jsonString)
                                     .columnTypesToDetect(List.of(ColumnType.STRING))
                     );
-        } catch (IOException e) {
+        } catch (Exception e) {
             log.debug(e.getMessage());
             throw new ParsingException(ParsingExceptionType.ERROR_READING_FILE);
         }

--- a/src/main/java/org/breedinginsight/utilities/FileUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/FileUtil.java
@@ -192,12 +192,17 @@ public class FileUtil {
     }
 
     public static Table parseTableFromJson(String jsonString) throws ParsingException {
+        try {
             return Table.read()
                     .usingOptions(
                             JsonReadOptions
                                     .builderFromString(jsonString)
                                     .columnTypesToDetect(List.of(ColumnType.STRING))
                     );
+        } catch (IOException e) {
+            log.debug(e.getMessage());
+            throw new ParsingException(ParsingExceptionType.ERROR_READING_FILE);
+        }
     }
 
     public static Table removeNullRows(Table table) {


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2058

Added Observations and ObservationUnits to the redis cache. They are eagerly fetched on application startup just like the other entities we cache. 

All the methods that **write** Observations or ObservationUnits have been modified to repopulate the cache, which is essential for reading one's own writes. 

Most of the methods that **read** Observations and Observation units have been modified to read from the cache.
>A few read methods still make BrAPI calls because it would be impractical to use the cache. For example, I did not update `BrAPIObservationUnitDAO::getObservationUnits` because some of the search parameters would be expensive to implement client-side (compared to SQL joins), notably the `seasonDbId` parameter, which is not directly on the `ObservationUnit` object.

Also, calling `ProgramCache::post` with a null `postFunction` would result in a NPE, I prevented this possibility, see [this commit](https://github.com/Breeding-Insight/bi-api/pull/339/commits/6a631d0b11f17d0a925197cbbe68b57c8d3c8e55).

# Dependencies

bi-web develop branch

# Testing

Ensure experiment upload, view, and download (file export) workflows work as expected.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
