### PR TITLE
BI-1680 - Added Migration That Removes "Somoclone" Breeding Method

### DIFF
--- a/src/main/resources/db/migration/V1.20.0__remove_breeding_method.sql
+++ b/src/main/resources/db/migration/V1.20.0__remove_breeding_method.sql
@@ -1,0 +1,23 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+DO $$
+
+BEGIN
+    DELETE FROM breeding_method
+    WHERE abbreviation = 'SOC' AND name = 'Somoclone';
+END $$;

--- a/src/main/resources/db/migration/V1.20.0__remove_breeding_method.sql
+++ b/src/main/resources/db/migration/V1.20.0__remove_breeding_method.sql
@@ -18,6 +18,10 @@
 DO $$
 
 BEGIN
+    -- Delete any rows with FK.
+    DELETE FROM program_enabled_breeding_methods
+    WHERE breeding_method_id = (SELECT id FROM breeding_method WHERE abbreviation = 'SOC' AND name = 'Somoclone');
+    -- Delete breeding method.
     DELETE FROM breeding_method
     WHERE abbreviation = 'SOC' AND name = 'Somoclone';
 END $$;


### PR DESCRIPTION
# Description
**Story:** [BI-1680](https://breedinginsight.atlassian.net/browse/BI-1680)

Per the **Desired Behavior** section of the Jira story, I added a migration to remove the "Somoclone" breeding method from the system preset breeding methods.

This [bi-web PR](https://github.com/Breeding-Insight/bi-web/pull/370) takes care of updating the import template.

# Dependencies
bi-web branch: `feature/BI-1680`.
# Testing
1. Checkout this branch, `git checkout feature/BI-1680`.
2. Run bi-api.
3. Ensure that the new migration ran (V1.20.0) by checking the bidb database, `SELECT * FROM flyway_schema_history;`.
4. Ensure that the "Somoclone" breeding method is not listed in the DeltaBreed UI, under **Program Administration > Breeding Methods**.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-1680]: https://breedinginsight.atlassian.net/browse/BI-1680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ