### PR TITLE
[BI-2267] Trim trailing white space on breeding method file uploads

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -325,6 +325,7 @@ public class GermplasmProcessor implements Processor {
     private void processNewGermplasm(Germplasm germplasm, ValidationErrors validationErrors, Map<String, ProgramBreedingMethodEntity> breedingMethods,
                                      List<String> badBreedingMethods,
                                      Program program, UUID importListId, boolean commit, PendingImport mappedImportRow, int i, User user, Supplier<BigInteger> nextVal) {
+        germplasm = removeBreedingMethodBlanks(germplasm);
         // Get the breeding method database object
         ProgramBreedingMethodEntity breedingMethod = null;
         if (germplasm.getBreedingMethod() != null) {
@@ -356,6 +357,14 @@ public class GermplasmProcessor implements Processor {
         }
 
         importList.addDataItem(newGermplasm.getGermplasmName());
+    }
+
+    // Removes leading and trailing blanks from the germplasm breedingMethod
+    private Germplasm removeBreedingMethodBlanks(Germplasm germplasm) {
+        if(germplasm.getBreedingMethod() != null ) {
+            germplasm.setBreedingMethod(germplasm.getBreedingMethod().strip());
+        }
+        return germplasm;
     }
 
     private boolean processExistingGermplasm(Germplasm germplasm, ValidationErrors validationErrors, List<BrAPIImport> importRows, Program program, UUID importListId, boolean commit, PendingImport mappedImportRow, int rowIndex) {


### PR DESCRIPTION
[BI-2267](https://breedinginsight.atlassian.net/browse/BI-2267) Trim trailing white space on breeding method file uploads

# Description
When importing germplasm, if there was a trailing blank in a _breeding method_ value, then the system was generating the table error  `Invalid breeding method`.

This fix removes any leading and trailing spaces in the imported _breeding method_ values.

# Dependencies
_Please include any dependencies to other code branches, testing configurations, scripts to be run, etc._

# Testing

1. Import a germplasm file with a trailing blanks in some of the _breeding method_ field.  You can use [ABC_germplasm_2024-08-02_06-20-46+0000import.xlsx](https://github.com/user-attachments/files/16697377/ABC_germplasm_2024-08-02_06-20-46%2B0000import.xlsx) which has trailing blanks in every _breeding method_ with the value "unknown "

**EXPECTED RESULT**
There should be no Table Error `Invalid breeding method`


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_



[BI-2267]: https://breedinginsight.atlassian.net/browse/BI-2267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ