### PR TITLE
[BI-2354] - Incorrect Case Sensitivity in Exp Import Error Message

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -525,7 +525,7 @@ public class ExperimentProcessor implements Processor {
                                                          .map(TraitEntity::getObservationVariableName)
                                                          .collect(Collectors.toSet());
             List<String> differences = varNames.stream()
-                                               .filter(var -> !returnedVarNames.contains(var))
+                                               .filter(var -> !Utilities.containsCaseInsensitive(var, returnedVarNames))
                                                .collect(Collectors.toList());
             //TODO convert this to a ValidationError
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY,

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/services/ExperimentValidateService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/services/ExperimentValidateService.java
@@ -27,6 +27,7 @@ import org.breedinginsight.dao.db.tables.pojos.TraitEntity;
 import org.breedinginsight.model.Trait;
 import org.breedinginsight.services.OntologyService;
 import org.breedinginsight.services.exceptions.DoesNotExistException;
+import org.breedinginsight.utilities.Utilities;
 import tech.tablesaw.columns.Column;
 
 import javax.inject.Inject;
@@ -78,7 +79,7 @@ public class ExperimentValidateService {
                     .map(TraitEntity::getObservationVariableName)
                     .collect(Collectors.toSet());
             List<String> differences = varNames.stream()
-                    .filter(var -> !returnedVarNames.contains(var))
+                    .filter(var -> !Utilities.containsCaseInsensitive(var, returnedVarNames))
                     .collect(Collectors.toList());
             //TODO convert this to a ValidationError
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY,

--- a/src/main/java/org/breedinginsight/utilities/Utilities.java
+++ b/src/main/java/org/breedinginsight/utilities/Utilities.java
@@ -27,10 +27,7 @@ import org.flywaydb.core.api.migration.Context;
 import java.lang.reflect.Field;
 import java.sql.ResultSet;
 import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -48,10 +45,10 @@ public class Utilities {
      * Case insensitive search for string in string list
      *
      * @param target - string to search for
-     * @param list - list of strings to search in
+     * @param list - collection of strings to search in
      * @return true if case insensitive match, false otherwise
      */
-    public static boolean containsCaseInsensitive(String target, List<String> list){
+    public static boolean containsCaseInsensitive(String target, Collection<String> list){
         return list.stream().anyMatch(x -> x.equalsIgnoreCase(target));
     }
 


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2354

- Made the code that collects invalid ontology terms for the error message do a case-insensitive contains (thanks Nick for the utility method).
- Modified aforementioned `containsCaseInsensitive` utility method to work on any `Collection<String>` so I could use it on a `Set<String>` as well as a `List<String>`.
- The second place I updated the code to be case-insensitive (in ExperimentProcessor.java) seems to be unused, but I updated the logic in case it is ever used again.

# Testing
1. Import germplasm: [100_germplasm_QUICK.csv](https://github.com/user-attachments/files/17576845/100_germplasm_QUICK.csv).
2. Import ontology: [R2D2_Active_Ontology_2024-10-30_04-56-59+0000.xlsx](https://github.com/user-attachments/files/17576849/R2D2_Active_Ontology_2024-10-30_04-56-59%2B0000.xlsx).
3. Try importing this experiment file before and after fixing the "Fry Colors" ontology term (should be "Fry Color"), with different casing: [Exp_Error.xls](https://github.com/user-attachments/files/17576917/Exp_Error.xls). The error message should only list ontology terms that are misspelled, it should be case-insensitive. And when the misspelling is corrected, the ontology terms should be accepted with any casing.



# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
