### PR TITLE
[hotfix] - updated application.properties

### DIFF
--- a/src/main/resources/brapi/properties/application.properties
+++ b/src/main/resources/brapi/properties/application.properties
@@ -25,7 +25,7 @@ spring.datasource.password=${BRAPI_DB_PASSWORD}
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-spring.flyway.locations=classpath:db/migration,classpath:db/sql,classpath:org/brapi/test/BrAPITestServer/db/migration
+spring.flyway.locations=classpath:db/migration,classpath:org/brapi/test/BrAPITestServer/db/migration
 spring.flyway.schemas=public
 spring.flyway.baselineOnMigrate=true
 


### PR DESCRIPTION
For the application.properties that is bind-mounted into brapi-server, I updated
`spring.flyway.locations=classpath:db/migration,classpath:db/sql,classpath:org/brapi/test/BrAPITestServer/db/migration`
to
`spring.flyway.locations=classpath:db/migration,classpath:org/brapi/test/BrAPITestServer/db/migration`.

It was necessary to remove the `classpath:db/sql` directory, because the SQL in that directory is seed data for dev/test and shouldn't be deployed.
