### PR TITLE
[BI-2343] - GID filtering not informative

### DIFF
--- a/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
+++ b/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
@@ -193,11 +193,16 @@ public class ResponseUtils {
                     .collect(Collectors.toList());
         }
 
-        //To enable checking for the case of Germplasm Search when the filter is accessionNumber and thereby needs to do exact match
+        //To enable checking for the case of Germplasm Search when the filter is accessionNumber or list entry number and thereby needs to do exact match
         String accessionNumFilter;
         if (mapper.exists("accessionNumber")) accessionNumFilter = mapper.getField("accessionNumber").toString();
         else {
             accessionNumFilter = "";
+        }
+        String entryNumFilter;
+        if (mapper.exists("importEntryNumber")) entryNumFilter = mapper.getField("importEntryNumber").toString();
+        else {
+            entryNumFilter = "";
         }
 
         if (filterFields.size() > 0){
@@ -221,6 +226,11 @@ public class ResponseUtils {
                                 }
                                 else if (!accessionNumFilter.isEmpty() && filterField.getField().toString().equals(accessionNumFilter)) {
                                     //enable exact match in case of GID
+                                    return filterField.getField().apply(record).toString()
+                                            .toLowerCase().equalsIgnoreCase(filterField.getValue().toLowerCase());
+                                }
+                                else if (!entryNumFilter.isEmpty() && filterField.getField().toString().equals(entryNumFilter)) {
+                                    //enable exact match in case of entry number
                                     return filterField.getField().apply(record).toString()
                                             .toLowerCase().equalsIgnoreCase(filterField.getValue().toLowerCase());
                                 } else {

--- a/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
+++ b/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
@@ -193,6 +193,13 @@ public class ResponseUtils {
                     .collect(Collectors.toList());
         }
 
+        //To enable checking for the case of Germplasm Search when the filter is accessionNumber and thereby needs to do exact match
+        String accessionNumFilter;
+        if (mapper.exists("accessionNumber")) accessionNumFilter = mapper.getField("accessionNumber").toString();
+        else {
+            accessionNumFilter = "";
+        }
+
         if (filterFields.size() > 0){
             // Apply filters
             List<FilterField> finalFilterFields = filterFields;
@@ -211,6 +218,11 @@ public class ResponseUtils {
                                     return recordList.stream()
                                             .anyMatch(listValue ->
                                                     listValue.toString().toLowerCase().contains(filterField.getValue().toLowerCase()));
+                                }
+                                else if (!accessionNumFilter.isEmpty() && filterField.getField().toString().equals(accessionNumFilter)) {
+                                    //enable exact match in case of GID
+                                    return filterField.getField().apply(record).toString()
+                                            .toLowerCase().equalsIgnoreCase(filterField.getValue().toLowerCase());
                                 } else {
                                     return filterField.getField().apply(record).toString()
                                             .toLowerCase().contains(filterField.getValue().toLowerCase());


### PR DESCRIPTION
# Description
**Story:** [BI-2343 - GID filtering not informative](https://breedinginsight.atlassian.net/browse/BI-2343)

Changes to enable exact match GID filtering for multiple tables

For Experiment Details and Sample Submission Details tables, frontend search is used, so a custom-search function was added in the respective buefy files to do exact search filtering in the GID case.

For Germplasm and Germplasm list tables, backend search is used, which presently only does partial matching. Due to the high risk associated with modifying backend search to alternatively enable exact or partial match for each filter, ResponseUtils:search was slightly modified to do an exact match specifically when the filter is accessionNumber.

# Dependencies
[bi-web: bug/BI-2343](https://github.com/Breeding-Insight/bi-web/pull/418)

# Testing
see bi-web

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: [_\<please include a link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/11936407481)
