### PR TITLE
BI-2134 Fix error message displayed for wrong observation variable headers

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/ExperimentUtilities.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/ExperimentUtilities.java
@@ -69,6 +69,7 @@ public class ExperimentUtilities {
     public static final String MULTIPLE_EXP_TITLES = "File contains more than one Experiment Title";
     public static final String PREEXISTING_EXPERIMENT_TITLE = "Experiment Title already exists";
     public static final String MISSING_OBS_UNIT_ID_ERROR = "Experimental entities are missing ObsUnitIDs";
+    public static final String UNMATCHED_COLUMN = "Ontology term(s) not found: ";
 
 
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/middleware/process/ImportTableProcess.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/middleware/process/ImportTableProcess.java
@@ -375,7 +375,7 @@ public class ImportTableProcess extends AppendOverwriteMiddleware {
             context.getAppendOverwriteWorkflowContext().setPendingObservationByHash(pendingObservationByHash);
 
             return processNext(context);
-        } catch (DoesNotExistException | ApiException | UnprocessableEntityException | ValidatorException e) {
+        } catch (DoesNotExistException | ApiException | UnprocessableEntityException | ValidatorException | IllegalStateException e) {
             context.getAppendOverwriteWorkflowContext().setProcessError(new MiddlewareException(e));
             return this.compensate(context);
         }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationUnitService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationUnitService.java
@@ -75,7 +75,7 @@ public class ObservationUnitService {
             missingIds.removeAll(brapiUnits.stream().map(BrAPIObservationUnit::getObservationUnitDbId).collect(Collectors.toSet()));
 
             // Throw exception with missing IDs information
-            throw new IllegalStateException("Observation unit not found for unit dbid(s): " + String.join(COMMA_DELIMITER, missingIds));
+            throw new IllegalStateException(ExperimentUtilities.UNMATCHED_COLUMN + String.join(COMMA_DELIMITER, missingIds));
         }
 
         return brapiUnits;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationVariableService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationVariableService.java
@@ -20,6 +20,7 @@ package org.breedinginsight.brapps.importer.services.processors.experiment.servi
 import io.micronaut.http.HttpStatus;
 import org.apache.commons.lang3.StringUtils;
 import org.breedinginsight.api.model.v1.response.ValidationError;
+import org.breedinginsight.brapps.importer.services.processors.experiment.ExperimentUtilities;
 import org.breedinginsight.brapps.importer.services.processors.experiment.model.ExpImportProcessConstants;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.Trait;
@@ -69,7 +70,7 @@ public class ObservationVariableService {
         if (varNames.size() != traits.size()) {
             Set<String> missingVarNames = new HashSet<>(varNames);
             missingVarNames.removeAll(traits.stream().map(TraitEntity::getObservationVariableName).collect(Collectors.toSet()));
-            throw new IllegalStateException("Observation variables not found for name(s): " + String.join(ExpImportProcessConstants.COMMA_DELIMITER, missingVarNames));
+            throw new DoesNotExistException(ExperimentUtilities.UNMATCHED_COLUMN + String.join(ExpImportProcessConstants.COMMA_DELIMITER, missingVarNames));
         }
 
         return traits;


### PR DESCRIPTION
# Description
**Story:** [BI-2134](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2134)

When ontology variable names are used in append workflow import that do not exist in the system, the type of error thrown was not getting caught and message displayed on the front end. The type of error was changed to a more appropriate type, the old one added to the catch clause, and the message updated to match the source of truth.



# Dependencies
none

# Testing
same test procedure as [BI-2134](https://github.com/Breeding-Insight/bi-api/pull/359)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2134]: https://breedinginsight.atlassian.net/browse/BI-2134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2134]: https://breedinginsight.atlassian.net/browse/BI-2134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ