### PR TITLE
BI-2328 and BI-2355 failed QA

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/FileImportService.java
@@ -171,12 +171,6 @@ public class FileImportService {
             throw new UnsupportedTypeException("Unsupported mime type");
         }
 
-        // replace certain special characters with "" in column names to deal with json flattening issue in tablesaw
-        // this includes ".", "[", "]"
-        df.columns().forEach(
-            (c) -> c.setName(c.name().replace(".","").replace("[","").replace("]",""))
-        );
-
         return df;
     }
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/DynamicColumnParser.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/DynamicColumnParser.java
@@ -16,6 +16,8 @@
  */
 package org.breedinginsight.brapps.importer.services.processors.experiment;
 
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
 import lombok.Getter;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
@@ -35,6 +37,15 @@ public class DynamicColumnParser {
      * @return A DynamicColumnParseResult object containing the parsed phenotype and timestamp columns.
      */
     public static DynamicColumnParseResult parse(Table data, String[] dynamicColumnNames) {
+
+        // don't allow periods (.) or square brackets in Dynamic Column Names
+        for (String dynamicColumnName: dynamicColumnNames) {
+            if(dynamicColumnName.contains(".") || dynamicColumnName.contains("[") || dynamicColumnName.contains("]")){
+                String errorMsg = String.format("Observation columns may not contain periods or square brackets (see column '%s')", dynamicColumnName);
+                throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, errorMsg);
+            }
+        }
+
         List<Column<?>> dynamicCols = data.columns(dynamicColumnNames);
         List<Column<?>> phenotypeCols = new ArrayList<>();
         List<Column<?>> timestampCols = new ArrayList<>();

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/middleware/process/ImportTableProcess.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/middleware/process/ImportTableProcess.java
@@ -22,6 +22,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Prototype;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.commons.lang3.StringUtils;
@@ -112,6 +114,14 @@ public class ImportTableProcess extends AppendOverwriteMiddleware {
         ImportUpload upload = context.getImportContext().getUpload();
         Table data = context.getImportContext().getData();
         String[] dynamicColNames = upload.getDynamicColumnNames();
+
+        // don't allow periods (.) or square brackets in Dynamic Column Names
+        for (String dynamicColumnName: dynamicColNames) {
+            if(dynamicColumnName.contains(".") || dynamicColumnName.contains("[") || dynamicColumnName.contains("]")){
+                String errorMsg = String.format("Observation columns may not contain periods or square brackets (see column '%s')", dynamicColumnName);
+                throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, errorMsg);
+            }
+        }
         List<Column<?>> dynamicCols = data.columns(dynamicColNames);
 
         // Collect the columns for observation variable data


### PR DESCRIPTION
[BI-2328](https://breedinginsight.atlassian.net/browse/BI-2328) Experimental observation file import removes periods from column headers
[BI-2355](https://breedinginsight.atlassian.net/browse/BI-2355) Non-informative error message: regression


If the user attempts to import an experiment with periods or square brackets in the observation headings.  The user will get an error.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2328]: https://breedinginsight.atlassian.net/browse/BI-2328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2355]: https://breedinginsight.atlassian.net/browse/BI-2355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ