### PR TITLE
[BI-2267]Trim trailing white space on breeding method file uploads (FAILED QA)

### DIFF
--- a/src/main/java/org/breedinginsight/daos/impl/BreedingMethodDAOImpl.java
+++ b/src/main/java/org/breedinginsight/daos/impl/BreedingMethodDAOImpl.java
@@ -4,6 +4,7 @@ import org.breedinginsight.dao.db.tables.daos.BreedingMethodDao;
 import org.breedinginsight.dao.db.tables.pojos.ProgramBreedingMethodEntity;
 import org.breedinginsight.daos.BreedingMethodDAO;
 import org.jooq.*;
+import org.jooq.impl.DSL;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -54,13 +55,13 @@ public class BreedingMethodDAOImpl extends BreedingMethodDao implements Breeding
 
     public List<ProgramBreedingMethodEntity> findByNameOrAbbreviation(String nameOrAbbrev, UUID programId) {
         List<ProgramBreedingMethodEntity> breedingMethodEntities = systemMethodBase(programId)
-                                                                      .and(BREEDING_METHOD.ABBREVIATION.equalIgnoreCase(nameOrAbbrev)
-                                                                                                       .or(BREEDING_METHOD.NAME.equalIgnoreCase(nameOrAbbrev)))
+                                                                      .and(DSL.trim(BREEDING_METHOD.ABBREVIATION).equalIgnoreCase(nameOrAbbrev)
+                                                                              .or(DSL.trim(BREEDING_METHOD.NAME).equalIgnoreCase(nameOrAbbrev)))
                                                                       .fetchInto(ProgramBreedingMethodEntity.class);
 
         List<ProgramBreedingMethodEntity> programBreedingMethodEntities = programMethodBase(programId)
-                                                                             .and(PROGRAM_BREEDING_METHOD.ABBREVIATION.equalIgnoreCase(nameOrAbbrev)
-                                                                                                                      .or(PROGRAM_BREEDING_METHOD.NAME.equalIgnoreCase(nameOrAbbrev)))
+                                                                             .and(DSL.trim(PROGRAM_BREEDING_METHOD.ABBREVIATION).equalIgnoreCase(nameOrAbbrev)
+                                                                                                                      .or(DSL.trim(PROGRAM_BREEDING_METHOD.NAME).equalIgnoreCase(nameOrAbbrev)))
                                                                              .fetchInto(ProgramBreedingMethodEntity.class);
 
         List<ProgramBreedingMethodEntity> ret = new ArrayList<>();

--- a/src/main/resources/db/migration/V1.29.0__remove_blank_from_breeding_method.sql
+++ b/src/main/resources/db/migration/V1.29.0__remove_blank_from_breeding_method.sql
@@ -1,0 +1,18 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+update breeding_method set name = 'Bulk or population' where name = 'Bulk or population ';


### PR DESCRIPTION
# Description
[BI-2267 ](https://breedinginsight.atlassian.net/browse/BI-2267)Trim trailing white space on breeding method file uploads (FAILED QA)

### THE BUG caused by the new code for [BI-2267 ](https://breedinginsight.atlassian.net/browse/BI-2267)
IF the he **Breeding Method** field in the germplasm import file has the value "Bulk or population " (with a trailing blank),
THEN the import fails with an erroneous "Invalid Breeding Method" error.

### BACKGROUND
- The **Breeding Method** field in the germplasm import file must match the `name` column in the `breeding_method` table _exactly_.
- One entry in the `breeding_method` table has a trailing blank in the `name` column; "Bulk or population ".
- The new code for [BI-2267 ](https://breedinginsight.atlassian.net/browse/BI-2267) trims the white space off of the value for the **Breeding Method** field in the germplasm import file.
- this causes an erroneous "Invalid Breeding Method" error (because "Bulk or population" <> "Bulk or population ").

### Solution
Two fixes were made.  Either one would fix the immediate problem, but both solutions are present for completeness and to prevent future problems.

1. A migration was added to remove the trailing space in the `breeding_method` table.
2. The lookup code for the `name` column in the `breeding_method` table, now includes `DSL.trim()`.


# Dependencies
bi-web: **develop**

# Testing

- import the germplasm file  [bi_germplasm_import_template_v11(2).xls](https://github.com/user-attachments/files/16894936/bi_germplasm_import_template_v11.2.xls)

**Expected Result**
It should import without errors.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
