### PR TITLE
BI-2376 - Create Delete Endpoint for Deltabreed Experiment Controller

### DIFF
--- a/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
@@ -319,7 +319,6 @@ public class ExperimentController {
             if(program.isEmpty()) {
                 return HttpResponse.notFound();
             }
-            // TODO: If hard and non-zero result, return 409 Conflict.
             int observationCount = experimentService.deleteExperiment(program.get(), experimentId, hard);
             if (observationCount > 0 && hard) {
                 // 409 Conflict. https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
@@ -327,11 +326,14 @@ public class ExperimentController {
             }
             // 204 No Content indicates successful delete. https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
             return HttpResponse.noContent();
-        } catch (Exception e) {
+        } catch (ApiException e) {
             log.error("Error deleting experiment.\n\tprogramId: " + programId +  "\n\texperimentId: " + experimentId + "\n\thard: " + hard);
-            throw e;
+            if (e.getCode() == 404) {
+                return HttpResponse.notFound();
+            } else {
+                return HttpResponse.serverError();
+            }
         }
-
     }
 
 

--- a/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
@@ -325,7 +325,8 @@ public class ExperimentController {
                 // 409 Conflict. https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
                 return HttpResponse.status(HttpStatus.CONFLICT);
             }
-            return HttpResponse.ok();
+            // 204 No Content indicates successful delete. https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+            return HttpResponse.noContent();
         } catch (Exception e) {
             log.error("Error deleting experiment.\n\tprogramId: " + programId +  "\n\texperimentId: " + experimentId + "\n\thard: " + hard);
             throw e;

--- a/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
@@ -319,9 +319,12 @@ public class ExperimentController {
             if(program.isEmpty()) {
                 return HttpResponse.notFound();
             }
-
-            experimentService.deleteExperiment(program.get(), experimentId, hard);
-
+            // TODO: If hard and non-zero result, return 409 Conflict.
+            int observationCount = experimentService.deleteExperiment(program.get(), experimentId, hard);
+            if (observationCount > 0 && hard) {
+                // 409 Conflict. https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+                return HttpResponse.status(HttpStatus.CONFLICT);
+            }
             return HttpResponse.ok();
         } catch (Exception e) {
             log.error("Error deleting experiment.\n\tprogramId: " + programId +  "\n\texperimentId: " + experimentId + "\n\thard: " + hard);

--- a/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
@@ -298,4 +298,37 @@ public class ExperimentController {
         }
 
     }
+
+    /**
+     * Deletes an experiment.
+     * @param programId The UUID of the program
+     * @param experimentId The UUID of the experiment
+     * @param hard Specifies hard or soft delete
+     * @return A Http Response
+     */
+    @Delete("/${micronaut.bi.api.version}/programs/{programId}/experiments/{experimentId}{?hard}")
+    @ProgramSecured(roles = {ProgramSecuredRole.PROGRAM_ADMIN, ProgramSecuredRole.SYSTEM_ADMIN})
+    @Produces(MediaType.APPLICATION_JSON)
+    public HttpResponse deleteExperiment(
+            @PathVariable("programId") UUID programId,
+            @PathVariable("experimentId") UUID experimentId,
+            @QueryValue(defaultValue = "false") Boolean hard
+    ) throws ApiException {
+        try {
+            Optional<Program> program = programService.getById(programId);
+            if(program.isEmpty()) {
+                return HttpResponse.notFound();
+            }
+
+            experimentService.deleteExperiment(program.get(), experimentId, hard);
+
+            return HttpResponse.ok();
+        } catch (Exception e) {
+            log.error("Error deleting experiment.\n\tprogramId: " + programId +  "\n\texperimentId: " + experimentId + "\n\thard: " + hard);
+            throw e;
+        }
+
+    }
+
+
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPICachedDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPICachedDAO.java
@@ -1,0 +1,16 @@
+package org.breedinginsight.brapi.v2.dao;
+
+import org.breedinginsight.daos.cache.ProgramCache;
+
+import java.util.UUID;
+
+public abstract class BrAPICachedDAO<T> {
+
+    protected ProgramCache<T> programCache;
+
+    public void repopulateCache(UUID programId) {
+        // TODO: test calling populate alone (without invalidate first).
+        this.programCache.invalidate(programId);
+        this.programCache.populate(programId);
+    }
+}

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPICachedDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPICachedDAO.java
@@ -9,7 +9,6 @@ public abstract class BrAPICachedDAO<T> {
     protected ProgramCache<T> programCache;
 
     public void repopulateCache(UUID programId) {
-        // TODO: test calling populate alone (without invalidate first).
         this.programCache.invalidate(programId);
         this.programCache.populate(programId);
     }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIListDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIListDAO.java
@@ -18,6 +18,7 @@
 package org.breedinginsight.brapi.v2.dao;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.core.ListsApi;
@@ -193,5 +194,9 @@ public class BrAPIListDAO {
         }
 
         throw new ApiException("No response after creating list");
+    }
+
+    public void deleteBrAPIList(String listDbId, UUID id, boolean hard) {
+        throw new NotImplementedException();
     }
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIListDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIListDAO.java
@@ -20,7 +20,6 @@ package org.breedinginsight.brapi.v2.dao;
 import lombok.extern.slf4j.Slf4j;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.model.exceptions.ApiException;
-import org.brapi.client.v2.model.queryParams.core.ListQueryParams;
 import org.brapi.client.v2.modules.core.ListsApi;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.BrAPIResponse;
@@ -30,7 +29,6 @@ import org.brapi.v2.model.core.BrAPIListTypes;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.core.request.BrAPIListSearchRequest;
 import org.brapi.v2.model.core.response.*;
-import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.breedinginsight.brapps.importer.daos.ImportDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.daos.ProgramDAO;
@@ -82,7 +80,7 @@ public class BrAPIListDAO {
         return response.getBody();
     }
 
-    public List<BrAPIListSummary> getListBySearch(@NotNull BrAPIListSearchRequest searchRequest, UUID programId) throws ApiException {
+    public List<BrAPIListSummary> getListsBySearch(@NotNull BrAPIListSearchRequest searchRequest, UUID programId) throws ApiException {
         ListsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ListsApi.class);
         List<BrAPIListSummary> programLists = brAPIDAOUtil.search(api::searchListsPost, api::searchListsSearchResultsDbIdGet, searchRequest);
         if (searchRequest.getExternalReferenceSources() != null && searchRequest.getExternalReferenceIDs() != null) {
@@ -94,7 +92,7 @@ public class BrAPIListDAO {
 
     }
 
-    public List<BrAPIListSummary> getListByTypeAndExternalRef(@NotNull BrAPIListTypes listType, UUID programId, String externalReferenceSource, UUID externalReferenceId) throws ApiException {
+    public List<BrAPIListSummary> getListsByTypeAndExternalRef(@NotNull BrAPIListTypes listType, UUID programId, String externalReferenceSource, UUID externalReferenceId) throws ApiException {
         BrAPIListSearchRequest searchRequest = new BrAPIListSearchRequest()
                 .externalReferenceIDs(List.of(externalReferenceId.toString()))
                 .externalReferenceSources(List.of(externalReferenceSource))

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
@@ -45,4 +45,6 @@ public interface BrAPITrialDAO {
     List<BrAPITrial> getTrialsByDbIds(Collection<String> trialDbIds, Program program) throws ApiException;
 
     List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException;
+
+    void deleteExperiment(UUID experimentId, boolean hard);
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
@@ -46,5 +46,5 @@ public interface BrAPITrialDAO {
 
     List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException;
 
-    void deleteExperiment(UUID experimentId, boolean hard);
+    void deleteBrAPITrial(Program program, BrAPITrial trial, boolean hard) throws ApiException;
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
@@ -47,4 +47,6 @@ public interface BrAPITrialDAO {
     List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException;
 
     void deleteBrAPITrial(Program program, BrAPITrial trial, boolean hard) throws ApiException;
+
+    void repopulateCache(UUID programId);
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -282,7 +282,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
 
     @Override
     public void deleteBrAPITrial(Program program, BrAPITrial trial, boolean hard) throws ApiException {
-        var programBrAPIBaseUrl = getProgramBrAPIBaseUrl(program.getId());
+        var programBrAPIBaseUrl = brAPIDAOUtil.getProgramBrAPIBaseUrl(program.getId());
         var requestUrl = HttpUrl.parse(programBrAPIBaseUrl + "/trials/" + trial.getTrialDbId()).newBuilder();
         requestUrl.addQueryParameter("hardDelete", Boolean.toString(hard));
         HttpUrl url = requestUrl.build();
@@ -291,6 +291,6 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
                 .addHeader("Content-Type", "application/json")
                 .build();
 
-        makeCall(brapiRequest);
+        brAPIDAOUtil.makeCall(brapiRequest);
     }
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -21,7 +21,8 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import io.micronaut.scheduling.annotation.Scheduled;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.NotImplementedException;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.core.TrialsApi;
 import org.brapi.v2.model.BrAPIExternalReference;
@@ -280,7 +281,16 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
     }
 
     @Override
-    public void deleteExperiment(UUID experimentId, boolean hard) {
-        throw new NotImplementedException();
+    public void deleteBrAPITrial(Program program, BrAPITrial trial, boolean hard) throws ApiException {
+        var programBrAPIBaseUrl = getProgramBrAPIBaseUrl(program.getId());
+        var requestUrl = HttpUrl.parse(programBrAPIBaseUrl + "/trials/" + trial.getTrialDbId()).newBuilder();
+        requestUrl.addQueryParameter("hardDelete", Boolean.toString(hard));
+        HttpUrl url = requestUrl.build();
+        var brapiRequest = new Request.Builder().url(url)
+                .method("DELETE", null)
+                .addHeader("Content-Type", "application/json")
+                .build();
+
+        makeCall(brapiRequest);
     }
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -21,6 +21,7 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import io.micronaut.scheduling.annotation.Scheduled;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.core.TrialsApi;
 import org.brapi.v2.model.BrAPIExternalReference;
@@ -276,5 +277,10 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
                 api::searchTrialsSearchResultsDbIdGet,
                 trialSearch
         ), program.getKey());
+    }
+
+    @Override
+    public void deleteExperiment(UUID experimentId, boolean hard) {
+        throw new NotImplementedException();
     }
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -282,6 +282,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
 
     @Override
     public void deleteBrAPITrial(Program program, BrAPITrial trial, boolean hard) throws ApiException {
+        // TODO: Switch to using the TrialsApi from the BrAPI client library once the delete endpoints are merged into it.
         var programBrAPIBaseUrl = brAPIDAOUtil.getProgramBrAPIBaseUrl(program.getId());
         var requestUrl = HttpUrl.parse(programBrAPIBaseUrl + "/trials/" + trial.getTrialDbId()).newBuilder();
         requestUrl.addQueryParameter("hardDelete", Boolean.toString(hard));
@@ -292,5 +293,11 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
                 .build();
 
         brAPIDAOUtil.makeCall(brapiRequest);
+    }
+
+    @Override
+    public void repopulateCache(UUID programId) {
+        this.programExperimentCache.invalidate(programId);
+        this.programExperimentCache.populate(programId);
     }
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIListService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIListService.java
@@ -53,7 +53,7 @@ public class BrAPIListService {
         if (xrefId != null && !xrefId.isEmpty()) {
             searchRequest.externalReferenceIDs(List.of(xrefId));
         }
-        List<BrAPIListSummary> lists = listDAO.getListBySearch(searchRequest, program.getId());
+        List<BrAPIListSummary> lists = listDAO.getListsBySearch(searchRequest, program.getId());
         if (lists == null) {
             throw new DoesNotExistException("list not returned from BrAPI service");
         }

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -688,6 +688,12 @@ public class BrAPITrialService {
             for (BrAPIListSummary list : lists) {
                 listDAO.deleteBrAPIList(list.getListDbId(), program.getId(), hard);  // TODO: not yet implemented.
             }
+            // TODO: if performance is poor, implement more precise invalidation, possibly using hierarchical cache keys.
+            // Invalidate and repopulate cache for Trial, Study, Observation, ObservationUnit.
+            trialDAO.repopulateCache(program.getId());
+            studyDAO.repopulateCache(program.getId());
+            observationDAO.repopulateCache(program.getId());
+            observationUnitDAO.repopulateCache(program.getId());
         } else {
             // Trying to hard delete a trial with existing observations, return 409 Conflict response.
             // TODO: remove if unused.

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -638,7 +638,7 @@ public class BrAPITrialService {
     }
 
     public List<Trait> getDatasetObsVars(String datasetId, Program program) throws ApiException, DoesNotExistException {
-        List<BrAPIListSummary> lists = listDAO.getListByTypeAndExternalRef(
+        List<BrAPIListSummary> lists = listDAO.getListsByTypeAndExternalRef(
                 BrAPIListTypes.OBSERVATIONVARIABLES,
                 program.getId(),
                 String.format("%s/%s", referenceSource, ExternalReferenceSource.DATASET.getName()),

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -667,10 +667,34 @@ public class BrAPITrialService {
         return experiments.get(0);
     }
 
-    public boolean deleteExperiment(Program program, UUID experimentId, boolean hard) throws ApiException {
-        // TODO: make BrAPI request to delete experiment.
-        // TODO: make BrAPI request to delete list for default observation dataset.
+    // TODO: create a result type for delete requests?
+    //       The caller could infer from the number of obs and hard whether delete succeeded.
+    public int deleteExperiment(Program program, UUID experimentId, boolean hard) throws ApiException {
+        // TODO: check for observations!
+        BrAPITrial trial = trialDAO.getTrialsByExperimentIds(List.of(experimentId), program).get(0);
+        List<BrAPIObservation> existingObservations = observationDAO.getObservationsByTrialDbId(List.of(trial.getTrialDbId()), program);
+        // If there are no observations or a soft delete is requested, proceed.
+        if (existingObservations.isEmpty() || !hard) {
+            // Make request to delete experiment.
+            trialDAO.deleteBrAPITrial(program, trial, hard);
+            // Get all lists for the trial.
+            List<BrAPIListSummary> lists = listDAO
+                    .getListsByTypeAndExternalRef(BrAPIListTypes.OBSERVATIONVARIABLES,
+                            program.getId(),
+                            Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.TRIALS),
+                            experimentId);
+            // TODO: replace with a single call to a batch delete method if that becomes available.
+            // Iterate over lists, delete each by listDbId.
+            for (BrAPIListSummary list : lists) {
+                listDAO.deleteBrAPIList(list.getListDbId(), program.getId(), hard);  // TODO: not yet implemented.
+            }
+        } else {
+            // Trying to hard delete a trial with existing observations, return 409 Conflict response.
+            // TODO: remove if unused.
+        }
 
+        // Successful or not, return the number of observations in this experiment.
+        return existingObservations.size();
     }
 
     private Map<String, Object> createExportRow(

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -667,6 +667,12 @@ public class BrAPITrialService {
         return experiments.get(0);
     }
 
+    public boolean deleteExperiment(Program program, UUID experimentId, boolean hard) throws ApiException {
+        // TODO: make BrAPI request to delete experiment.
+        // TODO: make BrAPI request to delete list for default observation dataset.
+
+    }
+
     private Map<String, Object> createExportRow(
             BrAPITrial experiment,
             Program program,

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -688,7 +688,7 @@ public class BrAPITrialService {
             // TODO: replace with a single call to a batch delete method if that becomes available.
             // Iterate over lists, delete each by listDbId.
             for (BrAPIListSummary list : lists) {
-                listDAO.deleteBrAPIList(list.getListDbId(), program.getId(), hard);  // TODO: not yet implemented.
+                listDAO.deleteBrAPIList(list.getListDbId(), program.getId(), hard);
             }
             // TODO: if performance is poor, implement more precise invalidation, possibly using hierarchical cache keys.
             // Invalidate and repopulate cache for Trial, Study, Observation, ObservationUnit.

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -2091,7 +2091,7 @@ public class ExperimentProcessor implements Processor {
 
             try {
                 List<BrAPIListSummary> existingDatasets = brAPIListDAO
-                        .getListByTypeAndExternalRef(BrAPIListTypes.OBSERVATIONVARIABLES,
+                        .getListsByTypeAndExternalRef(BrAPIListTypes.OBSERVATIONVARIABLES,
                                 program.getId(),
                                 String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.DATASET.getName()),
                                 UUID.fromString(datasetId));
@@ -2121,7 +2121,7 @@ public class ExperimentProcessor implements Processor {
                     ).getId().toString();
           try {
             List<BrAPIListSummary> existingDatasets = brAPIListDAO
-                    .getListByTypeAndExternalRef(BrAPIListTypes.OBSERVATIONVARIABLES,
+                    .getListsByTypeAndExternalRef(BrAPIListTypes.OBSERVATIONVARIABLES,
                     program.getId(),
                     String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.DATASET.getName()),
                     UUID.fromString(datasetId));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/PopulateExistingPendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/PopulateExistingPendingImportObjectsStep.java
@@ -383,7 +383,7 @@ public class PopulateExistingPendingImportObjectsStep {
 
             try {
                 List<BrAPIListSummary> existingDatasets = brAPIListDAO
-                        .getListByTypeAndExternalRef(BrAPIListTypes.OBSERVATIONVARIABLES,
+                        .getListsByTypeAndExternalRef(BrAPIListTypes.OBSERVATIONVARIABLES,
                                 program.getId(),
                                 String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.DATASET.getName()),
                                 UUID.fromString(datasetId));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/DatasetService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/DatasetService.java
@@ -23,21 +23,17 @@ import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPIListSummary;
 import org.brapi.v2.model.core.BrAPIListTypes;
-import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.core.response.BrAPIListDetails;
-import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapi.v2.dao.BrAPIListDAO;
 import org.breedinginsight.brapps.importer.model.response.ImportObjectState;
 import org.breedinginsight.brapps.importer.model.response.PendingImportObject;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.model.Program;
-import org.breedinginsight.model.Trait;
 import org.breedinginsight.utilities.Utilities;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -74,7 +70,7 @@ public class DatasetService {
 
         // Retrieve existing dataset summaries based on program ID and external reference
         List<BrAPIListSummary> existingDatasets = brAPIListDAO
-                .getListByTypeAndExternalRef(BrAPIListTypes.OBSERVATIONVARIABLES,
+                .getListsByTypeAndExternalRef(BrAPIListTypes.OBSERVATIONVARIABLES,
                         program.getId(),
                         String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.DATASET.getName()),
                         UUID.fromString(id));

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -15,5 +15,5 @@
 #
 
 
-version=v1.1.0+852
-versionInfo=https://github.com/Breeding-Insight/bi-api/commit/3fbb75f662c5600da816270d53699aa1192777b9
+version=v1.1.0+856
+versionInfo=https://github.com/Breeding-Insight/bi-api/commit/a98bbf813a1a0dda99c6273cf571c83a75ffaf9f

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -15,5 +15,5 @@
 #
 
 
-version=v1.1.0+864
-versionInfo=https://github.com/Breeding-Insight/bi-api/commit/99507a6d27aae4f689364b944357a2fc71d2f041
+version=v1.1.0+868
+versionInfo=https://github.com/Breeding-Insight/bi-api/commit/2f32914be2408d1b7511ba83e79b62553bfe2287

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -15,5 +15,5 @@
 #
 
 
-version=v1.1.0+856
-versionInfo=https://github.com/Breeding-Insight/bi-api/commit/a98bbf813a1a0dda99c6273cf571c83a75ffaf9f
+version=v1.1.0+864
+versionInfo=https://github.com/Breeding-Insight/bi-api/commit/99507a6d27aae4f689364b944357a2fc71d2f041


### PR DESCRIPTION
# Description
**Story:** [BI-2376](https://breedinginsight.atlassian.net/browse/BI-2376)

This feature adds a delete endpoint for experiments to bi-api. The endpoint is capable of requesting a hard or soft delete of the backing brapi service, but if an experiment has observations and a hard delete is requested, nothing will be deleted and a 409 Conflict response will be returned.

Additional features:
- Cache invalidation for all affected entities: trial, study, observation and observation unit (using an inefficient but effective full-key repopulation method).
- Uses the `BrAPIListDAO::deleteBrAPIList` method to delete all lists along with the experiment.
- Renamed several Lists methods for clarity.

# Dependencies
Now that https://github.com/Breeding-Insight/brapi-Java-TestServer/pull/41 has been merged, the delete endpoints are present in the `develop` tagged brapi-server docker image. You may need to manually run `docker pull breedinginsight/brapi-java-server:develop` to update your local image, and you'll certainly need to delete and recreate your local brapi-serve container to use the updated image.

# Testing
Use an API client to test the following 4 Cases.

The endpoint will be the following (substitute your programId, experimentId and hardDelete values.
`http://localhost:8081/v1/programs/{{programId}}/experiments/{{experimentId}}?hard={{hardDelete}}`

 1. Hard delete an experiment with observations — response: 409 Conflict.
 3. Soft delete an experiment with observations — response: 204 No Content.
 4. Hard delete an experiment without observations — response: 204 No Content.
 5. Soft delete an experiment without observations — response: 204 No Content.


# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2376]: https://breedinginsight.atlassian.net/browse/BI-2376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ