### PR TITLE
BI-2127 Position Information missing from exp download file

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -471,9 +471,15 @@ public class BrAPITrialService {
 
         // Lat, Long, Elevation
         Coordinates coordinates = extractCoordinates(ou);
-        row.put( ExperimentObservation.Columns.LAT, coordinates==null? null : doubleToString(coordinates.getLat()) );
-        row.put( ExperimentObservation.Columns.LONG, coordinates==null? null : doubleToString(coordinates.getLon()) );
-        row.put( ExperimentObservation.Columns.ELEVATION, coordinates==null? null : doubleToString(coordinates.getAlt()) );
+        Optional.ofNullable(coordinates)
+                .map(c -> doubleToString(c.getLat()))
+                .ifPresent(lat -> row.put(ExperimentObservation.Columns.LAT, lat));
+        Optional.ofNullable(coordinates)
+                .map(c -> doubleToString(c.getLon()))
+                .ifPresent(lon -> row.put(ExperimentObservation.Columns.LONG, lon));
+        Optional.ofNullable(coordinates)
+                .map(c -> doubleToString(c.getAlt()))
+                .ifPresent(elevation -> row.put(ExperimentObservation.Columns.ELEVATION, elevation));
 
         // RTK
         JsonObject additionalInfo = ou.getAdditionalInfo();

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -471,9 +471,9 @@ public class BrAPITrialService {
 
         // Lat, Long, Elevation
         Coordinates coordinates = extractCoordinates(ou);
-        row.put( ExperimentObservation.Columns.LAT, coordinates==null? null : String.valueOf(coordinates.getLat()) );
-        row.put( ExperimentObservation.Columns.LONG, coordinates==null? null : String.valueOf(coordinates.getLon()) );
-        row.put( ExperimentObservation.Columns.ELEVATION, coordinates==null? null : String.valueOf(coordinates.getAlt()) );
+        row.put( ExperimentObservation.Columns.LAT, coordinates==null? null : doubleToString(coordinates.getLat()) );
+        row.put( ExperimentObservation.Columns.LONG, coordinates==null? null : doubleToString(coordinates.getLon()) );
+        row.put( ExperimentObservation.Columns.ELEVATION, coordinates==null? null : doubleToString(coordinates.getAlt()) );
 
         // RTK
         JsonObject additionalInfo = ou.getAdditionalInfo();
@@ -518,6 +518,9 @@ public class BrAPITrialService {
         return row;
     }
 
+    private String doubleToString(double val){
+        return Double.isNaN(val) ? null : String.valueOf( val );
+    }
     private Coordinates extractCoordinates(BrAPIObservationUnit ou){
         Coordinates coordinates = null;
         if (        ou.getObservationUnitPosition()!=null


### PR DESCRIPTION
# Description
[BI-2127](https://breedinginsight.atlassian.net/browse/BI-2127) Position Information missing from exp download file

There were 2 separate problems:

1. The `row` and `column` fields would only populate if there was data for both `row` **and** `column`.  If a record only had data for `row` but not `column` or If a record only had data for `column` but not `row`, then the data for neither `row` or `column`would appear for that record.
2. The data for `Lat`, 'Long`, `Elevation`, and `RTK` was not being added to the download spreadsheet.

# Testing

1. Import an experiment with `row` data but not `column` data.
2. Import an experiment with `column` data but not `row` data.
3. In the above two import files, include data for `Lat`, 'Long`, `Elevation`, and `RTK` 
4. Download the experiments

**EXPECTED RESULTS**
The download data should match the import data.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2127]: https://breedinginsight.atlassian.net/browse/BI-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ