### PR TITLE
BI-2306 - Helium BrAPI integration filter by accessionNumber 

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIPedigreeController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIPedigreeController.java
@@ -95,13 +95,14 @@ public class BrAPIPedigreeController {
         try {
             List<BrAPIPedigreeNode> pedigree = pedigreeDAO.getPedigree(
                     program.get(),
-                    Optional.ofNullable(includeParents),
-                    Optional.ofNullable(includeSiblings),
-                    Optional.ofNullable(includeProgeny),
-                    Optional.ofNullable(includeFullTree),
-                    Optional.ofNullable(pedigreeDepth),
-                    Optional.ofNullable(progenyDepth),
-                    Optional.ofNullable(germplasmName));
+                    includeParents,
+                    includeSiblings,
+                    includeProgeny,
+                    includeFullTree,
+                    pedigreeDepth,
+                    progenyDepth,
+                    germplasmName,
+                    accessionNumber);
 
             return HttpResponse.ok(
                     new BrAPIPedigreeListResponse()

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIPedigreeDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIPedigreeDAO.java
@@ -73,13 +73,14 @@ public class BrAPIPedigreeDAO {
      */
     public List<BrAPIPedigreeNode> getPedigree(
             Program program,
-            Optional<Boolean> includeParents,
-            Optional<Boolean> includeSiblings,
-            Optional<Boolean> includeProgeny,
-            Optional<Boolean> includeFullTree,
-            Optional<Integer> pedigreeDepth,
-            Optional<Integer> progenyDepth,
-            Optional<String> germplasmName
+            Boolean includeParents,
+            Boolean includeSiblings,
+            Boolean includeProgeny,
+            Boolean includeFullTree,
+            Integer pedigreeDepth,
+            Integer progenyDepth,
+            String germplasmName,
+            String accessionNumber
     ) throws ApiException {
 
         PedigreeQueryParams pedigreeRequest = new PedigreeQueryParams();
@@ -94,13 +95,14 @@ public class BrAPIPedigreeDAO {
         pedigreeRequest.externalReferenceId(extRefId);
         pedigreeRequest.externalReferenceSource(extRefSrc);
 
-        includeParents.ifPresent(pedigreeRequest::includeParents);
-        includeSiblings.ifPresent(pedigreeRequest::includeSiblings);
-        includeProgeny.ifPresent(pedigreeRequest::includeProgeny);
-        includeFullTree.ifPresent(pedigreeRequest::includeFullTree);
-        pedigreeDepth.ifPresent(pedigreeRequest::pedigreeDepth);
-        progenyDepth.ifPresent(pedigreeRequest::progenyDepth);
-        germplasmName.ifPresent(pedigreeRequest::germplasmName);
+        if (includeParents != null) pedigreeRequest.includeParents(includeParents);
+        if (includeSiblings != null) pedigreeRequest.includeSiblings(includeSiblings);
+        if (includeProgeny != null) pedigreeRequest.includeProgeny(includeProgeny);
+        if (includeFullTree != null) pedigreeRequest.includeFullTree(includeFullTree);
+        if (pedigreeDepth != null) pedigreeRequest.pedigreeDepth(pedigreeDepth);
+        if (progenyDepth != null) pedigreeRequest.progenyDepth(progenyDepth);
+        if (germplasmName != null) pedigreeRequest.germplasmName(germplasmName);
+        if (accessionNumber != null) pedigreeRequest.accessionNumber(accessionNumber);
         // TODO: other parameters
 
         // TODO: write utility to do paging instead of hardcoding


### PR DESCRIPTION
# Description
**Story:** [BI-2306](https://breedinginsight.atlassian.net/browse/BI-2306?atlOrigin=eyJpIjoiNmY0ZDE4ODk3ZWNiNGQzZGFmYmQwM2RhMjVlZTdiYzciLCJwIjoiaiJ9)

- Added query parameter for accessionNumber

# Dependencies
- None

# Testing
- Load data in Helium (https://helium.hutton.ac.uk) via BrAPI and filter by accessionNumber
  - Verify get data for that germplasm and loading time is acceptable in program with large amount of germplasm

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2306]: https://breedinginsight.atlassian.net/browse/BI-2306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ