### PR TITLE
[BI-2104] Can't create experiment with timestamped observations

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -1175,7 +1175,10 @@ public class ExperimentProcessor implements Processor {
     }
 
     boolean isTimestampMatched(String observationHash, String timeStamp) {
-        OffsetDateTime priorStamp = existingObsByObsHash.get(observationHash).getObservationTimeStamp();
+        OffsetDateTime priorStamp = null;
+        if(existingObsByObsHash.get(observationHash)!=null){
+            priorStamp = existingObsByObsHash.get(observationHash).getObservationTimeStamp();
+        }
         if (priorStamp == null) {
             return timeStamp == null;
         }


### PR DESCRIPTION
# Description
[BI-2104](https://breedinginsight.atlassian.net/browse/BI-2104) - Can't create experiment with timestamped observations v0.9

There was a null pointer exception thrown in ExperimentProcessor.java at the line:
`priorStamp = existingObsByObsHash.get(observationHash).getObservationTimeStamp()`


# Testing
Import a new experiment with observations (least one observation will need to have an associated time-stamp)

**Expected Result**
* Experiment should import sucessfully.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2104]: https://breedinginsight.atlassian.net/browse/BI-2104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ