### PR TITLE
BI-2344 - Incorrect Germplasm Export in Case of Duplicate Germplasm Names

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -117,7 +117,8 @@ public class BrAPIGermplasmService {
 
             HashMap<String, Object> row = new HashMap<>();
             row.put("GID", Integer.valueOf(germplasmEntry.getAccessionNumber()));
-            row.put("Germplasm Name", germplasmEntry.getGermplasmName());
+            // Strip programKey and accessionNumber from germplasmName for the file output.
+            row.put("Germplasm Name", Utilities.removeProgramKeyAnyAccession(germplasmEntry.getGermplasmName(), program.getKey()));
             row.put("Breeding Method", germplasmEntry.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD).getAsString());
             String source = germplasmEntry.getSeedSource();
             row.put("Source", source);

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -89,7 +89,7 @@ public class BrAPIGermplasmService {
             // 1. the BrAPI list items are full names, and
             // 2. germplasmNames alone are not unique within a program, this led to unexpected behavior, see BI-2344.
             String uniqueGermplasmName = String.format("%s [%s-%s]", g.getGermplasmName(), program.getKey(), g.getAccessionNumber());
-            g.setGermplasmName(uniqueGermplasmName);  // For later.
+            g.setGermplasmName(uniqueGermplasmName);  // Mutate the germplasmName in place for later use.
             germplasmByName.put(uniqueGermplasmName, g);
         }
 

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -82,10 +82,15 @@ public class BrAPIGermplasmService {
         return germplasmDAO.getGermplasmByDBID(germplasmId, programId);
     }
 
-    public List<Map<String, Object>> processListData(List<BrAPIGermplasm> germplasm, BrAPIListDetails germplasmList){
+    public List<Map<String, Object>> processListData(List<BrAPIGermplasm> germplasm, BrAPIListDetails germplasmList, Program program){
         Map<String, BrAPIGermplasm> germplasmByName = new HashMap<>();
         for (BrAPIGermplasm g: germplasm) {
-            germplasmByName.put(g.getGermplasmName(), g);
+            // Use the full, unique germplasmName with programKey and accessionNumber (GID) for 2 reasons:
+            // 1. the BrAPI list items are full names, and
+            // 2. germplasmNames alone are not unique within a program, this led to unexpected behavior, see BI-2344.
+            String uniqueGermplasmName = String.format("%s [%s-%s]", g.getGermplasmName(), program.getKey(), g.getAccessionNumber());
+            g.setGermplasmName(uniqueGermplasmName);  // For later.
+            germplasmByName.put(uniqueGermplasmName, g);
         }
 
         List<Map<String, Object>> processedData =  new ArrayList<>();
@@ -107,8 +112,6 @@ public class BrAPIGermplasmService {
         for (String germplasmName: orderedGermplasmNames) {
             // Increment entryNumber.
             ++entryNumber;
-            // Strip program key and accession number from germplasm name.
-            germplasmName = Utilities.removeUnknownProgramKey(germplasmName);  // TODO: could move to the germplasmList != null codepath.
             // Lookup the BrAPI germplasm in the map.
             BrAPIGermplasm germplasmEntry = germplasmByName.get(germplasmName);
 
@@ -217,7 +220,7 @@ public class BrAPIGermplasmService {
         return (BrAPIGermplasm) gson.fromJson(gson.toJson(germplasm), BrAPIGermplasm.class);
     }
 
-    public DownloadFile exportGermplasm(UUID programId, FileType fileExtension) throws IllegalArgumentException, ApiException, IOException {
+    public DownloadFile exportGermplasm(UUID programId, FileType fileExtension) throws IllegalArgumentException, ApiException, IOException, DoesNotExistException {
         List<Column> columns = GermplasmFileColumns.getOrderedColumns();
 
         //Retrieve germplasm list data
@@ -238,7 +241,8 @@ public class BrAPIGermplasmService {
 
         StreamedFile downloadFile;
         //Convert list data to List<Map<String, Object>> data to pass into file writer
-        List<Map<String, Object>> processedData =  processListData(germplasm, null);
+        Program program = programService.getById(programId).orElseThrow(() -> new DoesNotExistException("Could not find program: " + programId));
+        List<Map<String, Object>> processedData =  processListData(germplasm, null, program);
 
         if (fileExtension == FileType.CSV){
             downloadFile = CSVWriter.writeToDownload(columns, processedData, fileExtension);
@@ -249,7 +253,7 @@ public class BrAPIGermplasmService {
         return new DownloadFile(fileName, downloadFile);
     }
 
-    public DownloadFile exportGermplasmList(UUID programId, String listId, FileType fileExtension) throws IllegalArgumentException, ApiException, IOException {
+    public DownloadFile exportGermplasmList(UUID programId, String listId, FileType fileExtension) throws IllegalArgumentException, ApiException, IOException, DoesNotExistException {
         List<Column> columns = GermplasmFileColumns.getOrderedColumns();
 
         //Retrieve germplasm list data
@@ -260,15 +264,12 @@ public class BrAPIGermplasmService {
         List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
 
         String listName = listData.getListName();
-        Optional<Program> optionalProgram = programService.getById(programId);
-        if (optionalProgram.isPresent()) {
-            Program program = optionalProgram.get();
-            listName = removeAppendedKey(listName, program.getKey());
-        }
+        Program program = programService.getById(programId).orElseThrow(() -> new DoesNotExistException("Could not find program: " + programId));
+        listName = removeAppendedKey(listName, program.getKey());
         String fileName = createFileName(listData, listName);
         StreamedFile downloadFile;
         //Convert list data to List<Map<String, Object>> data to pass into file writer
-        List<Map<String, Object>> processedData =  processListData(germplasm, listData);
+        List<Map<String, Object>> processedData =  processListData(germplasm, listData, program);
 
         if (fileExtension == FileType.CSV){
             downloadFile = CSVWriter.writeToDownload(columns, processedData, fileExtension);


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2344

I introduced this regression in [BI-2304](https://breedinginsight.atlassian.net/browse/BI-2304).

Because germplasm names are not guaranteed to be unique within a program or list, code that used germplasm name as a key for lookups had unexpected behavior in the case of multiple distinct germplasm in a list that shared the same name (different GIDs, same name is allowed).

The solution was to use the "{germplasmName} [{programKey}-{accessionNumber}]" format as the key for lookups instead, which is what is stored in the backing BrAPI service. Finally, the program key and accession number are stripped from the germplasm name when building the output file data (we don't want to display that to the user).


# Testing
1. Upload a germplasm file with duplicate germplasm names. Small example attached.
[germplasmDuplicateNames.xlsx](https://github.com/user-attachments/files/17559957/germplasmDuplicateNames.xlsx)
2. Download all germplasm for the program.
3. Ensure export file is ordered by GID and has no duplicate GIDs (though it has duplicate names).

The screenshot below shows an example upload file, erroneous output (release/1.0 branch) and correct output (bug/BI-2344 branch).
<img width="908" alt="Screenshot 2024-10-29 at 12 09 20 PM" src="https://github.com/user-attachments/assets/b73a3715-607e-4641-a810-f6d7753a6650">


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2304]: https://breedinginsight.atlassian.net/browse/BI-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ