### PR TITLE
BI-2338 - Germplasm file with problems is loading, but preventing download

### DIFF
--- a/src/main/java/org/breedinginsight/utilities/FileUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/FileUtil.java
@@ -101,11 +101,11 @@ public class FileUtil {
                         if (!stringValue.contains("-")) {
                             //No dashes, assume cell is numeric and not date
                             double cellValue = cell.getNumericCellValue();
-                            stringValue = BigDecimal.valueOf(cellValue).stripTrailingZeros().toPlainString();
+                            stringValue = BigDecimal.valueOf(cellValue).stripTrailingZeros().toPlainString().trim();
                         }
                         columns.get(header).add(stringValue);
                     } else {
-                        columns.get(header).add(formatter.formatCellValue(cell));
+                        columns.get(header).add(formatter.formatCellValue(cell).trim());
                     }
                 }
             }


### PR DESCRIPTION
# Description
**Story:** [BI-2338](https://breedinginsight.atlassian.net/browse/BI-2338?atlOrigin=eyJpIjoiMTRlYjM1YzkwYzFjNGZlZjkwNzJhNzI3NDZjODM2ZTMiLCJwIjoiaiJ9)

- Trim values in Excel file import flow

An additional [card](https://breedinginsight.atlassian.net/browse/BI-2366?atlOrigin=eyJpIjoiODA3ZTExNjVhZmM1NDA4ZDkxMmMwNjQ5NTE0OWQxOWIiLCJwIjoiaiJ9) was made for inclusion in a post MVP release to either not allow '[]' in germplasm names or only strip off the rightmost occurrence of them from names.

# Dependencies
- None

# Testing
- Ensure Germplasm import file with germplasm names containing trailing whitespace can be imported and downloaded without issue


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2338]: https://breedinginsight.atlassian.net/browse/BI-2338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ