### PR TITLE
fix error message for missing obs unit id

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/ExperimentUtilities.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/ExperimentUtilities.java
@@ -306,7 +306,7 @@ public class ExperimentUtilities {
      * @throws IllegalStateException if any ObsUnit ID is repeated in the import rows
      * @throws HttpStatusException if there is a mix of ObsUnit IDs for some but not all rows
      */
-    public static Set<String> collateReferenceOUIds(AppendOverwriteMiddlewareContext context) {
+    public static Set<String> collateReferenceOUIds(AppendOverwriteMiddlewareContext context) throws HttpStatusException, IllegalStateException {
         // Initialize variables to track the presence of ObsUnit IDs
         Set<String> referenceOUIds = new HashSet<>();
         boolean hasNoReferenceUnitIds = true;
@@ -333,7 +333,7 @@ public class ExperimentUtilities {
 
         if (!hasNoReferenceUnitIds && !hasAllReferenceUnitIds) {
             // Throw exception if there is a mix of ObsUnit IDs for some but not all rows
-            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, ExpImportProcessConstants.ErrMessage.MISSING_OBS_UNIT_ID_ERROR);
+            throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, ExpImportProcessConstants.ErrMessage.MISSING_OBS_UNIT_ID_ERROR.getValue());
         }
 
         return referenceOUIds;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/model/ExpImportProcessConstants.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/model/ExpImportProcessConstants.java
@@ -18,7 +18,7 @@ public class ExpImportProcessConstants {
 
     public enum ErrMessage {
         MULTIPLE_EXP_TITLES("File contains more than one Experiment Title"),
-        MISSING_OBS_UNIT_ID_ERROR("Experimental entities are missing ObsUnitIDs"),
+        MISSING_OBS_UNIT_ID_ERROR("Required field is blank"),
         PREEXISTING_EXPERIMENT_TITLE("Experiment Title already exists");
 
         private String value;


### PR DESCRIPTION
# Description
**Story:** [BI-2134](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2134)

The error message for the case of missing obs-unit ids for append workflow was changed to match the source of truth. A bug in writing the error message was fixed.



# Dependencies
bi-web:develop

# Testing
1. create an experiment
2. download experiment data
3. append data to the experiment download
4. delete one or more ids from the obs-unit-id column
5. import appended data
6. confirm the red error banner in the UI states "Required field is blank"


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2134]: https://breedinginsight.atlassian.net/browse/BI-2134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ