### PR TITLE
BI-2053-fix - Handled Trait Form Submission Code Path

### DIFF
--- a/src/main/java/org/breedinginsight/services/TraitService.java
+++ b/src/main/java/org/breedinginsight/services/TraitService.java
@@ -43,6 +43,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.*;
 import java.util.stream.Collectors;
+import org.breedinginsight.utilities.Utilities;
 
 @Slf4j
 @Singleton
@@ -256,20 +257,26 @@ public class TraitService {
 
     public void preprocessTraits(List<Trait> traits) {
 
-        // Set data type to numerical when method class is computation and include name and full name as synonyms
         for (Trait trait: traits) {
             List<String> brApiSynonyms = trait.getSynonyms() == null ? new ArrayList<>() : trait.getSynonyms();
+            // Include name and full name as synonyms.
             if (trait.getObservationVariableName() != null && !brApiSynonyms.contains(trait.getObservationVariableName())) {
                 brApiSynonyms.add(trait.getObservationVariableName());
             }
             if (trait.getFullName() != null && !brApiSynonyms.contains(trait.getFullName())) {
                 brApiSynonyms.add(trait.getFullName());
             }
-            if (trait.getMethod() != null && trait.getMethod().getMethodClass() != null &&
-                trait.getMethod().getMethodClass().equalsIgnoreCase(Method.COMPUTATION_TYPE)) {
-                if (trait.getScale() != null) {
+
+            if (trait.getScale() != null) {
+                // Set data type to numerical when method class is computation.
+                if (trait.getMethod() != null && trait.getMethod().getMethodClass() != null &&
+                        trait.getMethod().getMethodClass().equalsIgnoreCase(Method.COMPUTATION_TYPE)) {
                     trait.getScale().setDataType(DataType.NUMERICAL);
                 }
+                // Set scaleName to units, fallback to scale class if units is null.
+                String units = trait.getScale().getUnits();
+                String dataType = trait.getScale().getDataType() == null ? null : Utilities.capitalize(trait.getScale().getDataType().getLiteral());
+                trait.getScale().setScaleName(units == null ? dataType : units);
             }
         }
 

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
@@ -63,12 +63,12 @@ public class TraitValidatorService {
                 ValidationError error = traitValidatorErrors.getMissingScaleMsg();
                 errors.addError(traitValidatorErrors.getRowNumber(i), error);
             } else {
-                if (scale.getDataType() != null & scale.getDataType() == DataType.NUMERICAL &&
+                if (scale.getDataType() != null && scale.getDataType() == DataType.NUMERICAL &&
                         (isBlank(scale.getUnits()))) {
                     ValidationError error = traitValidatorErrors.getMissingScaleUnitMsg();
                     errors.addError(traitValidatorErrors.getRowNumber(i), error);
                 }
-                if (scale.getDataType() == null || scale.getDataType() == null) {
+                if (scale.getDataType() == null) {
                     ValidationError error = traitValidatorErrors.getMissingScaleDataTypeMsg();
                     errors.addError(traitValidatorErrors.getRowNumber(i), error);
                 }

--- a/src/main/java/org/breedinginsight/utilities/Utilities.java
+++ b/src/main/java/org/breedinginsight/utilities/Utilities.java
@@ -247,6 +247,14 @@ public class Utilities {
         return programs;
     }
 
+    /**
+     * Returns the input string with the first character capitalized, the rest lower cased.
+     * Note: does not account for whitespace, does not capitalize multiple words.
+     */
+    public static String capitalize(String input) {
+        return input.substring(0, 1).toUpperCase() + input.substring(1).toLowerCase();
+    }
+
     private static boolean isSafeChar(char c) {
         // Check if c is in the portable filename character set.
         // See https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282

--- a/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/TraitControllerIntegrationTest.java
@@ -62,6 +62,7 @@ import org.breedinginsight.daos.cache.ProgramCache;
 import org.breedinginsight.daos.cache.ProgramCacheProvider;
 import org.breedinginsight.model.*;
 import org.breedinginsight.services.SpeciesService;
+import org.breedinginsight.utilities.Utilities;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.*;
 import org.mockito.stubbing.Answer;
@@ -455,7 +456,8 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         String methodName = String.format("%s %s", trait1.getMethod().getDescription(), trait1.getMethod().getMethodClass());
         assertEquals(String.format("%s [%s]", methodName, validProgramKey),
                 variable.getMethod().getMethodName(), "Unexpected method name");
-        assertEquals(String.format("%s [%s]", trait1.getScale().getScaleName(), validProgramKey),
+        String expectedScaleName = trait1.getScale().getUnits() == null ? Utilities.capitalize(trait1.getScale().getDataType().getLiteral()) : trait1.getScale().getUnits();
+        assertEquals(String.format("%s [%s]", expectedScaleName, validProgramKey),
                 variable.getScale().getScaleName(), "Unexpected scale name");
         String traitName = String.format("%s %s", trait1.getEntity(), trait1.getAttribute());
         assertEquals(String.format("%s [%s]", traitName, validProgramKey),
@@ -484,7 +486,8 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         methodName = String.format("%s %s", trait1.getMethod().getDescription(), trait1.getMethod().getMethodClass());
         assertEquals(String.format("%s [%s]", methodName, validProgramKey),
                 variable.getMethod().getMethodName(), "Unexpected method name");
-        assertEquals(String.format("%s [%s]", trait1.getScale().getScaleName(), validProgramKey),
+        expectedScaleName = trait1.getScale().getUnits() == null ? Utilities.capitalize(trait1.getScale().getDataType().getLiteral()) : trait1.getScale().getUnits();
+        assertEquals(String.format("%s [%s]", expectedScaleName, validProgramKey),
                 variable.getScale().getScaleName(), "Unexpected scale name");
         traitName = String.format("%s %s", trait1.getEntity(), trait1.getAttribute());
         assertEquals(String.format("%s [%s]", traitName, validProgramKey),
@@ -1060,7 +1063,8 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         }
 
         JsonObject scale = traitJson.getAsJsonObject("scale");
-        assertEquals(trait.getScale().getScaleName(), scale.get("scaleName").getAsString(), "Scale names don't match");
+        String expectedScaleName = trait.getScale().getUnits() == null ? Utilities.capitalize(trait.getScale().getDataType().getLiteral()) : trait.getScale().getUnits();
+        assertEquals(expectedScaleName, scale.get("scaleName").getAsString(), "Scale names don't match");
         assertEquals(trait.getScale().getDataType().toString(), scale.get("dataType").getAsString(), "Scale data types don't match");
 
         JsonObject programOntology = traitJson.getAsJsonObject("programOntology");
@@ -1433,7 +1437,8 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         assertEquals(updateTrait.getObservationVariableName(), trait.get("observationVariableName").getAsString(), "wrong trait name");
         assertEquals(updateTrait.getProgramObservationLevel().getName(),
                 trait.get("programObservationLevel").getAsJsonObject().get("name").getAsString(), "wrong observation level");
-        assertEquals(updateTrait.getScale().getScaleName(),
+        String expectedScaleName = updateTrait.getScale().getUnits() == null ? Utilities.capitalize(updateTrait.getScale().getDataType().getLiteral()) : updateTrait.getScale().getUnits();
+        assertEquals(expectedScaleName,
                 trait.get("scale").getAsJsonObject().get("scaleName").getAsString(), "wrong scale name");
         assertEquals(updateTrait.getScale().getDataType().toString(),
                 trait.get("scale").getAsJsonObject().get("dataType").getAsString(), "wrong scale data type");
@@ -1589,9 +1594,5 @@ public class TraitControllerIntegrationTest extends BrAPITest {
         assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
 
     }
-
-
-
-
 
 }


### PR DESCRIPTION
# Description

Story: https://breedinginsight.atlassian.net/browse/BI-2053

These changes should have been done along with https://github.com/Breeding-Insight/bi-api/pull/331, but I missed the workflow where a user creates ontology terms one at a time by submitting the form on the DeltaBreed GUI. Please see [that original PR](https://github.com/Breeding-Insight/bi-api/pull/331#issue-2134480429) for rationale.

Corresponding PR on bi-web: https://github.com/Breeding-Insight/bi-api/pull/342.

# Dependencies

bi-web branch: `bug/BI-2053-fix`

# Testing

Ensure that traits of all types (Date, Ordinal, Nominal, Numerical, Text) can be created via form submission on the DeltaBreed GUI.


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
