### PR TITLE
[BI-2328] Experimental observation file import removes periods from column headers

### DIFF
--- a/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
@@ -66,6 +66,11 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
     }
 
     @Override
+    public ValidationError getPeriodObsVarNameMsg() {
+        return new ValidationError("Name", "Period is invalid", HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Override
     public ValidationError getMissingObsVarNameMsg() {
         return new ValidationError("Name", "Missing name", HttpStatus.UNPROCESSABLE_ENTITY);
     }

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
@@ -66,6 +66,10 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
     }
 
     @Override
+    public ValidationError getPeriodObsVarNameMsg() {
+        return new ValidationError("observationVariableName", "Period in name is invalid", HttpStatus.BAD_REQUEST);
+    }
+
     public ValidationError getMissingObsVarNameMsg() {
         return new ValidationError("observationVariableName", "Missing Name", HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorErrorInterface.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorErrorInterface.java
@@ -31,6 +31,7 @@ public interface TraitValidatorErrorInterface {
     ValidationError getMissingScaleUnitMsg();
     ValidationError getMissingScaleDataTypeMsg();
     ValidationError getMissingObsVarNameMsg();
+    ValidationError getPeriodObsVarNameMsg();
     ValidationError getMissingTraitEntityMsg();
     ValidationError getMissingTraitAttributeMsg();
     ValidationError getMissingTraitDescriptionMsg();

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
@@ -16,6 +16,7 @@
  */
 package org.breedinginsight.services.validators;
 
+import io.micronaut.http.HttpStatus;
 import org.breedinginsight.api.model.v1.response.ValidationError;
 import org.breedinginsight.api.model.v1.response.ValidationErrors;
 import org.breedinginsight.dao.db.enums.DataType;
@@ -207,6 +208,23 @@ public class TraitValidatorService {
         return errors;
     }
 
+    public ValidationErrors checkTraitFieldsFormat(List<Trait> traits, TraitValidatorErrorInterface traitValidatorErrors) {
+
+        ValidationErrors errors = new ValidationErrors();
+
+        for (int i = 0; i < traits.size(); i++) {
+
+            Trait trait = traits.get(i);
+            String name = trait.getObservationVariableName();
+
+            if (name != null && name.contains(".")){
+                ValidationError error = traitValidatorErrors.getPeriodObsVarNameMsg();
+                errors.addError(traitValidatorErrors.getRowNumber(i), error);
+            }
+        }
+        return errors;
+    }
+
     public List<Trait> checkDuplicateTraitsExistingByName(UUID programId, List<Trait> traits){
 
         List<Trait> duplicates = new ArrayList<>();
@@ -273,7 +291,8 @@ public class TraitValidatorService {
         ValidationErrors dataConsistencyErrors = checkTraitDataConsistency(traits, traitValidatorError);
         ValidationErrors duplicateTraitsInFile = checkDuplicateTraitsInFile(traits, traitValidatorError);
         ValidationErrors fieldLengthError =  checkTraitFieldsLength(traits, traitValidatorError);
-        validationErrors.mergeAll(requiredFieldErrors, dataConsistencyErrors, duplicateTraitsInFile, fieldLengthError);
+        ValidationErrors fieldFormatErrors =  checkTraitFieldsFormat(traits, traitValidatorError);
+        validationErrors.mergeAll(requiredFieldErrors, dataConsistencyErrors, duplicateTraitsInFile, fieldLengthError, fieldFormatErrors);
 
         if (validationErrors.hasErrors()){
             return Optional.of(validationErrors);

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
@@ -27,6 +27,8 @@ import org.breedinginsight.model.Trait;
 
 import javax.inject.Inject;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -217,7 +219,11 @@ public class TraitValidatorService {
             Trait trait = traits.get(i);
             String name = trait.getObservationVariableName();
 
-            if (name != null && name.contains(".")){
+            Pattern pattern = Pattern.compile("\\.");
+            Matcher matcher = pattern.matcher(name);
+            boolean containsInvalidCharacter = matcher.find();
+
+            if (name != null && containsInvalidCharacter){
                 ValidationError error = traitValidatorErrors.getPeriodObsVarNameMsg();
                 errors.addError(traitValidatorErrors.getRowNumber(i), error);
             }

--- a/src/test/java/org/breedinginsight/model/delta/DeltaEntityFactoryUnitTest.java
+++ b/src/test/java/org/breedinginsight/model/delta/DeltaEntityFactoryUnitTest.java
@@ -426,6 +426,7 @@ public class DeltaEntityFactoryUnitTest extends DatabaseTest {
             .additionalInfo(toJsonObject(additionalInfoString))
             .collector("intern")
             .externalReferences(createExternalReferences())
+            .geoCoordinates(BrApiGeoJSON.builder().geometry(null).type("Feature").build())
             .germplasmDbId("2bb19ef2-fcc5-406d-b9c3-4517c665b699")
             .germplasmName("lucky")
             .observationTimeStamp(OffsetDateTime.now())

--- a/src/test/java/org/breedinginsight/model/delta/DeltaEntityFactoryUnitTest.java
+++ b/src/test/java/org/breedinginsight/model/delta/DeltaEntityFactoryUnitTest.java
@@ -426,7 +426,7 @@ public class DeltaEntityFactoryUnitTest extends DatabaseTest {
             .additionalInfo(toJsonObject(additionalInfoString))
             .collector("intern")
             .externalReferences(createExternalReferences())
-            .geoCoordinates(BrApiGeoJSON.builder().geometry(null).type("Feature").build())
+//            .geoCoordinates(BrApiGeoJSON.builder().geometry(null).type("Feature").build())
             .germplasmDbId("2bb19ef2-fcc5-406d-b9c3-4517c665b699")
             .germplasmName("lucky")
             .observationTimeStamp(OffsetDateTime.now())

--- a/src/test/java/org/breedinginsight/model/delta/DeltaEntityFactoryUnitTest.java
+++ b/src/test/java/org/breedinginsight/model/delta/DeltaEntityFactoryUnitTest.java
@@ -426,7 +426,7 @@ public class DeltaEntityFactoryUnitTest extends DatabaseTest {
             .additionalInfo(toJsonObject(additionalInfoString))
             .collector("intern")
             .externalReferences(createExternalReferences())
-//            .geoCoordinates(BrApiGeoJSON.builder().geometry(null).type("Feature").build())
+            .geoCoordinates(BrApiGeoJSON.builder().geometry(null).type("Feature").build())
             .germplasmDbId("2bb19ef2-fcc5-406d-b9c3-4517c665b699")
             .germplasmName("lucky")
             .observationTimeStamp(OffsetDateTime.now())

--- a/src/test/java/org/breedinginsight/model/delta/DeltaEntityFactoryUnitTest.java
+++ b/src/test/java/org/breedinginsight/model/delta/DeltaEntityFactoryUnitTest.java
@@ -426,7 +426,6 @@ public class DeltaEntityFactoryUnitTest extends DatabaseTest {
             .additionalInfo(toJsonObject(additionalInfoString))
             .collector("intern")
             .externalReferences(createExternalReferences())
-            .geoCoordinates(BrApiGeoJSON.builder().geometry(null).type("Feature").build())
             .germplasmDbId("2bb19ef2-fcc5-406d-b9c3-4517c665b699")
             .germplasmName("lucky")
             .observationTimeStamp(OffsetDateTime.now())

--- a/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
@@ -361,7 +361,7 @@ public class TraitValidatorUnitTest {
         RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
         assertEquals(1, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
         assertEquals(400, rowValidationErrors.getErrors().get(0).getHttpStatusCode(), "Wrong error code");
-        assertEquals("Name", rowValidationErrors.getErrors().get(0).getField(), "Wrong error column");
+        assertEquals("observationVariableName", rowValidationErrors.getErrors().get(0).getField(), "Wrong error column");
 
         //There should be no errors
         Trait noPeriodTrait = new Trait();

--- a/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
@@ -348,5 +348,28 @@ public class TraitValidatorUnitTest {
         }
     }
 
+    @Test
+    @SneakyThrows
+    public void periodInName() {
+
+        Trait trait = new Trait();
+        trait.setObservationVariableName("Period.1");
+
+        ValidationErrors validationErrors = traitValidatorService.checkTraitFieldsFormat(List.of(trait), new TraitValidatorError());
+
+        assertEquals(1, validationErrors.getRowErrors().size(), "Wrong number of row errors returned");
+        RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
+        assertEquals(1, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
+        assertEquals(400, rowValidationErrors.getErrors().get(0).getHttpStatusCode(), "Wrong error code");
+        assertEquals("Name", rowValidationErrors.getErrors().get(0).getField(), "Wrong error column");
+
+        //There should be no errors
+        Trait noPeriodTrait = new Trait();
+        noPeriodTrait.setObservationVariableName("NoPeriod");
+        validationErrors = traitValidatorService.checkTraitFieldsFormat(List.of(noPeriodTrait), new TraitValidatorError());
+        assertEquals(0, validationErrors.getRowErrors().size(), "Wrong number of row errors returned");
+    }
+
+
 
 }


### PR DESCRIPTION
[BI-2328](https://breedinginsight.atlassian.net/browse/BI-2328) Experimental observation file import removes periods from column headers

Added a validation so that a user can no longer add an ontology term with a period (.) in the Name field. 

# Dependencies
bi-web: **bug/BI-2328**

# Testing
**Test 1 (Manually add Ontology)**
1. Given user is logged in the application as a Program Administrator
2. Given user has selected an appropriate program (one in which they are a Program Administrator).
3. WHEN user selects "Ontology" in navigation
4. AND user selects 'New Term' button on ontology list page
5. AND user enters a text value with a period ('.') into the 'Name' field
6. AND user selects 'Save' button
7. THEN an error banner will appear with the text "Period in name is invalid"
8. AND the error message  "Period in name is invalid" will appear below the 'Name' field

**Test 2 (import Ontology)**
1. Given user is logged in the application as a Program Administrator
2. Given user has selected an appropriate program (one in which they are a Program Administrator).
3. WHEN user selects "Ontology" in navigation
4. AND user selects "Manage Ontology" button
5. AND user selects "Import file" link
6. AND user uploads Ontology "[bi_ontology_UAT-tyrwh-oat.xls](https://github.com/user-attachments/files/17317965/bi_ontology_UAT-tyrwh-oat.xls)" file
7. AND user selects 'Import' button
8. THEN an error banner will appear with the text, "`Error(s) detected in file, bi_ontology_UAT-tyrwh-oat.xls . (See details below.) Import cannot proceed`."
9. AND the error table will have the following values:
- Row = 7
- Field = 'Name'
- Error = 'Period is invalid'


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [X] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2328]: https://breedinginsight.atlassian.net/browse/BI-2328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ