### PR TITLE
BI-2424 - Refactor getObservationUnitsByDbId for clarity

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/factory/entity/PendingObservationUnit.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/factory/entity/PendingObservationUnit.java
@@ -95,11 +95,11 @@ public class PendingObservationUnit implements ExperimentImportEntity<BrAPIObser
      */
     @Override
     public List<BrAPIObservationUnit> brapiRead() throws ApiException {
-        // Collect deltabreed-generated exp unit ids listed in the import
-        Set<String> expUnitIds = cache.getReferenceOUIds();
+        // Collect deltabreed-generated obs unit ids listed in the import
+        Set<String> obsUnitIds = cache.getReferenceOUIds();
 
         // For each id fetch the observation unit from the brapi data store
-        return observationUnitService.getObservationUnitsByDbId(new HashSet<>(expUnitIds), importContext.getProgram());
+        return observationUnitService.getObservationUnitsByDbId(new HashSet<>(obsUnitIds), importContext.getProgram());
     }
 
     /**

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationUnitService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationUnitService.java
@@ -49,27 +49,27 @@ public class ObservationUnitService {
     }
 
     /**
-     * Retrieves a list of BrAPI (Breeding API) observation units by their database IDs for a given set of experimental unit IDs and program.
+     * Retrieves a list of BrAPI (Breeding API) observation units by their database IDs for a given set of observation unit IDs and program.
      *
-     * This method queries the BrAPIObservationUnitDAO to retrieve BrAPI observation units based on the provided experimental unit IDs and program.
-     * If the database IDs of the retrieved BrAPI observation units do not match the provided experimental unit IDs, an IllegalStateException is thrown.
+     * This method queries the BrAPIObservationUnitDAO to retrieve BrAPI observation units based on the provided observation unit IDs and program.
+     * If the database IDs of the retrieved BrAPI observation units do not match the provided observation unit IDs, an IllegalStateException is thrown.
      * The exception includes information on the missing observation unit database IDs.
      *
-     * @param expUnitIds a set of experimental unit IDs for which to retrieve BrAPI observation units
+     * @param obsUnitIds a set of observation unit IDs for which to retrieve BrAPI observation units
      * @param program the program for which to retrieve BrAPI observation units
-     * @return a list of BrAPIObservationUnit objects corresponding to the provided experimental unit IDs
+     * @return a list of BrAPIObservationUnit objects corresponding to the provided observation unit IDs
      * @throws ApiException if an error occurs during the retrieval of observation units
-     * @throws IllegalStateException if the retrieved observation units do not match the provided experimental unit IDs
+     * @throws IllegalStateException if the retrieved observation units do not match the provided observation unit IDs
      */
-    public List<BrAPIObservationUnit> getObservationUnitsByDbId(Set<String> expUnitIds, Program program) throws ApiException, IllegalStateException {
+    public List<BrAPIObservationUnit> getObservationUnitsByDbId(Set<String> obsUnitIds, Program program) throws ApiException, IllegalStateException {
         List<BrAPIObservationUnit> brapiUnits = null;
 
         // Retrieve reference Observation Units based on IDs
-        brapiUnits = brAPIObservationUnitDAO.getObservationUnitsById(expUnitIds, program);
+        brapiUnits = brAPIObservationUnitDAO.getObservationUnitsById(obsUnitIds, program);
 
         // If no BrAPI units are found, throw an IllegalStateException with an error message
-        if (expUnitIds.size() != brapiUnits.size()) {
-            Set<String> missingIds = new HashSet<>(expUnitIds);
+        if (obsUnitIds.size() != brapiUnits.size()) {
+            Set<String> missingIds = new HashSet<>(obsUnitIds);
 
             // Calculate missing IDs based on retrieved BrAPI units
             missingIds.removeAll(brapiUnits.stream().map(BrAPIObservationUnit::getObservationUnitDbId).collect(Collectors.toSet()));


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2424

I updated several places where Observation Unit IDs were referred to as Experimental Unit IDs.

# Testing
No testable changes, this PR only renames things.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
