### PR TITLE
BI-1975 - "Unknown" Breeding Method not recognized

### DIFF
--- a/src/main/resources/db/migration/V1.23.0__change_unk_breeding_method_class.sql
+++ b/src/main/resources/db/migration/V1.23.0__change_unk_breeding_method_class.sql
@@ -1,0 +1,18 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+update breeding_method set category = 'Increase' where abbreviation = 'UNK';


### PR DESCRIPTION
# Description
**Story:** [BI-1975](https://breedinginsight.atlassian.net/browse/BI-1975?atlOrigin=eyJpIjoiYTBhNTAxNTMzZWI2NDk0YmI0ZDM4Yjg1ODY5ODVmMTUiLCJwIjoiaiJ9)

- Added db migration to change UNK breeding method class to Increase

# Dependencies
- bi-web bug/BI-1975

# Testing
- Germplasm import accepts UNK and Unknown breeding methods for germplasm records
- Breeding methods in program administration page shows Increase for the UNK method class


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
