### PR TITLE
BI-2156 - Upgrade Apache Tika to 2.3.0+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,8 @@
         <brapi-java-client.version>2.1-SNAPSHOT</brapi-java-client.version>
         <commons-io.version>2.11.0</commons-io.version>
         <tika-app.version>2.9.2</tika-app.version>
+        <!-- Hard-coded version of transitive dependency commons compress seems to be needed. -->
+        <commons-compress.version>1.26.1</commons-compress.version>
         <javaxmail.version>1.6.2</javaxmail.version>
         <st4.version>4.3.1</st4.version>
         <tablesaw.version>1.0.0-SNAPSHOT</tablesaw.version>
@@ -379,6 +381,11 @@
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-app</artifactId>
             <version>${tika-app.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons-compress.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,6 @@
         <okhttp.version>4.9.3</okhttp.version>
         <mockito.version>4.3.1</mockito.version>
         <brapi-java-client.version>2.1-SNAPSHOT</brapi-java-client.version>
-        <commons-io.version>2.11.0</commons-io.version>
         <tika-app.version>2.9.2</tika-app.version>
         <!-- Hard-coded version of transitive dependency commons compress seems to be needed. -->
         <commons-compress.version>1.26.1</commons-compress.version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,7 @@
         <mockito.version>4.3.1</mockito.version>
         <brapi-java-client.version>2.1-SNAPSHOT</brapi-java-client.version>
         <commons-io.version>2.11.0</commons-io.version>
-        <tika-app.version>2.2.1</tika-app.version>
-        <!-- Version of apache-poi depends on version of tika. Tika uses these. -->
-        <apache-poi.version>4.1.2</apache-poi.version>
-        <apache-poi-ooxml.version>4.1.2</apache-poi-ooxml.version>
+        <tika-app.version>2.9.2</tika-app.version>
         <javaxmail.version>1.6.2</javaxmail.version>
         <st4.version>4.3.1</st4.version>
         <tablesaw.version>1.0.0-SNAPSHOT</tablesaw.version>
@@ -377,31 +374,6 @@
             <groupId>org.brapi</groupId>
             <artifactId>brapi-java-client</artifactId>
             <version>${brapi-java-client.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-csv</artifactId>
-            <version>${apache-commons-csv.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.poi</groupId>
-            <artifactId>poi</artifactId>
-            <version>${apache-poi.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.poi</groupId>
-            <artifactId>poi-ooxml</artifactId>
-            <version>${apache-poi-ooxml.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>${apache-commons-lang.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>


### PR DESCRIPTION
# Description
**Story:** [BI-2156](https://breedinginsight.atlassian.net/browse/BI-2156)

- Upgraded apache tika to 2.9.2.
- Removed as many hard-coded transitive dependencies as possible.
- Hard-coded transitive dependency apache commons compress, because some tests were failing without specifying a compatible version.

# Testing
**You may need to do a maven `clean install`.**

- Test uploading files, verify no unexpected errors.
- Ensure tests pass.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2156]: https://breedinginsight.atlassian.net/browse/BI-2156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ