### PR TITLE
[BI-2317] System Admin Must Retain Full Read Access To All Programs

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIStudiesController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIStudiesController.java
@@ -128,9 +128,6 @@ public class BrAPIStudiesController {
         } catch (IllegalArgumentException e) {
             log.info(e.getMessage(), e);
             return HttpResponse.status(HttpStatus.UNPROCESSABLE_ENTITY, "Error parsing requested date format");
-        } catch (DoesNotExistException e) {
-            log.info(e.getMessage(), e);
-            return HttpResponse.status(HttpStatus.NOT_FOUND, e.getMessage());
         }
     }
 

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIStudiesController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIStudiesController.java
@@ -95,32 +95,29 @@ public class BrAPIStudiesController {
             @PathVariable("programId") UUID programId,
             @QueryValue @QueryValid(using = StudyQueryMapper.class) @Valid StudyQuery queryParams) {
         try {
-            log.debug("fetching studies for program: " + programId);
-            List<BrAPIStudy> studies;
-
-            Optional<ProgramUser> experimentalCollaborator = programUserService.getIfExperimentalCollaborator(programId, securityService.getUser().getId());
-            // If the program user is an experimental collaborator, filter results.
-            if (experimentalCollaborator.isPresent()) {
-                Optional<Program> program = programService.getById(programId);
-                if (program.isEmpty()) {
-                    return HttpResponse.notFound();
-                }
-
-                List<UUID> experimentIds = experimentalCollaboratorService.getAuthorizedExperimentIds(experimentalCollaborator.get().getId());
-                studies = studyService.getStudiesByExperimentIds(program.get(), experimentIds)
-                        .stream()
-                        .peek(this::setDbIds)
-                        .collect(Collectors.toList());
-            } else {
-                studies = studyService.getStudies(programId)
-                        .stream()
-                        .peek(this::setDbIds)
-                        .collect(Collectors.toList());
-            }
+            Optional<Program> program = programService.getById(programId);
+            if (program.isEmpty()) { return HttpResponse.notFound(); }
 
             queryParams.setSortField(studyQueryMapper.getDefaultSortField());
             queryParams.setSortOrder(studyQueryMapper.getDefaultSortOrder());
             SearchRequest searchRequest = queryParams.constructSearchRequest();
+            log.debug("fetching studies for program: " + programId);
+
+            // If the program user is an experimental collaborator, filter results for only authorized studies.
+            Optional<ProgramUser> experimentalCollaborator = programUserService.getIfExperimentalCollaborator(programId, securityService.getUser().getId());
+            if (experimentalCollaborator.isPresent()) {
+                List<UUID> authorizedExperimentIds = experimentalCollaboratorService.getAuthorizedExperimentIds(experimentalCollaborator.get().getId());
+                List<BrAPIStudy> authorizedStudies = studyService.getStudiesByExperimentIds(program.get(), authorizedExperimentIds)
+                        .stream()
+                        .peek(this::setDbIds)
+                        .collect(Collectors.toList());
+                return ResponseUtils.getBrapiQueryResponse(authorizedStudies, studyQueryMapper, queryParams, searchRequest);
+            }
+
+            List<BrAPIStudy> studies = studyService.getStudies(programId)
+                        .stream()
+                        .peek(this::setDbIds)
+                        .collect(Collectors.toList());
             return ResponseUtils.getBrapiQueryResponse(studies, studyQueryMapper, queryParams, searchRequest);
         } catch (ApiException e) {
             log.info(e.getMessage(), e);

--- a/src/main/java/org/breedinginsight/services/ProgramUserService.java
+++ b/src/main/java/org/breedinginsight/services/ProgramUserService.java
@@ -281,16 +281,13 @@ public class ProgramUserService {
      * @param userId the user ID.
      * @return an Optional that unwraps to a program user if it is an Experimental Collaborator, Optional.empty() otherwise.
      */
-    public Optional<ProgramUser> getIfExperimentalCollaborator(UUID programId, UUID userId) throws DoesNotExistException {
-        Optional<ProgramUser> programUser = getProgramUserbyId(programId, userId);
-        if (programUser.isEmpty()) {
-            throw new DoesNotExistException("Program User does not exist");
-        }
-        boolean isExperimentalCollaborator = programUser.get().getRoles().stream().anyMatch(x -> ProgramSecuredRole.getEnum(x.getDomain()).equals(ProgramSecuredRole.EXPERIMENTAL_COLLABORATOR));
-        if (isExperimentalCollaborator) {
-            return programUser;
-        }
-        return Optional.empty();
+    public Optional<ProgramUser> getIfExperimentalCollaborator(UUID programId, UUID userId) {
+        return getProgramUserbyId(programId, userId)
+                .flatMap(user -> user.getRoles().stream()
+                        .anyMatch(role -> ProgramSecuredRole.getEnum(role.getDomain()).equals(ProgramSecuredRole.EXPERIMENTAL_COLLABORATOR))
+                        ? Optional.of(user)
+                        : Optional.empty()
+                );
     }
 
     public List<ProgramUser> getProgramUsersByRole(UUID programId, UUID roleId) throws DoesNotExistException {


### PR DESCRIPTION
# Description
**Story:** [BI-2317](https://breedinginsight.atlassian.net/browse/BI-2317)

This pull request removes a check when fetching collaborators that throws an exception if the user is not a program user. This check was causing problems for system users like sys admins that have access to a program. It refactors code in three files to improve error handling, optimize data retrieval, and enhance code clarity. 

- In BrAPIStudiesController.java, unnecessary exception handling for DoesNotExistException is removed. 
- BrAPITrialsController.java is restructured to streamline the process of fetching experiments, with improved handling for experimental collaborators and more efficient use of Optional. 
- ProgramUserService.java is refactored to simplify the getIfExperimentalCollaborator method using functional programming concepts. 
- Additionally, BrAPIStudiesController.java is further refined to improve readability and reduce code duplication in the getStudies method, particularly in handling experimental collaborators and constructing the response. 

# Dependencies
none

# Testing

1. Log in to Deltabreed as a System Administrator,
2. Create a program, but do not assign your sys admin user as program user for the newly created program.
3. Navigate to the Experiments table and confirm that a red error banner does not appear and the backend returns a 200 response (not 404)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2317]: https://breedinginsight.atlassian.net/browse/BI-2317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ