### PR TITLE
[BI-2055] - Remove missingValueString tablesaw values

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/ExperimentProcessor.java
@@ -2428,6 +2428,13 @@ public class ExperimentProcessor implements Processor {
                     addRowError(columnHeader, "Undefined nominal category detected", validationErrors, row);
                 }
                 break;
+            case TEXT:
+                //due to null as free text value messing stuff up in backend
+                if (!validText(value)) {
+                    addRowError(columnHeader, "'Null' is not a valid value", validationErrors, row);
+
+                }
+                break;
             default:
                 break;
         }
@@ -2475,6 +2482,10 @@ public class ExperimentProcessor implements Processor {
                                                .map(category -> category.getValue().toLowerCase())
                                                .collect(Collectors.toSet());
         return categoryValues.contains(value.toLowerCase());
+    }
+
+    private boolean validText(String value){
+        return (value != null) && (!value.equalsIgnoreCase("null"));
     }
 
     /**

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/ExperimentUtilities.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/ExperimentUtilities.java
@@ -530,7 +530,7 @@ public class ExperimentUtilities {
             case NUMERICAL:
                 Optional<BigDecimal> number = validNumericValue(value);
                 if (number.isEmpty()) {
-                    addRowError(columnHeader, "Non-numeric text detected detected", validationErrors, row);
+                    addRowError(columnHeader, "Non-numeric text detected", validationErrors, row);
                 } else if (!validNumericRange(number.get(), variable.getScale())) {
                     addRowError(columnHeader, "Value outside of min/max range detected", validationErrors, row);
                 }
@@ -548,6 +548,11 @@ public class ExperimentUtilities {
             case NOMINAL:
                 if (!validCategory(variable.getScale().getCategories(), value)) {
                     addRowError(columnHeader, "Undefined nominal category detected", validationErrors, row);
+                }
+                break;
+            case TEXT:
+                if (!validText(value)) {
+                    addRowError(columnHeader, "'Null' is not a valid value", validationErrors, row);
                 }
                 break;
             default:
@@ -587,6 +592,10 @@ public class ExperimentUtilities {
                 .map(category -> category.getValue().toLowerCase())
                 .collect(Collectors.toSet());
         return categoryValues.contains(value.toLowerCase());
+    }
+
+    public static boolean validText(String value){
+        return (value != null) && (!value.equalsIgnoreCase("null"));
     }
 
     public static boolean isNAObservation(String value){

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationService.java
@@ -97,6 +97,11 @@ public class ObservationService {
         }
         return true;
     }
+
+    public boolean validText(String value){
+        return (value != null) && (!value.equalsIgnoreCase("null"));
+    }
+
     public String getObservationHash(String observationUnitName, String variableName, String studyName) {
         String concat = DigestUtils.sha256Hex(observationUnitName) +
                 DigestUtils.sha256Hex(variableName) +

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/validator/field/TextValidator.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/validator/field/TextValidator.java
@@ -1,0 +1,99 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.breedinginsight.brapps.importer.services.processors.experiment.validator.field;
+
+import io.micronaut.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.breedinginsight.api.model.v1.response.ValidationError;
+import org.breedinginsight.brapps.importer.services.processors.experiment.service.ObservationService;
+import org.breedinginsight.model.Trait;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Optional;
+
+import static org.breedinginsight.brapps.importer.services.processors.experiment.model.ExpImportProcessConstants.TIMESTAMP_PREFIX;
+import static org.breedinginsight.dao.db.enums.DataType.TEXT;
+
+//so much todotodotod
+
+
+/**
+ * This class represents a TextValidator which implements the ObservationValidator interface.
+ * It is responsible for validating text fields within observations.
+ */
+@Slf4j
+@Singleton
+public class TextValidator implements ObservationValidator {
+
+    @Inject
+    ObservationService observationService;
+
+    /**
+     * Constructor for TextValidator class that takes an ObservationService as a parameter.
+     * @param observationService the ObservationService used for validation
+     */
+    public TextValidator(ObservationService observationService) {
+        this.observationService = observationService;
+    }
+
+    /**
+     * Validates a field within an observation for text data.
+     *
+     * @param fieldName the name of the field being validated
+     * @param value the value of the field being validated
+     * @param variable the Trait variable associated with the field
+     * @return an Optional containing a ValidationError if validation fails, otherwise an empty Optional
+     */
+    @Override
+    public Optional<ValidationError> validateField(String fieldName, String value, Trait variable) {
+        // Skip validation if observation is blank
+        if (observationService.isBlankObservation(value)) {
+            log.debug(String.format("Skipping validation of observation because there is no value.\n\tvariable: %s", fieldName));
+            return Optional.empty();
+        }
+
+        // Skip validation if observation is NA
+        if (observationService.isNAObservation(value)) {
+            log.debug(String.format("Skipping validation of observation because it is NA.\n\tvariable: %s", fieldName));
+            return Optional.empty();
+        }
+
+        // Skip if field is a timestamp
+        if (fieldName.startsWith(TIMESTAMP_PREFIX)) {
+            return Optional.empty();
+        }
+
+        // Skip if there is no trait data
+        if (variable == null || variable.getScale() == null || variable.getScale().getDataType() == null) {
+            return Optional.empty();
+        }
+
+        // Skip if this is not a text trait
+        if (!TEXT.equals(variable.getScale().getDataType())) {
+            return Optional.empty();
+        }
+
+        // Validate text
+        if (!observationService.validText(value)) {
+            return Optional.of(new ValidationError(fieldName, "'Null' is not a valid value", HttpStatus.UNPROCESSABLE_ENTITY));
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/validator/field/TextValidator.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/validator/field/TextValidator.java
@@ -30,7 +30,6 @@ import java.util.Optional;
 import static org.breedinginsight.brapps.importer.services.processors.experiment.model.ExpImportProcessConstants.TIMESTAMP_PREFIX;
 import static org.breedinginsight.dao.db.enums.DataType.TEXT;
 
-//so much todotodotod
 
 
 /**

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -15,5 +15,5 @@
 #
 
 
-version=v1.1.0+893
-versionInfo=https://github.com/Breeding-Insight/bi-api/commit/16cdff9a3f15138b35958dd4aee554ed1a7dc26c
+version=v1.1.0+895
+versionInfo=https://github.com/Breeding-Insight/bi-api/commit/8e7ec0c2ef021f8f9a5e5e6ead6f666e25a51cdb


### PR DESCRIPTION
# Description
**Story:** [BI-2055 - Remove missingValueString tablesaw values](https://breedinginsight.atlassian.net/browse/BI-2055)

Default tablesaw behavior silently converts certain values to an empty string when processing tables, which can lead to unexpected behavior when importing files in DeltaBreed. This follows up on work implemented in BI-1993 to  also remove this silent conversion for N/A, NaN, *, and null values and update associated tests. Since before this card any of the aforementioned values would be converted to null, this revealed some unexpected behavior in downstream workflows processing said values, which this part of the card addressed.

# Dependencies
tablesaw: bug/BI-2055 (should be merged into master before this card is tested to avoid a great deal of pain)

# Testing
For both the new experiment and append/overwrite workflows
- Upload a file that has the following values (N/A, NaN, *, null) for each ontology term scale class
   - Confirm that appropriate error appears for numerical, date, ordinal, and nominal scale classes when N/A, NaN, *, and null are observation inputs
   - Confirm that no error appears for cells with free text values with N/A, NaN, and *
   - Confirm that "'Null' is not a valid value" error appears for cells with free text value of null
- Upload a file with just N/A, NaN, and * values for a free text ontology term
  - Confirm that import preview loads and displays correct values for free text terms
  - Complete upload and ensure that free text terms display in experiment and observations table
  
Smoke test other upload workflows as a sanity measure

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [X] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _[\<please include a link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/12716826097)
