### PR TITLE
[BI-2310] - Exp import: extraneous error message

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -972,7 +972,11 @@ public class ExperimentProcessor implements Processor {
             String errorMessage = String.format("The ID (%s) is not unique within the environment(%s)", importRow.getExpUnitId(), importRow.getEnv());
             this.addRowError(Columns.EXP_UNIT_ID, errorMessage, validationErrors, rowNum);
         } else {
-            uniqueStudyAndObsUnit.add(envIdPlusStudyId);
+            //Only want to add valid unique study-obs unit combos
+            //To avoid situations like system counting a null value as a unique combo
+            if (!envIdPlusStudyId.isBlank()) {
+                uniqueStudyAndObsUnit.add(envIdPlusStudyId);
+            }
         }
     }
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/ExperimentUtilities.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/ExperimentUtilities.java
@@ -169,13 +169,19 @@ public class ExperimentUtilities {
      *
      * This method takes in the name of a study and the name of an observation unit and concatenates them to create a unique key.
      *
+     * If one or both of the inputs is null, returns an empty string since not a valid combination
+     *
      * @param studyName The name of the study
      * @param obsUnitName The name of the observation unit
      * @return A string representing the unique key formed by concatenating the study name and observation unit name
      */
     public static String createObservationUnitKey(String studyName, String obsUnitName) {
         // Concatenate the study name and observation unit name to create the unique key
-        return studyName + obsUnitName;
+        if (studyName != null && obsUnitName != null) {
+            return studyName + obsUnitName;
+        } else {
+            return "";
+        }
     }
 
 // Module/Script-level documentation

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/ValidatePendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/ValidatePendingImportObjectsStep.java
@@ -290,7 +290,11 @@ public class ValidatePendingImportObjectsStep {
             String errorMessage = String.format("The ID (%s) is not unique within the environment(%s)", importRow.getExpUnitId(), importRow.getEnv());
             ExperimentUtilities.addRowError(ExperimentObservation.Columns.EXP_UNIT_ID, errorMessage, validationErrors, rowNum);
         } else {
-            uniqueStudyAndObsUnit.add(envIdPlusStudyId);
+            //Only want to add valid unique study-obs unit combos
+            //To avoid situations like system counting a null value as a unique combo
+            if (!envIdPlusStudyId.isBlank()) {
+                uniqueStudyAndObsUnit.add(envIdPlusStudyId);
+            }
         }
     }
 


### PR DESCRIPTION
# Description
**Story:** [BI-2310 - Exp import: extraneous error message](https://breedinginsight.atlassian.net/browse/BI-2310)

Fix to prevent duplicate errors appearing on experiment import when the Exp Unit Id was missing that was due to the code treating <environment name> + null as a valid unique environment-expunitid combo.

# Dependencies
n/a

# Testing
Try to import an experiment file with a missing Exp Unit Id
In errors table should see for corresponding row and field combo a "Field is blank when creating a new experiment." error
And should NOT see a secondary "not unique within the environment" error

Also good to try the missing Env case and a valid file case

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
