### PR TITLE
[BI-2355] - Non-informative error message: regression

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
@@ -172,7 +172,7 @@ public class FileImportService {
         }
 
         // replace certain special characters with "" in column names to deal with json flattening issue in tablesaw
-        // this includes ".", "[", "["
+        // this includes ".", "[", "]"
         List<String> columnNames = df.columnNames();
         List<String> namesToReplace = new ArrayList<>();
         for (String name : columnNames) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
@@ -171,11 +171,12 @@ public class FileImportService {
             throw new UnsupportedTypeException("Unsupported mime type");
         }
 
-        // replace "." with "" in column names to deal with json flattening issue in tablesaw
+        // replace certain special characters with "" in column names to deal with json flattening issue in tablesaw
+        // this includes ".", "[", "["
         List<String> columnNames = df.columnNames();
         List<String> namesToReplace = new ArrayList<>();
         for (String name : columnNames) {
-            if (name.contains(".")) {
+            if (name.contains(".") || name.contains("[") || name.contains("]")) {
                 namesToReplace.add(name);
             }
         }
@@ -183,7 +184,8 @@ public class FileImportService {
         List<Column<?>> columns = df.columns(namesToReplace.stream().toArray(String[]::new));
         for (int i=0; i<columns.size(); i++) {
             Column<?> column = columns.get(i);
-            column.setName(namesToReplace.get(i).replace(".",""));
+            //if more characters, could use replaceall and regex, but this works presently
+            column.setName(namesToReplace.get(i).replace(".","").replace("[","").replace("]",""));
         }
 
         return df;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
@@ -173,20 +173,9 @@ public class FileImportService {
 
         // replace certain special characters with "" in column names to deal with json flattening issue in tablesaw
         // this includes ".", "[", "]"
-        List<String> columnNames = df.columnNames();
-        List<String> namesToReplace = new ArrayList<>();
-        for (String name : columnNames) {
-            if (name.contains(".") || name.contains("[") || name.contains("]")) {
-                namesToReplace.add(name);
-            }
-        }
-
-        List<Column<?>> columns = df.columns(namesToReplace.stream().toArray(String[]::new));
-        for (int i=0; i<columns.size(); i++) {
-            Column<?> column = columns.get(i);
-            //if more characters, could use replaceall and regex, but this works presently
-            column.setName(namesToReplace.get(i).replace(".","").replace("[","").replace("]",""));
-        }
+        df.columns().forEach(
+            (c) -> c.setName(c.name().replace(".","").replace("[","").replace("]",""))
+        );
 
         return df;
     }

--- a/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitFileValidatorError.java
@@ -66,8 +66,8 @@ public class TraitFileValidatorError implements TraitValidatorErrorInterface {
     }
 
     @Override
-    public ValidationError getPeriodObsVarNameMsg() {
-        return new ValidationError("Name", "Period is invalid", HttpStatus.UNPROCESSABLE_ENTITY);
+    public ValidationError getInvalidCharObsVarNameMsg() {
+        return new ValidationError("Name", "Periods and brackets are invalid", HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Override

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
@@ -67,7 +67,7 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
     
     @Override
     public ValidationError getInvalidCharObsVarNameMsg() {
-        return new ValidationError("observationVariableName", "Periods and brackets in name is invalid", HttpStatus.BAD_REQUEST);
+        return new ValidationError("observationVariableName", "Periods and brackets in name are invalid", HttpStatus.BAD_REQUEST);
     }
 
     @Override

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
@@ -70,6 +70,7 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
         return new ValidationError("observationVariableName", "Periods and brackets in name is invalid", HttpStatus.BAD_REQUEST);
     }
 
+    @Override
     public ValidationError getMissingObsVarNameMsg() {
         return new ValidationError("observationVariableName", "Missing Name", HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorError.java
@@ -66,11 +66,10 @@ public class TraitValidatorError implements TraitValidatorErrorInterface {
     }
     
     @Override
-    public ValidationError getPeriodObsVarNameMsg() {
-        return new ValidationError("observationVariableName", "Period in name is invalid", HttpStatus.BAD_REQUEST);
+    public ValidationError getInvalidCharObsVarNameMsg() {
+        return new ValidationError("observationVariableName", "Periods and brackets in name is invalid", HttpStatus.BAD_REQUEST);
     }
 
-    @Override
     public ValidationError getMissingObsVarNameMsg() {
         return new ValidationError("observationVariableName", "Missing Name", HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorErrorInterface.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorErrorInterface.java
@@ -31,7 +31,7 @@ public interface TraitValidatorErrorInterface {
     ValidationError getMissingScaleUnitMsg();
     ValidationError getMissingScaleDataTypeMsg();
     ValidationError getMissingObsVarNameMsg();
-    ValidationError getPeriodObsVarNameMsg();
+    ValidationError getInvalidCharObsVarNameMsg();
     ValidationError getMissingTraitEntityMsg();
     ValidationError getMissingTraitAttributeMsg();
     ValidationError getMissingTraitDescriptionMsg();

--- a/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
+++ b/src/main/java/org/breedinginsight/services/validators/TraitValidatorService.java
@@ -217,12 +217,12 @@ public class TraitValidatorService {
             Trait trait = traits.get(i);
             String name = trait.getObservationVariableName();
 
-            Pattern pattern = Pattern.compile("\\.");
+            Pattern pattern = Pattern.compile("[\\.\\]\\[]");
             Matcher matcher = pattern.matcher(name);
             boolean containsInvalidCharacter = matcher.find();
 
             if (name != null && containsInvalidCharacter){
-                ValidationError error = traitValidatorErrors.getPeriodObsVarNameMsg();
+                ValidationError error = traitValidatorErrors.getInvalidCharObsVarNameMsg();
                 errors.addError(traitValidatorErrors.getRowNumber(i), error);
             }
         }


### PR DESCRIPTION
# Description
(New branch due to soiled changelist in previous attempt)

**Story:**  [BI-2355 - Non-informative error message: regression](https://breedinginsight.atlassian.net/browse/BI-2355)

This error was due to tablesaw processing brackets weirdly, resulting in the column name stored in data not matching the column name stored in dynamic column names. This was fixed in two parts:

1) Removing brackets from ontology term names on upload

2) Preventing ontology terms with brackets in the name from being created by extending the functionality created in BI-2328

Note that this means for the error message re ontology terms not found, periods and brackets will be removed from the invalid ontology term names

# Dependencies
bi-web: [bug/BI-2355.2](https://github.com/Breeding-Insight/bi-web/pull/412)

# Testing
Test that on upload of an experiment file with invalid ontology term columns headings that contain brackets and/or periods that the unknown error message no longer shows and instead the invalid ontology term message shows

Test that upload of experiment file with valid ontology terms proceeds as expected

Test that the appropriate error is thrown when an ontology term contains ".", "[" and/or "]" and that that error is not thrown when the ontology term does not contain those characters for:
- Ontology Term Creation in UI
- Ontology Term Edit
- Ontology Term File Upload

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_