### PR TITLE
[BI-2295] - Allow Experimental Collaborators To View Collaborators

### DIFF
--- a/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
@@ -219,7 +219,7 @@ public class ExperimentController {
      *  Response includes name and email as a convenience to the front end to avoid making another api call
      */
     @Get("/${micronaut.bi.api.version}/programs/{programId}/experiments/{experimentId}/collaborators{?active}")
-    @ProgramSecured(roles = {ProgramSecuredRole.PROGRAM_ADMIN, ProgramSecuredRole.SYSTEM_ADMIN})
+    @ProgramSecured(roles = {ProgramSecuredRole.PROGRAM_ADMIN, ProgramSecuredRole.SYSTEM_ADMIN, ProgramSecuredRole.EXPERIMENTAL_COLLABORATOR, ProgramSecuredRole.READ_ONLY})
     @Produces(MediaType.APPLICATION_JSON)
     public HttpResponse<Response<DataResponse<List<ExperimentalCollaboratorResponse>>>> getExperimentalCollaborators(
             @PathVariable("programId") UUID programId,


### PR DESCRIPTION
# Description
**Story:** [BI-2295 - Allow Experimental Collaborators To View Collaborators](https://breedinginsight.atlassian.net/browse/BI-2295)

Changed permissions for GET collaborators endpoint to enable Read Only and Experimental Collaborators to access the endpoint so they can view collaborators on an experiment.

# Dependencies
bi-web: [feature/BI-2295](https://github.com/Breeding-Insight/bi-web/pull/397)

# Testing
see bi-web

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: [_\<please include a link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/10691131125)
