### PR TITLE
Bug/bi 2093 - (Performance) Observation Cache Refreshing After Every PUT During Overwrite

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -277,6 +277,9 @@ public class BrAPIObservationDAO {
         }
     }
 
+    // This method overloads updateBrAPIObservation(String dbId, BrAPIObservation observation, UUID programId)
+    // It was added to increase efficiency.  It insures that ProgramCache<BrAPIObservation>.populate() is called only once
+    // not once per observation.
     public void updateBrAPIObservation(Map<String, BrAPIObservation> mutatedObservationByDbId, UUID programId) throws ApiException {
         ObservationsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ObservationsApi.class);
         var program = programDAO.fetchOneById(programId);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -423,7 +423,6 @@ public class ExperimentProcessor implements Processor {
                 obsVarIds.addAll(newObsVarIds);
                 dataset.setData(obsVarIds);
                 brAPIListDAO.updateBrAPIList(id, dataset, program.getId());
-               // Map<String, BrAPIObservation> updatedObservationByDbId = brAPIObservationDAO.updateBrAPIObservation( mutatedObservationByDbId, program.getId() );
             } catch (ApiException e) {
                 log.error("Error updating dataset observation variables: " + Utilities.generateApiExceptionLogMessage(e), e);
                 throw new InternalServerException("Error saving experiment import", e);

--- a/src/main/java/org/breedinginsight/daos/cache/ProgramCache.java
+++ b/src/main/java/org/breedinginsight/daos/cache/ProgramCache.java
@@ -169,6 +169,11 @@ public class ProgramCache<R> {
 
     public List<R> post(UUID key, Callable<Map<String, R>> postMethod) throws Exception {
         log.debug("posting for key: " + generateCacheKey(key));
+        Map<String, R> response = post_map(key,postMethod);
+        return new ArrayList<>(response.values());
+    }
+    public Map<String, R> post_map(UUID key, Callable<Map<String, R>> postMethod) throws Exception {
+        log.debug("posting for key: " + generateCacheKey(key));
         Map<String, R> response = null;
         try {
             response = postMethod.call();
@@ -181,14 +186,13 @@ public class ProgramCache<R> {
             }
             populate(key);
 
-            return new ArrayList<>(response.values());
+            return response;
         } catch (Exception e) {
             log.error("Error posting data and populating the cache", e);
             invalidate(key);
             throw e;
         }
     }
-
     public boolean isRefreshing(UUID key) {
         RAtomicLong isRefreshing = connection.getAtomicLong(generateCacheKey(key) + ":refreshing");
 

--- a/src/main/java/org/breedinginsight/daos/cache/ProgramCache.java
+++ b/src/main/java/org/breedinginsight/daos/cache/ProgramCache.java
@@ -169,11 +169,6 @@ public class ProgramCache<R> {
 
     public List<R> post(UUID key, Callable<Map<String, R>> postMethod) throws Exception {
         log.debug("posting for key: " + generateCacheKey(key));
-        Map<String, R> response = post_map(key,postMethod);
-        return new ArrayList<>(response.values());
-    }
-    public Map<String, R> post_map(UUID key, Callable<Map<String, R>> postMethod) throws Exception {
-        log.debug("posting for key: " + generateCacheKey(key));
         Map<String, R> response = null;
         try {
             response = postMethod.call();
@@ -186,13 +181,14 @@ public class ProgramCache<R> {
             }
             populate(key);
 
-            return response;
+            return new ArrayList<>(response.values());
         } catch (Exception e) {
             log.error("Error posting data and populating the cache", e);
             invalidate(key);
             throw e;
         }
     }
+
     public boolean isRefreshing(UUID key) {
         RAtomicLong isRefreshing = connection.getAtomicLong(generateCacheKey(key) + ":refreshing");
 


### PR DESCRIPTION
# Description
[Bug/bi 2093](https://breedinginsight.atlassian.net/browse/BI-2093) - (Performance) Observation Cache Refreshing After Every PUT During Overwrite

Modified code so ProgramCache<BrAPIObservation>.populate() is called only once (instead of once per updated observation as it was doing.)


# Dependencies
bi-web: develop

# Testing

- Use Wireshark to track activity between bapi and the Java BrAPI Test Server (JBTS) while overwriting an experiment's observations [ I used the filter `http && tcp.port == 8083 && http.request.method == POST`   where `8083` was the port on which JBTS is running. ]

- Import an _Experiment & Observation_ file that overwrites observations

 **EXPECTED RESULT**
The http `POST /brapi/v2/search/observations HTTP/1.1 , JSON (application/json)` should be sent once.
**ACTUAL RESULT**
The http `POST /brapi/v2/search/observations HTTP/1.1 , JSON (application/json)` was sent once per overwritten observation.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
