### PR TITLE
BI-2283 - Modify the experiment_program_user_role.program_user_role_id FK to use ON DELETE CASCADE

### DIFF
--- a/src/main/resources/db/migration/V1.27.0__fix_fk_constraint.sql
+++ b/src/main/resources/db/migration/V1.27.0__fix_fk_constraint.sql
@@ -1,0 +1,27 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+DO $$
+BEGIN
+     -- Drop foreign key constraint (can't directly alter ON DELETE behavior).
+    ALTER TABLE experiment_program_user_role DROP CONSTRAINT experiment_program_user_role_program_user_role_id_fkey;
+    -- Add foreign key constraint with ON DELETE CASCADE.
+    ALTER TABLE experiment_program_user_role
+    ADD CONSTRAINT experiment_program_user_role_program_user_role_id_fkey
+        FOREIGN KEY (program_user_role_id) REFERENCES program_user_role (id)
+        ON DELETE CASCADE;
+END $$;

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-version=v0.10.0+790
-versionInfo=https://github.com/Breeding-Insight/bi-api/commit/026884428e9df6a25869e63339395c3602ef5a39
+version=v0.10.0+792
+versionInfo=https://github.com/Breeding-Insight/bi-api/commit/ff9abc7fb9fca3af818f696513a119123add685a


### PR DESCRIPTION
# Description
**Story:** [BI-2283](https://breedinginsight.atlassian.net/browse/BI-2283)

This migration gives the `experiment_program_user_role.program_user_role_id` foreign key constraint the `ON DELETE CASCADE` behavior. From the end user perspective, when a program user in the "Experimental Collaborator" role is assigned to a different role, this operation will not result in an error, and any record of the experiments they were given access to as an "Experimental Collaborator" will be lost.

> Because changing the role a program user is in results in a DELETE followed by an INSERT, changing a program user's role results in any associated rows in `experiment_program_user_role` being deleted once this migration is applied.



# Testing
1. Run this migration.
2. If it hasn't been merged into develop yet, check out and run the feature/BI-2258 branch of bi-api.
3. Upload all the data files in [this story](https://breedinginsight.atlassian.net/browse/BI-2258).
4. Make a user you can log in as an "Experimental Collaborator". You'll need the email address of this user for step 6.
5. Navigate to the detail view of an experiment and copy the programId and experimentId from the URL for step 6.
6. Run the following SQL script against your bidb database after pasting in the email address from step 4 and the programId and experimentId from step 5.
    ```sql
    -- Inputs:
    --      - the email of the experimental collaborator user
    --      - the program id
    --      - the experiment id
    
    DO $$
        DECLARE
            -- populate these variables!
            collaborator_email text := 'REPLACE';
            program_uuid uuid := 'REPLACE'::uuid;
            experiment_uuid uuid := 'REPLACE'::uuid;
        BEGIN
            INSERT INTO
                experiment_program_user_role (experiment_id, program_user_role_id, created_by, updated_by)
            VALUES
            (
                experiment_uuid,
                (SELECT r.id FROM program_user_role r JOIN public.bi_user u on u.id = r.user_id WHERE u.email = collaborator_email AND r.program_id = program_uuid),
                '00000000-0000-0000-0000-000000000000'::uuid,
                '00000000-0000-0000-0000-000000000000'::uuid
            )
            ;
        END
    $$;

    ```
7.  [BONUS! - tests BI-2258] Step 6 authorized the Experimental Collaborator to access one of the experiments. Navigate to the experiment list view **as the Experimental Collaborator** to ensure the results are filtered to only the authorized experiment(s).
8. Now, as a System Admin, change the role that the Experimental Collaborator user is in. Ensure that saving does not produce an error. If you check the database, you will see that the row that step 6 inserted into `experiment_program_user_role` has been deleted.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2283]: https://breedinginsight.atlassian.net/browse/BI-2283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ