### PR TITLE
BI-2304 - Support Duplicate Germplasm in Lists Referencing Existing Germplasm

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/constants/BrAPIAdditionalInfoFields.java
@@ -18,7 +18,6 @@
 package org.breedinginsight.brapi.v2.constants;
 
 public final class BrAPIAdditionalInfoFields {
-    public static final String GERMPLASM_LIST_ENTRY_NUMBERS = "listEntryNumbers";
     public static final String GERMPLASM_LIST_ID = "listId";
     public static final String GERMPLASM_RAW_PEDIGREE = "rawPedigree";
     public static final String GERMPLASM_PEDIGREE_BY_NAME = "pedigreeByName";

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -96,6 +96,8 @@ public class BrAPIGermplasmService {
         for (String germplasmName: orderedGermplasmNames) {
             // Increment entryNumber.
             ++entryNumber;
+            // Strip program key and accession number from germplasm name.
+            germplasmName = Utilities.removeUnknownProgramKey(germplasmName);  // TODO: would be better to use known program key.
             // Lookup the BrAPI germplasm in the map.
             BrAPIGermplasm germplasmEntry = germplasmByName.get(germplasmName);
 

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -1,5 +1,6 @@
 package org.breedinginsight.brapi.v2.services;
 
+import com.google.gson.Gson;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import io.micronaut.http.server.types.files.StreamedFile;
@@ -24,6 +25,7 @@ import org.breedinginsight.services.writers.CSVWriter;
 import org.breedinginsight.services.writers.ExcelWriter;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
+import org.breedinginsight.utilities.Utilities;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -31,7 +33,6 @@ import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -72,10 +73,32 @@ public class BrAPIGermplasmService {
         return germplasmDAO.getGermplasmByDBID(germplasmId, programId);
     }
 
-    public List<Map<String, Object>> processListData(List<BrAPIGermplasm> germplasm, UUID germplasmListId){
+    // TODO: pass in a hashmap of <GermplasmName, BrAPIGermplasm> as well as BrAPI list object.
+    public List<Map<String, Object>> processListData(List<BrAPIGermplasm> germplasm, BrAPIListDetails germplasmList){
+        Map<String, BrAPIGermplasm> germplasmByName = new HashMap<>();
+        for (BrAPIGermplasm g: germplasm) {
+            germplasmByName.put(g.getGermplasmName(), g);
+        }
+
         List<Map<String, Object>> processedData =  new ArrayList<>();
 
-        for (BrAPIGermplasm germplasmEntry: germplasm) {
+        // This holds the BrAPI list items or all germplasm in a program if the list is null.
+        List<String> orderedGermplasmNames = new ArrayList<>();
+        if (germplasmList == null) {
+            // TODO: sort by GID.
+            orderedGermplasmNames = germplasm.stream().map(BrAPIGermplasm::getGermplasmName).collect(Collectors.toList());
+        } else {
+            orderedGermplasmNames = germplasmList.getData();
+        }
+
+        // TODO: for export, number sequentially based on BrAPI list order
+        int entryNumber = 0;
+        for (String germplasmName: orderedGermplasmNames) {
+            // Increment entryNumber.
+            ++entryNumber;
+            // Lookup the BrAPI germplasm in the map.
+            BrAPIGermplasm germplasmEntry = germplasmByName.get(germplasmName);
+
             HashMap<String, Object> row = new HashMap<>();
             row.put("GID", Integer.valueOf(germplasmEntry.getAccessionNumber()));
             row.put("Germplasm Name", germplasmEntry.getGermplasmName());
@@ -84,12 +107,14 @@ public class BrAPIGermplasmService {
             row.put("Source", source);
 
             // Use the entry number in the list map if generated
-            if(new UUID(0,0).compareTo(germplasmListId) == 0) {
+            if(germplasmList == null) {
+                // TODO: ask Shawn if she still wants entryNumber to be GID in this case, or if it should be sequential?
                 // Not downloading a real list, use GID (https://breedinginsight.atlassian.net/browse/BI-2266).
                 row.put("Entry No", Integer.valueOf(germplasmEntry.getAccessionNumber()));
             } else {
-                row.put("Entry No", germplasmEntry.getAdditionalInfo()
-                        .getAsJsonObject(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS).get(germplasmListId.toString()).getAsInt());
+                // TODO: if there are duplicates in a list, which to use?
+                //  if there are duplicates, it makes more sense to build entry number from BrAPI list
+                row.put("Entry No", entryNumber);
             }
 
             //If germplasm was imported with an external UID, it will be stored in external reference with same source as seed source
@@ -148,11 +173,38 @@ public class BrAPIGermplasmService {
             // get list BrAPI germplasm variables
             List<String> germplasmNames = listResponse.getResult().getData();
             List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
+            Map<String, BrAPIGermplasm> germplasmByName = new HashMap<>();
 
-            // set the list ID in the germplasm additional info
-             germplasm.forEach(g -> g.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ID, listId));
-            return germplasm;
+            for (BrAPIGermplasm g : germplasm) {
+                // set the list ID in the germplasm additional info
+                germplasm.forEach(x -> x.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ID, listId));
+                // Add to map.
+                germplasmByName.put(g.getGermplasmName(), g);
+            }
+
+            // TODO: is this really necessary? Also, handle the exception.
+            String programKey = programService.getById(programId).get().getKey();
+
+            // Build list from BrAPI list that preserves ordering and duplicates and assigns sequential entry numbers.
+            List<BrAPIGermplasm> germplasmList = new ArrayList<>();
+            int entryNumber = 0;
+            for (String germplasmName : germplasmNames) {
+                ++entryNumber;
+                BrAPIGermplasm listEntry = cloneBrAPIGermplasm(germplasmByName.get(Utilities.removeProgramKeyAndUnknownAdditionalData(germplasmName, programKey)));
+                // Set entry number.
+                listEntry.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER, entryNumber);
+                germplasmList.add(listEntry);
+                // TODO: need to set entry number, need to deep copy duplicates...
+            }
+
+            return germplasmList;
         } else throw new ApiException();
+    }
+
+    // Serialize then deserialize to deep copy.
+    private BrAPIGermplasm cloneBrAPIGermplasm(BrAPIGermplasm germplasm) {
+        Gson gson = new Gson();
+        return (BrAPIGermplasm) gson.fromJson(gson.toJson(germplasm), BrAPIGermplasm.class);
     }
 
     public DownloadFile exportGermplasm(UUID programId, FileType fileExtension) throws IllegalArgumentException, ApiException, IOException {
@@ -176,7 +228,7 @@ public class BrAPIGermplasmService {
 
         StreamedFile downloadFile;
         //Convert list data to List<Map<String, Object>> data to pass into file writer
-        List<Map<String, Object>> processedData =  processListData(germplasm, new UUID(0,0));
+        List<Map<String, Object>> processedData =  processListData(germplasm, null);
 
         if (fileExtension == FileType.CSV){
             downloadFile = CSVWriter.writeToDownload(columns, processedData, fileExtension);
@@ -198,8 +250,9 @@ public class BrAPIGermplasmService {
         List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
 
         //processGermplasmForDisplay, numbers
-        UUID germplasmListId = getGermplasmListId(listData);
-        germplasm.sort(Comparator.comparingInt(getEntryNumber(germplasmListId)));
+//        UUID germplasmListId = getGermplasmListId(listData);
+        // TODO: sort happens here based on entry number
+//        germplasm.sort(Comparator.comparingInt(getEntryNumber(germplasmListId)));
 
         String listName = listData.getListName();
         Optional<Program> optionalProgram = programService.getById(programId);
@@ -210,7 +263,7 @@ public class BrAPIGermplasmService {
         String fileName = createFileName(listData, listName);
         StreamedFile downloadFile;
         //Convert list data to List<Map<String, Object>> data to pass into file writer
-        List<Map<String, Object>> processedData =  processListData(germplasm, germplasmListId);
+        List<Map<String, Object>> processedData =  processListData(germplasm, listData);
 
         if (fileExtension == FileType.CSV){
             downloadFile = CSVWriter.writeToDownload(columns, processedData, fileExtension);
@@ -246,31 +299,31 @@ public class BrAPIGermplasmService {
         return refs.stream().anyMatch(e -> referenceSource.concat("/lists").equals(e.getReferenceSource()));
     }
 
-    private ToIntFunction<BrAPIGermplasm> getEntryNumber(UUID germplasmListId) throws IllegalArgumentException {
-        if(germplasmListId.compareTo(new UUID(0,0)) == 0) {
-            return this::getImportEntryNumber;
-        } else {
-            return g -> getGermplasmListEntryNumber(g, germplasmListId);
-        }
-    }
+//    private ToIntFunction<BrAPIGermplasm> getEntryNumber(UUID germplasmListId) throws IllegalArgumentException {
+//        if(germplasmListId.compareTo(new UUID(0,0)) == 0) {
+//            return this::getImportEntryNumber;
+//        } else {
+//            return g -> getGermplasmListEntryNumber(g, germplasmListId);
+//        }
+//    }
 
-    private Integer getImportEntryNumber(BrAPIGermplasm g) throws IllegalArgumentException {
-        if(Objects.nonNull(g.getAdditionalInfo()) &&
-                g.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER)) {
-            return g.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsInt();
-        } else {
-            throw new IllegalArgumentException();
-        }
-    }
-    private Integer getGermplasmListEntryNumber(BrAPIGermplasm g, UUID germplasmListId) throws IllegalArgumentException {
-        if(Objects.nonNull(g.getAdditionalInfo()) &&
-                g.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS)) {
-            return g.getAdditionalInfo().getAsJsonObject(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS)
-                .get(germplasmListId.toString()).getAsInt();
-        } else {
-            throw new IllegalArgumentException();
-        }
-    }
+//    private Integer getImportEntryNumber(BrAPIGermplasm g) throws IllegalArgumentException {
+//        if(Objects.nonNull(g.getAdditionalInfo()) &&
+//                g.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER)) {
+//            return g.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsInt();
+//        } else {
+//            throw new IllegalArgumentException();
+//        }
+//    }
+//    private Integer getGermplasmListEntryNumber(BrAPIGermplasm g, UUID germplasmListId) throws IllegalArgumentException {
+//        if(Objects.nonNull(g.getAdditionalInfo()) &&
+//                g.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS)) {
+//            return g.getAdditionalInfo().getAsJsonObject(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS)
+//                .get(germplasmListId.toString()).getAsInt();
+//        } else {
+//            throw new IllegalArgumentException();
+//        }
+//    }
 
     private String createFileName(BrAPIListDetails listData, String listName) {
         //TODO change timestamp to edit date when editing functionality is added

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -91,7 +91,7 @@ public class BrAPIGermplasmService {
             orderedGermplasmNames = germplasmList.getData();
         }
 
-        // TODO: for export, number sequentially based on BrAPI list order
+        // For export, assign entry number sequentially based on BrAPI list order.
         int entryNumber = 0;
         for (String germplasmName: orderedGermplasmNames) {
             // Increment entryNumber.
@@ -251,11 +251,6 @@ public class BrAPIGermplasmService {
         List<String> germplasmNames = listData.getData();
         List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
 
-        //processGermplasmForDisplay, numbers
-//        UUID germplasmListId = getGermplasmListId(listData);
-        // TODO: sort happens here based on entry number
-//        germplasm.sort(Comparator.comparingInt(getEntryNumber(germplasmListId)));
-
         String listName = listData.getListName();
         Optional<Program> optionalProgram = programService.getById(programId);
         if (optionalProgram.isPresent()) {
@@ -300,32 +295,6 @@ public class BrAPIGermplasmService {
         if (refs == null) throw new IllegalArgumentException();
         return refs.stream().anyMatch(e -> referenceSource.concat("/lists").equals(e.getReferenceSource()));
     }
-
-//    private ToIntFunction<BrAPIGermplasm> getEntryNumber(UUID germplasmListId) throws IllegalArgumentException {
-//        if(germplasmListId.compareTo(new UUID(0,0)) == 0) {
-//            return this::getImportEntryNumber;
-//        } else {
-//            return g -> getGermplasmListEntryNumber(g, germplasmListId);
-//        }
-//    }
-
-//    private Integer getImportEntryNumber(BrAPIGermplasm g) throws IllegalArgumentException {
-//        if(Objects.nonNull(g.getAdditionalInfo()) &&
-//                g.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER)) {
-//            return g.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsInt();
-//        } else {
-//            throw new IllegalArgumentException();
-//        }
-//    }
-//    private Integer getGermplasmListEntryNumber(BrAPIGermplasm g, UUID germplasmListId) throws IllegalArgumentException {
-//        if(Objects.nonNull(g.getAdditionalInfo()) &&
-//                g.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS)) {
-//            return g.getAdditionalInfo().getAsJsonObject(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS)
-//                .get(germplasmListId.toString()).getAsInt();
-//        } else {
-//            throw new IllegalArgumentException();
-//        }
-//    }
 
     private String createFileName(BrAPIListDetails listData, String listName) {
         //TODO change timestamp to edit date when editing functionality is added

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -73,7 +73,6 @@ public class BrAPIGermplasmService {
         return germplasmDAO.getGermplasmByDBID(germplasmId, programId);
     }
 
-    // TODO: pass in a hashmap of <GermplasmName, BrAPIGermplasm> as well as BrAPI list object.
     public List<Map<String, Object>> processListData(List<BrAPIGermplasm> germplasm, BrAPIListDetails germplasmList){
         Map<String, BrAPIGermplasm> germplasmByName = new HashMap<>();
         for (BrAPIGermplasm g: germplasm) {
@@ -85,8 +84,11 @@ public class BrAPIGermplasmService {
         // This holds the BrAPI list items or all germplasm in a program if the list is null.
         List<String> orderedGermplasmNames = new ArrayList<>();
         if (germplasmList == null) {
-            // TODO: sort by GID.
-            orderedGermplasmNames = germplasm.stream().map(BrAPIGermplasm::getGermplasmName).collect(Collectors.toList());
+            orderedGermplasmNames = germplasm.stream().sorted((left, right) -> {
+                Integer leftAccessionNumber = Integer.parseInt(left.getAccessionNumber());
+                Integer rightAccessionNumber = Integer.parseInt(right.getAccessionNumber());
+                return leftAccessionNumber.compareTo(rightAccessionNumber);
+            }).map(BrAPIGermplasm::getGermplasmName).collect(Collectors.toList());
         } else {
             orderedGermplasmNames = germplasmList.getData();
         }
@@ -110,12 +112,9 @@ public class BrAPIGermplasmService {
 
             // Use the entry number in the list map if generated
             if(germplasmList == null) {
-                // TODO: ask Shawn if she still wants entryNumber to be GID in this case, or if it should be sequential?
                 // Not downloading a real list, use GID (https://breedinginsight.atlassian.net/browse/BI-2266).
                 row.put("Entry No", Integer.valueOf(germplasmEntry.getAccessionNumber()));
             } else {
-                // TODO: if there are duplicates in a list, which to use?
-                //  if there are duplicates, it makes more sense to build entry number from BrAPI list
                 row.put("Entry No", entryNumber);
             }
 

--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -185,13 +185,6 @@ public class Germplasm implements BrAPIObject {
             }
         }
 
-        // Add germplasm to the new list
-        JsonObject listEntryNumbers = germplasm.getAdditionalInfo().getAsJsonObject(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS);
-        if(listEntryNumbers == null) {
-            listEntryNumbers = new JsonObject();
-            germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS, listEntryNumbers);
-        }
-        listEntryNumbers.addProperty(listId.toString(), entryNo);
         germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER, entryNo); //so the preview UI shows correctly
 
         // TODO: figure out why clear this out: brapi-server
@@ -241,9 +234,6 @@ public class Germplasm implements BrAPIObject {
         createdBy.put(BrAPIAdditionalInfoFields.CREATED_BY_USER_ID, user.getId().toString());
         createdBy.put(BrAPIAdditionalInfoFields.CREATED_BY_USER_NAME, user.getName());
         germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.CREATED_BY, createdBy);
-        Map<UUID, String> listEntryNumbers = new HashMap<>();
-        listEntryNumbers.put(listId, entryNo);
-        germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS, listEntryNumbers);
         //TODO: Need to check that the acquisition date it in date format
         //brAPIGermplasm.setAcquisitionDate(pedigreeImport.getGermplasm().getAcquisitionDate());
         germplasm.setCountryOfOriginCode(getCountryOfOrigin());

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -264,6 +264,12 @@ public class GermplasmProcessor implements Processor {
         Map<String, Integer> entryNumberCounts = new HashMap<>();
         List<String> userProvidedEntryNumbers = new ArrayList<>();
         ValidationErrors validationErrors = new ValidationErrors();
+        // Sort importRows by entry number (if present).
+        importRows.sort((left, right) -> {
+            Integer leftEntryNo = Integer.parseInt(left.getGermplasm().getEntryNo());
+            Integer rightEntryNo = Integer.parseInt(right.getGermplasm().getEntryNo());
+            return leftEntryNo.compareTo(rightEntryNo);
+        });
         for (int i = 0; i < importRows.size(); i++) {
             log.debug("processing germplasm row: " + (i+1));
             BrAPIImport brapiImport = importRows.get(i);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -266,9 +266,13 @@ public class GermplasmProcessor implements Processor {
         ValidationErrors validationErrors = new ValidationErrors();
         // Sort importRows by entry number (if present).
         importRows.sort((left, right) -> {
-            Integer leftEntryNo = Integer.parseInt(left.getGermplasm().getEntryNo());
-            Integer rightEntryNo = Integer.parseInt(right.getGermplasm().getEntryNo());
-            return leftEntryNo.compareTo(rightEntryNo);
+            if (left.getGermplasm().getEntryNo() == null || right.getGermplasm().getEntryNo() == null) {
+                return 0;
+            } else {
+                Integer leftEntryNo = Integer.parseInt(left.getGermplasm().getEntryNo());
+                Integer rightEntryNo = Integer.parseInt(right.getGermplasm().getEntryNo());
+                return leftEntryNo.compareTo(rightEntryNo);
+            }
         });
         for (int i = 0; i < importRows.size(); i++) {
             log.debug("processing germplasm row: " + (i+1));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -16,6 +16,7 @@
  */
 package org.breedinginsight.brapps.importer.services.processors;
 
+import com.google.gson.Gson;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.http.HttpStatus;
@@ -373,6 +374,9 @@ public class GermplasmProcessor implements Processor {
         String gid = germplasm.getAccessionNumber();
         if (germplasmByAccessionNumber.containsKey(gid)) {
             existingGermplasm = germplasmByAccessionNumber.get(gid).getBrAPIObject();
+            // TODO: hacky, but deep copy is needed and serialize/deserialize works.
+            Gson gson = new Gson();
+            existingGermplasm = gson.fromJson(gson.toJson(existingGermplasm), BrAPIGermplasm.class);
         } else {
             //should be caught in getExistingBrapiData
             ValidationError ve = new ValidationError("GID", String.format(missingGID, gid), HttpStatus.NOT_FOUND);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -71,6 +71,7 @@ public class GermplasmProcessor implements Processor {
     private final BrAPIListDAO brAPIListDAO;
     private final DSLContext dsl;
     private final BrAPIGermplasmDAO brAPIGermplasmDAO;
+    private final Gson gson = new Gson();
 
     Map<String, PendingImportObject<BrAPIGermplasm>> germplasmByAccessionNumber = new HashMap<>();
     Map<String, Integer> fileGermplasmByName = new HashMap<>();
@@ -384,8 +385,7 @@ public class GermplasmProcessor implements Processor {
         String gid = germplasm.getAccessionNumber();
         if (germplasmByAccessionNumber.containsKey(gid)) {
             existingGermplasm = germplasmByAccessionNumber.get(gid).getBrAPIObject();
-            // TODO: hacky, but deep copy is needed and serialize/deserialize works.
-            Gson gson = new Gson();
+            // Serialize and deserialize to deep copy
             existingGermplasm = gson.fromJson(gson.toJson(existingGermplasm), BrAPIGermplasm.class);
         } else {
             //should be caught in getExistingBrapiData

--- a/src/main/java/org/breedinginsight/utilities/response/mappers/GermplasmQueryMapper.java
+++ b/src/main/java/org/breedinginsight/utilities/response/mappers/GermplasmQueryMapper.java
@@ -31,20 +31,12 @@ public class GermplasmQueryMapper extends AbstractQueryMapper {
 
     public GermplasmQueryMapper() {
         fields = Map.ofEntries(
-                Map.entry("importEntryNumber", (germplasm) ->{
+                Map.entry("importEntryNumber", (germplasm) -> {
                     String entryNumber = null;
                         if (germplasm.getAdditionalInfo() != null) {
                             // if additionalInfo contains the importEntryNumber key then return the value
                             if (germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER)) {
                                 entryNumber = germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER).getAsString();
-                            }
-
-                            // if additionalInfo has both listEntryNumbers and listId keys then return the entry number
-                            // mapped to the listId
-                            if (germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS)
-                                && germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ID)) {
-                                String listId = germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ID).getAsString();
-                                entryNumber = germplasm.getAdditionalInfo().getAsJsonObject(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ENTRY_NUMBERS).get(listId).getAsString();
                             }
                         }
                     return entryNumber;

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
@@ -133,8 +133,6 @@ public class GermplasmFileImportTest extends BrAPITest {
         for (int i = 0; i < previewRows.size(); i++) {
             JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
             germplasmNames.add(germplasm.get("germplasmName").getAsString());
-            int finalI = i;
-            gson.fromJson(germplasm.getAsJsonObject("additionalInfo").getAsJsonObject("listEntryNumbers"), Map.class).forEach((listId, entryNumber) -> assertEquals(Integer.toString(finalI +1), entryNumber, "Wrong entry number"));
         }
 
         // Check the germplasm list
@@ -563,8 +561,6 @@ public class GermplasmFileImportTest extends BrAPITest {
         for (int i = 0; i < previewRows.size(); i++) {
             JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
             germplasmNames.add(germplasm.get("germplasmName").getAsString());
-            int finalI = i;
-            gson.fromJson(germplasm.getAsJsonObject("additionalInfo").getAsJsonObject("listEntryNumbers"), Map.class).forEach((listId, entryNumber) -> assertEquals(Integer.toString(finalI +1), entryNumber, "Wrong entry number"));
         }
 
         // Check the germplasm list
@@ -650,8 +646,6 @@ public class GermplasmFileImportTest extends BrAPITest {
 
         // Germplasm display name
         assertEquals(fileData.getString(i, "Germplasm Name"), germplasm.get("defaultDisplayName").getAsString(), "Wrong display name");
-        // Entry Number
-        gson.fromJson(germplasm.getAsJsonObject("additionalInfo").getAsJsonObject("listEntryNumbers"), Map.class).forEach((listId, entryNumber) -> assertEquals(fileData.getString(i, "Entry No"), entryNumber, "Wrong entry number"));
         JsonObject additionalInfo = germplasm.getAsJsonObject("additionalInfo");
         // Created By User ID
         assertEquals(testUser.getId().toString(), additionalInfo.getAsJsonObject(BrAPIAdditionalInfoFields.CREATED_BY).get(BrAPIAdditionalInfoFields.CREATED_BY_USER_ID).getAsString(), "Wrong createdBy userId");

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
@@ -91,28 +91,6 @@ public class GermplasmFileImportTest extends BrAPITest {
         testUser = (BiUserEntity) setupObjects.get("testUser");
     }
 
-    // Tests
-    // Minimum import required fields, success
-    // Female parent not exist db id, throw error
-    // Female parent not exist entry number, throw error
-    // Male parent not exist db id, throw error
-    // Female parent not exist entry number, throw error
-    // Bad breeding method, throw error
-    // Some entry numbers, throw an error
-    // Numerical entry numbers
-    // Required fields missing, throw error
-    // Missing required headers
-    // Missing optional headers
-    // No entry numbers, automatic generation
-    // Full import, success
-    // Preview, non-preview fields not shown
-    // Male db, no female db id, pedigree string is null
-    // Circular parent dependency
-    // Name and description success
-    // Name only success
-    // Dup list name test
-    // Missing required fields tests
-
     @Test
     @SneakyThrows
     @Order(1)
@@ -143,18 +121,13 @@ public class GermplasmFileImportTest extends BrAPITest {
     @SneakyThrows
     @Order(2)
     public void fullImportPreviewSuccess() {
-        File file = new File("src/test/resources/files/germplasm_import/full_import.csv");
-        Table fileData = Table.read().file("src/test/resources/files/germplasm_import/full_import.csv");
+
+        String pathname = "src/test/resources/files/germplasm_import/full_import.csv";
+        Table fileData = Table.read().file(pathname);
         String listName = "FullList";
         String listDescription = "A full import";
 
-        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(file, Map.of(GERM_LIST_NAME, listName, GERM_LIST_DESC, listDescription), false, client, validProgram, germplasmMappingId);
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.ACCEPTED, response.getStatus());
-        String importId = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").get("importId").getAsString();
-
-        HttpResponse<String> upload = importTestUtils.getUploadedFile(importId, client, validProgram, germplasmMappingId);
-        JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
+        JsonObject result = importGermplasm(pathname, listName, listDescription, false);
         assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt());
 
         JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
@@ -203,18 +176,13 @@ public class GermplasmFileImportTest extends BrAPITest {
     @SneakyThrows
     @Order(3)
     public void fullImportCommitSuccess() {
-        File file = new File("src/test/resources/files/germplasm_import/full_import.csv");
-        Table fileData = Table.read().file("src/test/resources/files/germplasm_import/full_import.csv");
 
+        String pathname = "src/test/resources/files/germplasm_import/full_import.csv";
+        Table fileData = Table.read().file(pathname);
         String listName = "FullList";
         String listDescription = "A full import";
-        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(file, Map.of(GERM_LIST_NAME, listName, GERM_LIST_DESC, listDescription), true, client, validProgram, germplasmMappingId);
-        HttpResponse<String> response = call.blockingFirst();
-        assertEquals(HttpStatus.ACCEPTED, response.getStatus());
-        String importId = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").get("importId").getAsString();
 
-        HttpResponse<String> upload = importTestUtils.getUploadedFile(importId, client, validProgram, germplasmMappingId);
-        JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
+        JsonObject result = importGermplasm(pathname, listName, listDescription, true);
         assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt());
 
         JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
@@ -302,6 +270,130 @@ public class GermplasmFileImportTest extends BrAPITest {
                 assertEquals(ImportObjectState.NEW.name(), state, "Wrong state returned");
             }
         }
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(5)
+    public void duplicateListEntriesSuccess() {
+        // Test that a germplasm list import referencing existing germplasm by GID can have duplicate entries.
+
+        String pathname = "src/test/resources/files/germplasm_import/valid_duplicate_entries.csv";
+        Table fileData = Table.read().file(pathname);
+        String listName = "Duplicates";
+        String listDescription = "New list referencing existing germplasm by GID with duplicate entries";
+
+        JsonObject result = importGermplasm(pathname, listName, listDescription, true);
+        assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt());
+
+        JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
+        List<String> germplasmNames = new ArrayList<>();
+        for (int i = 0; i < previewRows.size(); i++) {
+            JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
+            germplasmNames.add(germplasm.get("germplasmName").getAsString());
+            checkBasicResponse(germplasm, fileData, i);
+
+            // Germplasm name (display name)
+            String expectedGermplasmName = String.format("%s [%s-%s]", fileData.getString(i, "Germplasm Name"), validProgram.getKey(), germplasm.get("accessionNumber").getAsString());
+            assertEquals(expectedGermplasmName, germplasm.get("germplasmName").getAsString());
+            // Created Date
+            JsonObject additionalInfo = germplasm.getAsJsonObject("additionalInfo");
+            assertTrue(additionalInfo.has(BrAPIAdditionalInfoFields.CREATED_DATE), "createdDate is missing");
+            // Accession Number
+            assertTrue(germplasm.has("accessionNumber"), "accessionNumber missing");
+            // Pedigree (germplasm names)
+            String pedigree = germplasm.get("pedigree").getAsString();
+            String mother = !pedigree.isBlank() ? pedigree.split("/")[0] : null;
+            String father = !pedigree.isBlank() && pedigree.split("/").length > 1 ? pedigree.split("/")[1] : null;
+            String regexMatcher = "^(.*\\b) \\[([A-Z]{2,6})-(\\d+)\\]$";
+
+            // External Reference germplasm
+            JsonArray externalReferences = germplasm.getAsJsonArray("externalReferences");
+            boolean referenceFound = false;
+            for (JsonElement reference: externalReferences) {
+                String referenceSource = reference.getAsJsonObject().get("referenceSource").getAsString();
+                if (referenceSource.equals(BRAPI_REFERENCE_SOURCE)) {
+                    referenceFound = true;
+                    break;
+                }
+            }
+            assertTrue(referenceFound, "Germplasm UUID reference not found");
+
+            // Synonyms
+            String[] splitGermplasmName = germplasm.get("germplasmName").getAsString().split(" ");
+            String scope = splitGermplasmName[splitGermplasmName.length - 1];
+            JsonArray synonyms = germplasm.getAsJsonArray("synonyms");
+            for (JsonElement synonym: synonyms) {
+                String synonymName = synonym.getAsJsonObject().get("synonym").getAsString();
+                assertNotNull(synonymName);
+                assertTrue(synonymName.contains(scope), "Germplasm synonym was not properly scoped");
+            }
+        }
+
+        // Check the germplasm list
+        checkGermplasmList(Germplasm.constructGermplasmListName(listName, validProgram), listDescription, germplasmNames);
+    }
+
+    @Test
+    @SneakyThrows
+    @Order(6)
+    public void newAndExistingListEntriesSuccess() {
+        // Test that a germplasm list import that both creates new germplasm (GID empty) and references existing germplasm (by GID) succeeds.
+
+        String pathname = "src/test/resources/files/germplasm_import/new_and_existing_list_entries.csv";
+        Table fileData = Table.read().file(pathname);
+        String listName = "New and Existing Germplasm";
+        String listDescription = "New list containing both new and existing germplasm";
+
+        JsonObject result = importGermplasm(pathname, listName, listDescription, true);
+        assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt());
+
+        JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
+        List<String> germplasmNames = new ArrayList<>();
+        for (int i = 0; i < previewRows.size(); i++) {
+            JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
+            germplasmNames.add(germplasm.get("germplasmName").getAsString());
+            checkBasicResponse(germplasm, fileData, i);
+
+            // Germplasm name (display name)
+            String expectedGermplasmName = String.format("%s [%s-%s]", fileData.getString(i, "Germplasm Name"), validProgram.getKey(), germplasm.get("accessionNumber").getAsString());
+            assertEquals(expectedGermplasmName, germplasm.get("germplasmName").getAsString());
+            // Created Date
+            JsonObject additionalInfo = germplasm.getAsJsonObject("additionalInfo");
+            assertTrue(additionalInfo.has(BrAPIAdditionalInfoFields.CREATED_DATE), "createdDate is missing");
+            // Accession Number
+            assertTrue(germplasm.has("accessionNumber"), "accessionNumber missing");
+            // Pedigree (germplasm names)
+            String pedigree = germplasm.get("pedigree").getAsString();
+            String mother = !pedigree.isBlank() ? pedigree.split("/")[0] : null;
+            String father = !pedigree.isBlank() && pedigree.split("/").length > 1 ? pedigree.split("/")[1] : null;
+            String regexMatcher = "^(.*\\b) \\[([A-Z]{2,6})-(\\d+)\\]$";
+
+            // External Reference germplasm
+            JsonArray externalReferences = germplasm.getAsJsonArray("externalReferences");
+            boolean referenceFound = false;
+            for (JsonElement reference: externalReferences) {
+                String referenceSource = reference.getAsJsonObject().get("referenceSource").getAsString();
+                if (referenceSource.equals(BRAPI_REFERENCE_SOURCE)) {
+                    referenceFound = true;
+                    break;
+                }
+            }
+            assertTrue(referenceFound, "Germplasm UUID reference not found");
+
+            // Synonyms
+            String[] splitGermplasmName = germplasm.get("germplasmName").getAsString().split(" ");
+            String scope = splitGermplasmName[splitGermplasmName.length - 1];
+            JsonArray synonyms = germplasm.getAsJsonArray("synonyms");
+            for (JsonElement synonym: synonyms) {
+                String synonymName = synonym.getAsJsonObject().get("synonym").getAsString();
+                assertNotNull(synonymName);
+                assertTrue(synonymName.contains(scope), "Germplasm synonym was not properly scoped");
+            }
+        }
+
+        // Check the germplasm list
+        checkGermplasmList(Germplasm.constructGermplasmListName(listName, validProgram), listDescription, germplasmNames);
     }
 
     @Test
@@ -641,6 +733,17 @@ public class GermplasmFileImportTest extends BrAPITest {
         assertEquals(GermplasmProcessor.circularDependency, result.getAsJsonObject("progress").get("message").getAsString());
     }
 
+    private JsonObject importGermplasm(String pathname, String listName, String listDescription, Boolean commit) throws InterruptedException {
+        File file = new File(pathname);
+
+        Flowable<HttpResponse<String>> call = importTestUtils.uploadDataFile(file, Map.of(GERM_LIST_NAME, listName, GERM_LIST_DESC, listDescription), commit, client, validProgram, germplasmMappingId);
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.ACCEPTED, response.getStatus());
+        String importId = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("result").get("importId").getAsString();
+
+        HttpResponse<String> upload = importTestUtils.getUploadedFile(importId, client, validProgram, germplasmMappingId);
+        return JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
+    }
 
     public void checkBasicResponse(JsonObject germplasm, Table fileData, Integer i) {
 
@@ -720,6 +823,8 @@ public class GermplasmFileImportTest extends BrAPITest {
             JsonObject detailResult = JsonParser.parseString(detailResponse.body()).getAsJsonObject().getAsJsonObject("result");
             JsonArray germplasmList = detailResult.getAsJsonArray("data");
             List<Boolean> found = new ArrayList<>();
+            // Check that the list size is correct.
+            assertEquals(germplasmNames.size(), germplasmList.size());
             for (String germplasmName: germplasmNames) {
                 for (JsonElement listElement: germplasmList) {
                     if (listElement.getAsString().equals(germplasmName)) {

--- a/src/test/resources/files/germplasm_import/new_and_existing_list_entries.csv
+++ b/src/test/resources/files/germplasm_import/new_and_existing_list_entries.csv
@@ -1,0 +1,6 @@
+﻿GID,Germplasm Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID,Synonyms
+1,Germplasm 1,BCR,Wild,,,1,,,1414,
+2,Germplasm 2,BCR,Cultivated,,,2,,,1515,
+3,Germplasm 3,BCR,Kinda Wild,,,3,,,1616,
+,New Germ 1,BCR,Wild,1,2,4,,,3142,test01
+,New Germ 2,BCR,Wild,1,2,5,,,4211,test02

--- a/src/test/resources/files/germplasm_import/valid_duplicate_entries.csv
+++ b/src/test/resources/files/germplasm_import/valid_duplicate_entries.csv
@@ -1,4 +1,5 @@
 ﻿GID,Germplasm Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID,Synonyms
-,Germplasm 1,BCR,Wild,,,,,,1414,
-,Germplasm 2,BCR,Cultivated,,,,,,1515,
-,Germplasm 3,BCR,Kinda Wild,,,,,,1616,
+1,Germplasm 1,BCR,Wild,,,4,,,1414,
+2,Germplasm 2,BCR,Cultivated,,,3,,,1515,
+2,Germplasm 2,BCR,Cultivated,,,2,,,1515,
+1,Germplasm 1,BCR,Wild,,,1,,,1414,


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2304

- Removed `listEntryNumbers` additional info field.
- Used BrAPI list ordering to assign sequential entry numbers for display (including preview) and export of germplasm lists (instead of `listEntryNumbers`). The `importEntryNumber` additional info field is used for display purposes, i.e. it is set (or overwritten) based on the BrAPI list item ordering as germplasm records are processed for display. In this way, it can be used without issue for the same germplasm record in different positions in multiple lists or even the same list (in the case of duplicate entry).
- Used deep copy (the serialize and deserialize technique in `GermplasmProcessor::processExistingGermplasm` and `BrAPIGermplasmService::cloneBrAPIGermplasm` to support duplicate germplasm entries in a single list. The only reason for this is to get distinct entry numbers for display, there may be a better way to achieve this same functionality.
- Added integration tests for two germplasm list import cases,
    - when a germplasm import references existing germplasm by GID and has duplicates, and
    - when a germplasm import references existing germplasm by GID and creates new germplasm (empty GID) in the same list.
- Updated test files for a few germplasm tests that were using outdated templates.

bi-web PR: https://github.com/Breeding-Insight/bi-web/pull/399
BrAPI-Java-TestServer PR: https://github.com/Breeding-Insight/brapi-Java-TestServer/pull/35

# Dependencies
bi-web branch: feature/BI-2304
BrAPI-Java-TestServer branch: [feature/BI-2304](https://github.com/Breeding-Insight/brapi-Java-TestServer/tree/feature/BI-2304)

# Testing

### 1. Establish data to migrate.

- Run the `develop` branches of bi-api, bi-web and BrAPI-Java-TestServer.
- Import germplasm, ontology, and experiments into DeltaBreed.

### 2. Test migration process.

- Checkout the `feature/BI-2304` branches of bi-api, bi-web and BrAPI-Java-TestServer.
- Ensure the UI views and download files for experiments (but especially) germplasm still have all data.
    - In particular, ensure that germplasm lists are still ordered the same as when they were imported when sorted by Entry Number. Note that the Entry Number itself may change if you used non-contiguous Entry Numbers on your import, but the order must not change.

### 3. Test new functionality.

- Follow the acceptance criteria on [the Jira story](https://breedinginsight.atlassian.net/browse/BI-2304) to test the new functionality.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
