### PR TITLE
BI-2257 - Experimental Collaborator DAO and Services for experimental_program_user_role

### DIFF
--- a/src/main/java/org/breedinginsight/daos/ExperimentalCollaboratorDAO.java
+++ b/src/main/java/org/breedinginsight/daos/ExperimentalCollaboratorDAO.java
@@ -19,11 +19,17 @@ package org.breedinginsight.daos;
 
 import lombok.extern.slf4j.Slf4j;
 import org.breedinginsight.dao.db.tables.daos.ExperimentProgramUserRoleDao;
+import org.breedinginsight.dao.db.tables.pojos.ExperimentProgramUserRoleEntity;
 import org.jooq.Configuration;
 import org.jooq.DSLContext;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.breedinginsight.dao.db.Tables.EXPERIMENT_PROGRAM_USER_ROLE;
 
 @Slf4j
 @Singleton
@@ -35,5 +41,23 @@ public class ExperimentalCollaboratorDAO extends ExperimentProgramUserRoleDao {
     public ExperimentalCollaboratorDAO(Configuration config, DSLContext dsl) {
         super(config);
         this.dsl = dsl;
+    }
+
+    public ExperimentProgramUserRoleEntity create(UUID experimentId, UUID programUserRoleId, UUID userId) {
+        return dsl.insertInto(EXPERIMENT_PROGRAM_USER_ROLE)
+                .columns(EXPERIMENT_PROGRAM_USER_ROLE.EXPERIMENT_ID,
+                        EXPERIMENT_PROGRAM_USER_ROLE.PROGRAM_USER_ROLE_ID,
+                        EXPERIMENT_PROGRAM_USER_ROLE.CREATED_BY,
+                        EXPERIMENT_PROGRAM_USER_ROLE.CREATED_AT,
+                        EXPERIMENT_PROGRAM_USER_ROLE.UPDATED_BY,
+                        EXPERIMENT_PROGRAM_USER_ROLE.UPDATED_AT)
+                .values(experimentId,
+                        programUserRoleId,
+                        userId,
+                        OffsetDateTime.now(),
+                        userId,
+                        OffsetDateTime.now())
+                .returning(EXPERIMENT_PROGRAM_USER_ROLE.fields())
+                .fetchOneInto(ExperimentProgramUserRoleEntity.class);
     }
 }

--- a/src/main/java/org/breedinginsight/daos/ProgramUserDAO.java
+++ b/src/main/java/org/breedinginsight/daos/ProgramUserDAO.java
@@ -201,6 +201,7 @@ public class ProgramUserDAO extends ProgramUserRoleDao {
 
         Result<Record> records = getProgramUsersQuery(createdByUser, updatedByUser)
                 .where(PROGRAM.ACTIVE.eq(true))
+                .and(PROGRAM_USER_ROLE.ACTIVE.eq(true))
                 .and(PROGRAM.ID.eq(programId))
                 .and(ROLE.ID.eq(roleId))
                 .fetch();

--- a/src/main/java/org/breedinginsight/daos/ProgramUserDAO.java
+++ b/src/main/java/org/breedinginsight/daos/ProgramUserDAO.java
@@ -194,4 +194,17 @@ public class ProgramUserDAO extends ProgramUserRoleDao {
 
         return resultProgramsUsers;
     }
+
+    public List<ProgramUser> getProgramUsersByRole(UUID programId, UUID roleId) {
+        BiUserTable createdByUser = BI_USER.as("createdByUser");
+        BiUserTable updatedByUser = BI_USER.as("updatedByUser");
+
+        Result<Record> records = getProgramUsersQuery(createdByUser, updatedByUser)
+                .where(PROGRAM.ACTIVE.eq(true))
+                .and(PROGRAM.ID.eq(programId))
+                .and(ROLE.ID.eq(roleId))
+                .fetch();
+
+        return parseRecords(records, createdByUser, updatedByUser);
+    }
 }

--- a/src/main/java/org/breedinginsight/services/ExperimentalCollaboratorService.java
+++ b/src/main/java/org/breedinginsight/services/ExperimentalCollaboratorService.java
@@ -18,17 +18,36 @@
 package org.breedinginsight.services;
 
 import lombok.extern.slf4j.Slf4j;
+import org.breedinginsight.dao.db.tables.pojos.ExperimentProgramUserRoleEntity;
 import org.breedinginsight.daos.ExperimentalCollaboratorDAO;
 
 import javax.inject.Inject;
+import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 public class ExperimentalCollaboratorService {
 
     private final ExperimentalCollaboratorDAO experimentalCollaboratorDAO;
+    private final ProgramUserService programUserService;
 
     @Inject
-    public ExperimentalCollaboratorService(ExperimentalCollaboratorDAO experimentalCollaboratorDAO) {
+    public ExperimentalCollaboratorService(ExperimentalCollaboratorDAO experimentalCollaboratorDAO, ProgramUserService programUserService) {
         this.experimentalCollaboratorDAO = experimentalCollaboratorDAO;
+        this.programUserService = programUserService;
+    }
+
+    public ExperimentProgramUserRoleEntity createExperimentalCollaborator(UUID programUserRoleId, UUID experimentId, UUID userId) {
+        return this.experimentalCollaboratorDAO.create(experimentId, programUserRoleId, userId);
+    }
+
+    public List<ExperimentProgramUserRoleEntity> getExperimentalCollaborators(UUID experimentId) {
+        // Get all collaborators for an experiment.
+        return this.experimentalCollaboratorDAO.fetchByExperimentId(experimentId);
+    }
+
+    public void deleteExperimentalCollaborator(UUID collaboratorId) {
+        // Note: collaboratorId is the PK of the experiment_program_user_role table.
+        this.experimentalCollaboratorDAO.deleteById(collaboratorId);
     }
 }

--- a/src/main/java/org/breedinginsight/services/ExperimentalCollaboratorService.java
+++ b/src/main/java/org/breedinginsight/services/ExperimentalCollaboratorService.java
@@ -22,10 +22,12 @@ import org.breedinginsight.dao.db.tables.pojos.ExperimentProgramUserRoleEntity;
 import org.breedinginsight.daos.ExperimentalCollaboratorDAO;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.List;
 import java.util.UUID;
 
 @Slf4j
+@Singleton
 public class ExperimentalCollaboratorService {
 
     private final ExperimentalCollaboratorDAO experimentalCollaboratorDAO;

--- a/src/main/java/org/breedinginsight/services/ExperimentalCollaboratorService.java
+++ b/src/main/java/org/breedinginsight/services/ExperimentalCollaboratorService.java
@@ -31,12 +31,10 @@ import java.util.UUID;
 public class ExperimentalCollaboratorService {
 
     private final ExperimentalCollaboratorDAO experimentalCollaboratorDAO;
-    private final ProgramUserService programUserService;
 
     @Inject
-    public ExperimentalCollaboratorService(ExperimentalCollaboratorDAO experimentalCollaboratorDAO, ProgramUserService programUserService) {
+    public ExperimentalCollaboratorService(ExperimentalCollaboratorDAO experimentalCollaboratorDAO) {
         this.experimentalCollaboratorDAO = experimentalCollaboratorDAO;
-        this.programUserService = programUserService;
     }
 
     public ExperimentProgramUserRoleEntity createExperimentalCollaborator(UUID programUserRoleId, UUID experimentId, UUID userId) {

--- a/src/main/java/org/breedinginsight/services/ProgramUserService.java
+++ b/src/main/java/org/breedinginsight/services/ProgramUserService.java
@@ -274,4 +274,11 @@ public class ProgramUserService {
         return programUserDao.existsAndActive(programId, userId);
     }
 
+    public List<ProgramUser> getProgramUsersByRole(UUID programId, UUID roleId) throws DoesNotExistException {
+        if (!programService.exists(programId)) {
+            throw new DoesNotExistException("Program id does not exist");
+        }
+
+        return programUserDao.getProgramUsersByRole(programId, roleId);
+    }
 }

--- a/src/test/java/org/breedinginsight/services/ExperimentalCollaboratorServiceTest.java
+++ b/src/test/java/org/breedinginsight/services/ExperimentalCollaboratorServiceTest.java
@@ -1,0 +1,93 @@
+package org.breedinginsight.services;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import lombok.SneakyThrows;
+import org.breedinginsight.DatabaseTest;
+import io.kowalski.fannypack.FannyPack;
+import org.breedinginsight.dao.db.tables.pojos.ExperimentProgramUserRoleEntity;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ExperimentalCollaboratorServiceTest extends DatabaseTest {
+
+    private FannyPack fp;
+
+    @Inject
+    private DSLContext dsl;
+
+    @Inject
+    private ExperimentalCollaboratorService experimentalCollaboratorService;
+
+
+    @BeforeAll
+    public void setup() {
+
+        // Insert test data into the db
+        fp = FannyPack.fill("src/test/resources/sql/ExperimentalCollaboratorServiceTest.sql");
+
+        // Create user.
+        dsl.execute(fp.get("CreateUser"));
+
+        // Create program.
+        dsl.execute(fp.get("CreateProgram"));
+
+        // Add user to program in the Experimental Collaborator role.
+        dsl.execute(fp.get("AddUserToProgram"));
+    }
+
+    @Test
+    @SneakyThrows
+    void testExperimentalCollaboratorCRUD() {
+        // TODO: currently only Created, Read, and Delete are implemented. Once update is implemented, test that too.
+        // Create experiment_program_user_role row using the service method, and ensure it was created and returned as expected.
+
+        UUID experimentId = UUID.fromString("12d8aaf8-d0d9-4837-a71e-aa64b47885ae");
+        UUID programUserRoleId = UUID.fromString("0fb8ecf4-3a16-40c6-9c7f-cdfc945967a1");
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
+        // Test create.
+        ExperimentProgramUserRoleEntity created = experimentalCollaboratorService.createExperimentalCollaborator(
+                programUserRoleId,
+                experimentId,
+                userId
+        );
+
+        assertNotNull(created);
+        assertEquals(experimentId, created.getExperimentId());
+        assertEquals(programUserRoleId, created.getProgramUserRoleId());
+        assertEquals(userId, created.getCreatedBy());
+        assertEquals(userId, created.getUpdatedBy());
+
+        // Test read.
+        ExperimentProgramUserRoleEntity retrieved = experimentalCollaboratorService.getExperimentalCollaborators(experimentId).get(0);
+
+        assertNotNull(retrieved);
+
+        assertEquals(created.getId(), retrieved.getId());
+        assertEquals(created.getProgramUserRoleId(), retrieved.getProgramUserRoleId());
+        assertEquals(created.getExperimentId(), retrieved.getExperimentId());
+        assertEquals(created.getCreatedBy(), retrieved.getCreatedBy());
+        assertEquals(created.getUpdatedBy(), retrieved.getUpdatedBy());
+        assertEquals(created.getCreatedAt(), retrieved.getCreatedAt());
+        assertEquals(created.getUpdatedAt(), retrieved.getUpdatedAt());
+
+        // TODO: test update.
+
+        // Test delete.
+        experimentalCollaboratorService.deleteExperimentalCollaborator(created.getId());
+
+        List<ExperimentProgramUserRoleEntity> result = experimentalCollaboratorService.getExperimentalCollaborators(experimentId);
+        assertTrue(result.isEmpty());
+    }
+
+}

--- a/src/test/resources/sql/ExperimentalCollaboratorServiceTest.sql
+++ b/src/test/resources/sql/ExperimentalCollaboratorServiceTest.sql
@@ -1,0 +1,34 @@
+-- name: CopyrightNotice
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- name: CreateUser
+INSERT INTO bi_user (id, orcid, name, email, created_by, updated_by, active)
+VALUES ('594ec70e-0476-4c40-baf5-581ab0cfcd75', '0000-0001-2345-6789', 'Tester', 'tester@mailinator.com', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', true);
+
+-- name: CreateProgram
+INSERT INTO program (id, species_id, name, created_by, updated_by, active, key, germplasm_sequence, exp_sequence, env_sequence)
+SELECT '33a69523-b7b2-4867-94af-a1352c4a69d4', species.id, 'Trail Mix', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', true, 'TMTEST', 'tmtest_germplasm_sequence', 'tmtest_exp_sequence', 'tmtest_env_sequence'
+FROM species WHERE species.common_name = 'Grape';
+
+-- name: AddUserToProgram
+INSERT INTO program_user_role (id, program_id, user_id, role_id, created_by, updated_by, active)
+SELECT '0fb8ecf4-3a16-40c6-9c7f-cdfc945967a1', program.id, bi_user.id, role.id, '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', true
+FROM
+    bi_user
+    JOIN role ON bi_user.name = 'Tester' and role.domain = 'Experimental Collaborator'
+    JOIN program ON program.name = 'Trail Mix';


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2257

- Implemented create, read and delete service (and when needed, DAO) methods for ExperimentalCollaborator. Keep in mind that the `ExperimentalCollaboratorService` and `ExperimentalCollaboratorDAO` are for interacting with the `experiment_program_user_role` table, they were named to make the purpose of this table obvious, rather than to make the connection to the table obvious.
- Updated the `ProgramUserService` and `ProgramUserDAO` methods to get a list of `ProgramUser` by role.
- Added tests for the new `ExperimentalCollaboratorService` methods.

> Note: An example of how to get the userId to pass down into the service method can be seen in `BreedingMethodController::createProgramBreedingMethod`. This is similar to how the `ExperimentalCollaboratorService` will ultimately be used from controller methods.


# Testing
There is nothing to test manually until controller endpoints are implemented.


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
