### PR TITLE
BI-2328 Failed QA

### DIFF
--- a/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
@@ -66,6 +66,11 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
     }
 
     @Override
+    public ValidationError getPeriodObsVarNameMsg() {
+        return new ValidationError("Name", "Period is invalid", HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Override
     public ValidationError getMissingObsVarNameMsg() {
         return new ValidationError("Name", "Missing name", HttpStatus.UNPROCESSABLE_ENTITY);
     }

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
@@ -64,6 +64,11 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
     public ValidationError getMissingScaleDataTypeMsg() {
         return new ValidationError("scale.dataType", "Missing scale class", HttpStatus.BAD_REQUEST);
     }
+    
+    @Override
+    public ValidationError getPeriodObsVarNameMsg() {
+        return new ValidationError("observationVariableName", "Period in name is invalid", HttpStatus.BAD_REQUEST);
+    }
 
     @Override
     public ValidationError getMissingObsVarNameMsg() {

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorErrorInterface.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorErrorInterface.java
@@ -31,6 +31,7 @@ public interface TraitValidatorErrorInterface {
     ValidationError getMissingScaleUnitMsg();
     ValidationError getMissingScaleDataTypeMsg();
     ValidationError getMissingObsVarNameMsg();
+    ValidationError getPeriodObsVarNameMsg();
     ValidationError getMissingTraitEntityMsg();
     ValidationError getMissingTraitAttributeMsg();
     ValidationError getMissingTraitDescriptionMsg();

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
@@ -26,6 +26,8 @@ import org.breedinginsight.model.Trait;
 
 import javax.inject.Inject;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -206,7 +208,26 @@ public class TraitValidatorService {
         }
         return errors;
     }
+    public ValidationErrors checkTraitFieldsFormat(List<Trait> traits, TraitValidatorErrorInterface traitValidatorErrors) {
 
+        ValidationErrors errors = new ValidationErrors();
+
+        for (int i = 0; i < traits.size(); i++) {
+
+            Trait trait = traits.get(i);
+            String name = trait.getObservationVariableName();
+
+            Pattern pattern = Pattern.compile("\\.");
+            Matcher matcher = pattern.matcher(name);
+            boolean containsInvalidCharacter = matcher.find();
+
+            if (name != null && containsInvalidCharacter){
+                ValidationError error = traitValidatorErrors.getPeriodObsVarNameMsg();
+                errors.addError(traitValidatorErrors.getRowNumber(i), error);
+            }
+        }
+        return errors;
+    }
     public List<Trait> checkDuplicateTraitsExistingByName(UUID programId, List<Trait> traits){
 
         List<Trait> duplicates = new ArrayList<>();
@@ -273,7 +294,8 @@ public class TraitValidatorService {
         ValidationErrors dataConsistencyErrors = checkTraitDataConsistency(traits, traitValidatorError);
         ValidationErrors duplicateTraitsInFile = checkDuplicateTraitsInFile(traits, traitValidatorError);
         ValidationErrors fieldLengthError =  checkTraitFieldsLength(traits, traitValidatorError);
-        validationErrors.mergeAll(requiredFieldErrors, dataConsistencyErrors, duplicateTraitsInFile, fieldLengthError);
+        ValidationErrors fieldFormatErrors =  checkTraitFieldsFormat(traits, traitValidatorError);
+        validationErrors.mergeAll(requiredFieldErrors, dataConsistencyErrors, duplicateTraitsInFile, fieldLengthError, fieldFormatErrors);
 
         if (validationErrors.hasErrors()){
             return Optional.of(validationErrors);

--- a/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/validators/TraitValidatorUnitTest.java
@@ -348,5 +348,26 @@ public class TraitValidatorUnitTest {
         }
     }
 
+    @Test
+    @SneakyThrows
+    public void periodInName() {
+
+        Trait trait = new Trait();
+        trait.setObservationVariableName("Period.1");
+
+        ValidationErrors validationErrors = traitValidatorService.checkTraitFieldsFormat(List.of(trait), new TraitValidatorError());
+
+        assertEquals(1, validationErrors.getRowErrors().size(), "Wrong number of row errors returned");
+        RowValidationErrors rowValidationErrors = validationErrors.getRowErrors().get(0);
+        assertEquals(1, rowValidationErrors.getErrors().size(), "Wrong number of errors for row");
+        assertEquals(400, rowValidationErrors.getErrors().get(0).getHttpStatusCode(), "Wrong error code");
+        assertEquals("observationVariableName", rowValidationErrors.getErrors().get(0).getField(), "Wrong error column");
+
+        //There should be no errors
+        Trait noPeriodTrait = new Trait();
+        noPeriodTrait.setObservationVariableName("NoPeriod");
+        validationErrors = traitValidatorService.checkTraitFieldsFormat(List.of(noPeriodTrait), new TraitValidatorError());
+        assertEquals(0, validationErrors.getRowErrors().size(), "Wrong number of row errors returned");
+    }
 
 }


### PR DESCRIPTION
# Description
[BI-2328](https://breedinginsight.atlassian.net/browse/BI-2328) Experimental observation file import removes periods from column headers

The [previous pull request](https://github.com/Breeding-Insight/bi-api/pull/411) passed but was branched off of the 'develop' branch instead of the  'release/1.0' branch.  This PR fixes that.

# Dependencies
bi-web: bug/[BI-2328](https://breedinginsight.atlassian.net/browse/BI-2328)

# Testing
See the [previous pull request](https://github.com/Breeding-Insight/bi-api/pull/411)


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2328]: https://breedinginsight.atlassian.net/browse/BI-2328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2328]: https://breedinginsight.atlassian.net/browse/BI-2328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ