### PR TITLE
Bug/bi 2126

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -301,13 +301,13 @@ public class BrAPITrialService {
         log.debug("fetching observationUnits for dataset: " + datasetId);
         List<BrAPIObservationUnit> datasetOUs = ouDAO.getObservationUnitsForDataset(datasetId.toString(), program);
 
-        //Add years to addition_data elements
-        Map<String, Integer> studyDbId2Year = new HashMap<>();
+        //Add years to the addition_data elements
+        Map<String, Integer> studyDbId2Year = new HashMap<>();  // used to prevent the same study from being fetched repeatedly.
         for (BrAPIObservationUnit ou: datasetOUs
                      ) {
             String studyDbId = ou.getStudyDbId();
             if( !studyDbId2Year.containsKey( studyDbId)) {
-
+                // Get the Study and extract the year from its Season
                 BrAPIStudy study = studyDAO.getStudyByDbId(studyDbId, program).orElseThrow(() -> new DoesNotExistException(String.format("Study Id '%s' not found.", studyDbId)));
                 String seasonId = study.getSeasons().get(0);
                 BrAPISeason season = seasonDAO.getSeasonById(seasonId, program.getId());


### PR DESCRIPTION
# Description
[BI-2126](https://breedinginsight.atlassian.net/browse/BI-2126) Env year missing from dataset view

Now the Env Year is fetched on the back-end and passed to the front-end in the _additional_Info_ element of each Observation Unit.


# Dependencies
bi-api: bug/BI-2126 branch

# Testing

1. Vew any experiment.
EXPECTED RESULT
* The correct Env Year should be displayed for each Observation Unit.
# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2126]: https://breedinginsight.atlassian.net/browse/BI-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ