### PR TITLE
BI-2047 - Pull Existing Observation Values For An Experiment Into Field-Book

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
@@ -28,13 +28,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.modules.phenotype.ObservationsApi;
+import org.brapi.v2.model.BrAPIIndexPagination;
+import org.brapi.v2.model.BrAPIMetadata;
+import org.brapi.v2.model.BrAPIStatus;
 import org.brapi.v2.model.BrAPIWSMIMEDataTypes;
 import org.brapi.v2.model.core.BrAPIStudy;
 import org.brapi.v2.model.pheno.BrAPIObservation;
-import org.brapi.v2.model.pheno.response.BrAPIObservationTableResponse;
+import org.brapi.v2.model.pheno.response.*;
 import org.breedinginsight.api.auth.ProgramSecured;
 import org.breedinginsight.api.auth.ProgramSecuredRoleGroup;
 import org.breedinginsight.brapi.v1.controller.BrapiVersion;
+import org.breedinginsight.brapi.v2.dao.BrAPIObservationDAO;
 import org.breedinginsight.brapi.v2.dao.BrAPIStudyDAO;
 import org.breedinginsight.brapi.v2.model.request.query.ObservationQuery;
 import org.breedinginsight.daos.ProgramDAO;
@@ -47,6 +51,8 @@ import org.breedinginsight.utilities.Utilities;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 @Controller("/${micronaut.bi.api.version}/programs/{programId}" + BrapiVersion.BRAPI_V2)
@@ -57,13 +63,20 @@ public class BrAPIObservationsController {
     private final ProgramDAO programDAO;
     private final BrAPIStudyDAO brAPIStudyDAO;
     private final BrAPIEndpointProvider brAPIEndpointProvider;
+    private final BrAPIObservationDAO observationDAO;
 
     @Inject
-    public BrAPIObservationsController(ProgramService programService, ProgramDAO programDAO, ProgramDAO programDAO1, BrAPIStudyDAO brAPIStudyDAO, BrAPIEndpointProvider brAPIEndpointProvider) {
+    public BrAPIObservationsController(ProgramService programService,
+                                       ProgramDAO programDAO,
+                                       ProgramDAO programDAO1,
+                                       BrAPIStudyDAO brAPIStudyDAO,
+                                       BrAPIEndpointProvider brAPIEndpointProvider,
+                                       BrAPIObservationDAO brAPIObservationDAO) {
         this.programService = programService;
         this.programDAO = programDAO1;
         this.brAPIStudyDAO = brAPIStudyDAO;
         this.brAPIEndpointProvider = brAPIEndpointProvider;
+        this.observationDAO = brAPIObservationDAO;
     }
 
     @Get("/observations")
@@ -93,8 +106,64 @@ public class BrAPIObservationsController {
                                         @Nullable @QueryValue("externalReferenceSource") String externalReferenceSource,
                                         @Nullable @QueryValue("page") Integer page,
                                         @Nullable @QueryValue("pageSize") Integer pageSize) {
-        //TODO
-        return HttpResponse.notFound();
+        log.debug("observationsGet: fetching observations by filters");
+        Optional<Program> program = programService.getById(programId);
+        if(program.isEmpty()) {
+            log.warn("Program id: " + programId + " not found");
+            return HttpResponse.notFound();
+        }
+
+        try {
+
+            // TODO: BI-2506 - implement support for all query parameters.
+            List<Object> unsupportedParams = Stream.of(
+                    observationDbId,
+                    observationUnitDbId,
+                    observationVariableDbId,
+                    locationDbId,
+                    seasonDbId,
+                    observationTimeStampRangeStart,
+                    observationTimeStampRangeEnd,
+                    observationUnitLevelName,
+                    observationUnitLevelOrder,
+                    observationUnitLevelCode,
+                    observationUnitLevelRelationshipName,
+                    observationUnitLevelRelationshipOrder,
+                    observationUnitLevelRelationshipCode,
+                    observationUnitLevelRelationshipDbId,
+                    commonCropName,
+                    programDbId,
+                    trialDbId,
+                    germplasmDbId,
+                    externalReferenceID,
+                    externalReferenceId,
+                    externalReferenceSource
+            ).filter(Objects::nonNull).collect(Collectors.toList());
+
+            if (!unsupportedParams.isEmpty()) {
+                return HttpResponse.status(HttpStatus.NOT_IMPLEMENTED).body(
+                        new BrAPIObservationListResponse().metadata(new BrAPIMetadata().status(List.of(new BrAPIStatus().messageType(BrAPIStatus.MessageTypeEnum.ERROR)
+                                .message("Unsupported query parameter. Only studyDbId, page, and pageSize are supported."))))
+                );
+            }
+
+            // Handle studyDbId and pagination query params for Field Book integration.
+            List<BrAPIObservation> observations = observationDAO.getObservationsByStudyIds(List.of(studyDbId), program.get());
+
+            return HttpResponse.ok(new BrAPIObservationListResponse().metadata(new BrAPIMetadata().pagination(new BrAPIIndexPagination().currentPage(0)
+                            .totalPages(1)
+                            .pageSize(observations.size())
+                            .totalCount(observations.size())))
+                    .result(new BrAPIObservationListResponseResult().data(observations)));
+        } catch (ApiException e) {
+            log.error(Utilities.generateApiExceptionLogMessage(e), e);
+            return HttpResponse.serverError(new BrAPIObservationListResponse().metadata(new BrAPIMetadata().status(List.of(new BrAPIStatus().messageType(BrAPIStatus.MessageTypeEnum.ERROR)
+                    .message("Error fetching observations")))));
+        } catch (Exception e) {
+            log.error("Error fetching Observations", e);
+            return HttpResponse.serverError(new BrAPIObservationListResponse().metadata(new BrAPIMetadata().status(List.of(new BrAPIStatus().messageType(BrAPIStatus.MessageTypeEnum.ERROR)
+                    .message("Error fetching observations")))));
+        }
     }
 
     @Get("/observations/{observationDbId}")

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
@@ -147,14 +147,43 @@ public class BrAPIObservationsController {
                 );
             }
 
-            // Handle studyDbId and pagination query params for Field Book integration.
-            List<BrAPIObservation> observations = observationDAO.getObservationsByStudyIds(List.of(studyDbId), program.get());
+            // Get a filtered list of observations.
+            List<BrAPIObservation> observations = observationDAO.getObservationsByFilters(program.get(), studyDbId);
 
-            return HttpResponse.ok(new BrAPIObservationListResponse().metadata(new BrAPIMetadata().pagination(new BrAPIIndexPagination().currentPage(0)
-                            .totalPages(1)
+            // Handle pagination query params.
+            int totalCount = observations.size();  // Total number of records in the unpaged super set.
+            int actualPage = page != null ? page : 0;  // Zero-indexed page.
+            int requestedPageSize = pageSize != null ? Math.min(pageSize, totalCount) : totalCount; // The lesser of pageSize and totalCount.
+            int totalPages = totalCount / requestedPageSize + ((totalCount % requestedPageSize == 0) ? 0 : 1); // Integer division and round up.
+            log.info("(Pagination) totalCount: " + totalCount + " actualPage (0-indexed): " + actualPage + " requestedPageSize: " + requestedPageSize + " totalPages: " + totalPages);
+
+            // Determine validity of pagination query parameters.
+            boolean pageSizeValid = pageSize != null && pageSize > 0 && pageSize <= totalCount;
+            boolean pageValid = page != null && page >= 0 && page < totalPages;
+
+            // Only paginate if valid pagination values were sent.
+            if (pageSizeValid && pageValid) {
+                int start = actualPage * requestedPageSize;
+                // Account for last page, which may have fewer than requestedPageSize items, or exactly requestedPageSize items.
+                int end = (actualPage == (totalPages - 1) && totalCount % requestedPageSize != 0) ? (start + (totalCount % requestedPageSize)) : Math.min(((actualPage + 1) * requestedPageSize), totalCount);
+                log.info("(Pagination) start " + start + " end " + end);
+                // Sort observations so that paging is consistent and coherent.
+                observations.sort(Comparator.comparing(BrAPIObservation::getObservationDbId));
+                // Paginate response.
+                observations = observations.subList(start, end);
+            } else if (pageSize != null || page != null) {
+                // If one or more of the pagination query parameters are not null, both must be present and valid.
+                String errorMessage = "Invalid query parameters: page, pageSize";
+                return HttpResponse.badRequest(new BrAPIObservationListResponse().metadata(new BrAPIMetadata().status(List.of(new BrAPIStatus().messageType(BrAPIStatus.MessageTypeEnum.ERROR)
+                        .message(errorMessage)))));
+            }
+
+            return HttpResponse.ok(new BrAPIObservationListResponse().metadata(new BrAPIMetadata().pagination(new BrAPIIndexPagination().currentPage(actualPage)
+                            .totalPages(totalPages)
                             .pageSize(observations.size())
-                            .totalCount(observations.size())))
+                            .totalCount(totalCount)))
                     .result(new BrAPIObservationListResponseResult().data(observations)));
+            
         } catch (ApiException e) {
             log.error(Utilities.generateApiExceptionLogMessage(e), e);
             return HttpResponse.serverError(new BrAPIObservationListResponse().metadata(new BrAPIMetadata().status(List.of(new BrAPIStatus().messageType(BrAPIStatus.MessageTypeEnum.ERROR)

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
@@ -150,11 +150,14 @@ public class BrAPIObservationsController {
             // Get a filtered list of observations.
             List<BrAPIObservation> observations = observationDAO.getObservationsByFilters(program.get(), studyDbId);
 
-            // Handle pagination query params.
-            int totalCount = observations.size();  // Total number of records in the unpaged super set.
-            int actualPage = page != null ? page : 0;  // Zero-indexed page.
-            int requestedPageSize = pageSize != null ? Math.min(pageSize, totalCount) : totalCount; // The lesser of pageSize and totalCount.
-            int totalPages = totalCount / requestedPageSize + ((totalCount % requestedPageSize == 0) ? 0 : 1); // Integer division and round up.
+            // Total number of records in the unpaged super set.
+            int totalCount = observations.size();
+            // Zero-indexed page, default to zero.
+            int actualPage = page != null ? page : 0;
+            // The least of pageSize and totalCount, unless pageSize is null or zero, in which case use totalCount.
+            int requestedPageSize = (pageSize != null && pageSize > 0) ? Math.min(pageSize, totalCount) : totalCount;
+            // Integer division and round up.
+            int totalPages = totalCount / requestedPageSize + ((totalCount % requestedPageSize == 0) ? 0 : 1);
             log.info("(Pagination) totalCount: " + totalCount + " actualPage (0-indexed): " + actualPage + " requestedPageSize: " + requestedPageSize + " totalPages: " + totalPages);
 
             // Determine validity of pagination query parameters.

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
@@ -183,7 +183,7 @@ public class BrAPIObservationsController {
                             .pageSize(observations.size())
                             .totalCount(totalCount)))
                     .result(new BrAPIObservationListResponseResult().data(observations)));
-            
+
         } catch (ApiException e) {
             log.error(Utilities.generateApiExceptionLogMessage(e), e);
             return HttpResponse.serverError(new BrAPIObservationListResponse().metadata(new BrAPIMetadata().status(List.of(new BrAPIStatus().messageType(BrAPIStatus.MessageTypeEnum.ERROR)

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
@@ -178,7 +178,6 @@ public class BrAPIObservationsController {
                 // Paginate response.
                 observations = observations.subList(start, end);
             } else {
-                // If one or more of the pagination query parameters are not null, both must be present and valid.
                 String errorMessage = "Invalid query parameters: page, pageSize";
                 return HttpResponse.badRequest(new BrAPIObservationListResponse().metadata(new BrAPIMetadata().status(List.of(new BrAPIStatus().messageType(BrAPIStatus.MessageTypeEnum.ERROR)
                         .message(errorMessage)))));

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
@@ -150,38 +150,42 @@ public class BrAPIObservationsController {
             // Get a filtered list of observations.
             List<BrAPIObservation> observations = observationDAO.getObservationsByFilters(program.get(), studyDbId);
 
+            // If page is not provided, set it to the default value 0.
+            if (page == null) page = 0;
+            // If pageSize is not provided, set it to the default value 1000.
+            if (pageSize == null) pageSize = 1000;
+
             // Total number of records in the unpaged super set.
             int totalCount = observations.size();
-            // Zero-indexed page, default to zero.
-            int actualPage = page != null ? page : 0;
-            // The least of pageSize and totalCount, unless pageSize is null or zero, in which case use totalCount.
-            int requestedPageSize = (pageSize != null && pageSize > 0) ? Math.min(pageSize, totalCount) : totalCount;
+            // The least of pageSize and totalCount, unless pageSize is zero, in which case use totalCount.
+            int requestedPageSize = pageSize > 0 ? Math.min(pageSize, totalCount) : totalCount;
             // Integer division and round up.
             int totalPages = totalCount / requestedPageSize + ((totalCount % requestedPageSize == 0) ? 0 : 1);
-            log.info("(Pagination) totalCount: " + totalCount + " actualPage (0-indexed): " + actualPage + " requestedPageSize: " + requestedPageSize + " totalPages: " + totalPages);
+            log.info("(Pagination) totalCount: " + totalCount + " page (0-indexed): " + page + " requestedPageSize: " + requestedPageSize + " totalPages: " + totalPages);
 
             // Determine validity of pagination query parameters.
-            boolean pageSizeValid = pageSize != null && pageSize > 0;
-            boolean pageValid = page != null && page >= 0 && page < totalPages;
+            boolean pageSizeValid = pageSize > 0;
+            boolean pageValid = page >= 0 && page < totalPages;
 
             // Only paginate if valid pagination values were sent.
             if (pageSizeValid && pageValid) {
-                int start = actualPage * requestedPageSize;
+                int start = page * requestedPageSize;
                 // Account for last page, which may have fewer than requestedPageSize items, or exactly requestedPageSize items.
-                int end = (actualPage == (totalPages - 1) && totalCount % requestedPageSize != 0) ? (start + (totalCount % requestedPageSize)) : Math.min(((actualPage + 1) * requestedPageSize), totalCount);
+                int end = (page == (totalPages - 1) && totalCount % requestedPageSize != 0) ? (start + (totalCount % requestedPageSize)) : Math.min(((page + 1) * requestedPageSize), totalCount);
                 log.info("(Pagination) start " + start + " end " + end);
                 // Sort observations so that paging is consistent and coherent.
                 observations.sort(Comparator.comparing(BrAPIObservation::getObservationDbId));
                 // Paginate response.
                 observations = observations.subList(start, end);
-            } else if (pageSize != null || page != null) {
+            } else {
                 // If one or more of the pagination query parameters are not null, both must be present and valid.
                 String errorMessage = "Invalid query parameters: page, pageSize";
                 return HttpResponse.badRequest(new BrAPIObservationListResponse().metadata(new BrAPIMetadata().status(List.of(new BrAPIStatus().messageType(BrAPIStatus.MessageTypeEnum.ERROR)
                         .message(errorMessage)))));
             }
 
-            return HttpResponse.ok(new BrAPIObservationListResponse().metadata(new BrAPIMetadata().pagination(new BrAPIIndexPagination().currentPage(actualPage)
+            return HttpResponse.ok(new BrAPIObservationListResponse().metadata(new BrAPIMetadata().pagination(new BrAPIIndexPagination()
+                            .currentPage(page)
                             .totalPages(totalPages)
                             .pageSize(observations.size())
                             .totalCount(totalCount)))

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
@@ -161,7 +161,7 @@ public class BrAPIObservationsController {
             log.info("(Pagination) totalCount: " + totalCount + " actualPage (0-indexed): " + actualPage + " requestedPageSize: " + requestedPageSize + " totalPages: " + totalPages);
 
             // Determine validity of pagination query parameters.
-            boolean pageSizeValid = pageSize != null && pageSize > 0 && pageSize <= totalCount;
+            boolean pageSizeValid = pageSize != null && pageSize > 0;
             boolean pageValid = page != null && page >= 0 && page < totalPages;
 
             // Only paginate if valid pagination values were sent.

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -38,7 +38,10 @@ import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.daos.ProgramDAO;
 import org.breedinginsight.daos.cache.ProgramCacheProvider;
 import org.breedinginsight.model.Program;
+import org.breedinginsight.model.Trait;
+import org.breedinginsight.services.TraitService;
 import org.breedinginsight.services.brapi.BrAPIEndpointProvider;
+import org.breedinginsight.services.exceptions.DoesNotExistException;
 import org.breedinginsight.utilities.BrAPIDAOUtil;
 import org.breedinginsight.utilities.Utilities;
 import org.jetbrains.annotations.NotNull;
@@ -62,6 +65,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
     private final BrAPIEndpointProvider brAPIEndpointProvider;
     private final String referenceSource;
     private boolean runScheduledTasks;
+    private final TraitService traitService;
 
     @Inject
     public BrAPIObservationDAO(ProgramDAO programDAO,
@@ -71,7 +75,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
                                BrAPIEndpointProvider brAPIEndpointProvider,
                                @Property(name = "brapi.server.reference-source") String referenceSource,
                                @Property(name = "micronaut.bi.api.run-scheduled-tasks") boolean runScheduledTasks,
-                               ProgramCacheProvider programCacheProvider) {
+                               ProgramCacheProvider programCacheProvider, TraitService traitService) {
         this.programDAO = programDAO;
         this.importDAO = importDAO;
         this.observationUnitDAO = observationUnitDAO;
@@ -79,6 +83,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
         this.brAPIEndpointProvider = brAPIEndpointProvider;
         this.referenceSource = referenceSource;
         this.runScheduledTasks = runScheduledTasks;
+        this.traitService = traitService;
         this.programCache = programCacheProvider.getProgramCache(this::fetchProgramObservations, BrAPIObservation.class);
     }
 
@@ -240,6 +245,27 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
         return getProgramObservations(program.getId()).values().stream()
                 .filter(o -> ouDbIds.contains(o.getObservationUnitDbId()) && studyDbIds.contains(o.getStudyDbId()))
                 .collect(Collectors.toList());
+    }
+
+    public List<BrAPIObservation> getObservationsByStudyIds(Collection<String> studyDbIds, Program program) throws ApiException {
+        if(studyDbIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String xrefSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.STUDIES);
+        // Lookup studyDbId
+        return getProgramObservations(program.getId()).values().stream()
+                .filter(o -> {
+                    Optional<BrAPIExternalReference> xref = Utilities.getExternalReference(o.getExternalReferences(), xrefSource);
+                    return xref.filter(brAPIExternalReference -> studyDbIds.contains(brAPIExternalReference.getReferenceId())).isPresent();
+                }).peek(o -> {
+                    try {
+                        Trait trait = traitService.getByObservationVariableDbId(program.getId(), o.getObservationVariableDbId());
+                        o.setObservationVariableDbId(trait.getId().toString());
+                    } catch (DoesNotExistException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                }).collect(Collectors.toList());
     }
 
     @NotNull

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -259,7 +259,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
         // Build a hashmap of traits for fast lookup. The key is ObservationVariableDbId, the value is the Trait Id.
         HashMap<String, String> traitIdsByObservationVariableDbId = traitService.getIdsByObservationVariableDbIds(program.getId(), observations.stream().map(BrAPIObservation::getObservationVariableDbId).collect(Collectors.toList()));
 
-        // Lookup studyDbId
+        // Lookup studyDbId.
         return observations.stream()
                 .filter(o -> {
                     // Short circuit if filter is null.

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -276,6 +276,9 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
                     // Translate ObservationId.
                     o.setObservationDbId(Utilities.getExternalReference(o.getExternalReferences(), observationSource)
                             .orElseThrow(() -> new RuntimeException("observation xref not found on observation")).getReferenceId());
+                    // Translate StudyDbId.
+                    o.setStudyDbId(Utilities.getExternalReference(o.getExternalReferences(), studySource)
+                            .orElseThrow(() -> new RuntimeException("study xref not found on observation")).getReferenceId());
                     // TODO: consider translating germplasmDbId in BI-2506.
                 }).collect(Collectors.toList());
     }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -260,7 +260,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
         HashMap<String, String> traitIdsByObservationVariableDbId = traitService.getIdsByObservationVariableDbIds(program.getId(), observations.stream().map(BrAPIObservation::getObservationVariableDbId).collect(Collectors.toList()));
 
         // Lookup studyDbId
-        return getProgramObservations(program.getId()).values().stream()
+        return observations.stream()
                 .filter(o -> {
                     // Short circuit if filter is null.
                     if (studyDbId == null) return true;

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -247,7 +247,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
                 .collect(Collectors.toList());
     }
 
-    // TODO: implement other filters.
+    // TODO: implement other filters in BI-2506.
     public List<BrAPIObservation> getObservationsByFilters(Program program, String studyDbId) throws ApiException, DoesNotExistException {
 
         String studySource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.STUDIES);
@@ -268,14 +268,15 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
                     return xref.filter(brAPIExternalReference -> studyDbId.equals(brAPIExternalReference.getReferenceId())).isPresent();
                 })
                 .peek(o -> {
-                    // TODO: avoid NPEs!
                     // Translate ObservationVariableDbId.
                     o.setObservationVariableDbId(traitIdsByObservationVariableDbId.get(o.getObservationVariableDbId()));
                     // Translate ObservationUnitDbId.
-                    o.setObservationUnitDbId(Utilities.getExternalReference(o.getExternalReferences(), observationUnitSource).get().getReferenceId());
+                    o.setObservationUnitDbId(Utilities.getExternalReference(o.getExternalReferences(), observationUnitSource)
+                            .orElseThrow(() -> new RuntimeException("observationUnit xref not found on observation")).getReferenceId());
                     // Translate ObservationId.
-                    o.setObservationDbId(Utilities.getExternalReference(o.getExternalReferences(), observationSource).get().getReferenceId());
-                    // TODO: do we need to translate germplasmDbId?
+                    o.setObservationDbId(Utilities.getExternalReference(o.getExternalReferences(), observationSource)
+                            .orElseThrow(() -> new RuntimeException("observation xref not found on observation")).getReferenceId());
+                    // TODO: consider translating germplasmDbId in BI-2506.
                 }).collect(Collectors.toList());
     }
 

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -247,25 +247,24 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
                 .collect(Collectors.toList());
     }
 
-    public List<BrAPIObservation> getObservationsByStudyIds(Collection<String> studyDbIds, Program program) throws ApiException {
+    public List<BrAPIObservation> getObservationsByStudyIds(Collection<String> studyDbIds, Program program) throws ApiException, DoesNotExistException {
         if(studyDbIds.isEmpty()) {
             return Collections.emptyList();
         }
         String xrefSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.STUDIES);
+        // Get all observations for the program.
+        Collection<BrAPIObservation> observations = getProgramObservations(program.getId()).values();
+        // Build a hashmap of traits for fast lookup. The key is ObservationVariableDbId, the value is the Trait Id.
+        HashMap<String, String> traitIdsByObservationVariableDbId = traitService.getIdsByObservationVariableDbIds(program.getId(), observations.stream().map(BrAPIObservation::getObservationVariableDbId).collect(Collectors.toList()));
+
         // Lookup studyDbId
         return getProgramObservations(program.getId()).values().stream()
                 .filter(o -> {
                     Optional<BrAPIExternalReference> xref = Utilities.getExternalReference(o.getExternalReferences(), xrefSource);
                     return xref.filter(brAPIExternalReference -> studyDbIds.contains(brAPIExternalReference.getReferenceId())).isPresent();
-                }).peek(o -> {
-                    try {
-                        Trait trait = traitService.getByObservationVariableDbId(program.getId(), o.getObservationVariableDbId());
-                        o.setObservationVariableDbId(trait.getId().toString());
-                    } catch (DoesNotExistException e) {
-                        throw new RuntimeException(e);
-                    }
-
-                }).collect(Collectors.toList());
+                })
+                .peek(o -> o.setObservationVariableDbId(traitIdsByObservationVariableDbId.get(o.getObservationVariableDbId())))
+                .collect(Collectors.toList());
     }
 
     @NotNull

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -247,11 +247,13 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
                 .collect(Collectors.toList());
     }
 
-    public List<BrAPIObservation> getObservationsByStudyIds(Collection<String> studyDbIds, Program program) throws ApiException, DoesNotExistException {
-        if(studyDbIds.isEmpty()) {
-            return Collections.emptyList();
-        }
-        String xrefSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.STUDIES);
+    // TODO: implement other filters.
+    public List<BrAPIObservation> getObservationsByFilters(Program program, String studyDbId) throws ApiException, DoesNotExistException {
+
+        String studySource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.STUDIES);
+        String observationUnitSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.OBSERVATION_UNITS);
+        String observationSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.OBSERVATIONS);
+
         // Get all observations for the program.
         Collection<BrAPIObservation> observations = getProgramObservations(program.getId()).values();
         // Build a hashmap of traits for fast lookup. The key is ObservationVariableDbId, the value is the Trait Id.
@@ -260,11 +262,21 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
         // Lookup studyDbId
         return getProgramObservations(program.getId()).values().stream()
                 .filter(o -> {
-                    Optional<BrAPIExternalReference> xref = Utilities.getExternalReference(o.getExternalReferences(), xrefSource);
-                    return xref.filter(brAPIExternalReference -> studyDbIds.contains(brAPIExternalReference.getReferenceId())).isPresent();
+                    // Short circuit if filter is null.
+                    if (studyDbId == null) return true;
+                    Optional<BrAPIExternalReference> xref = Utilities.getExternalReference(o.getExternalReferences(), studySource);
+                    return xref.filter(brAPIExternalReference -> studyDbId.equals(brAPIExternalReference.getReferenceId())).isPresent();
                 })
-                .peek(o -> o.setObservationVariableDbId(traitIdsByObservationVariableDbId.get(o.getObservationVariableDbId())))
-                .collect(Collectors.toList());
+                .peek(o -> {
+                    // TODO: avoid NPEs!
+                    // Translate ObservationVariableDbId.
+                    o.setObservationVariableDbId(traitIdsByObservationVariableDbId.get(o.getObservationVariableDbId()));
+                    // Translate ObservationUnitDbId.
+                    o.setObservationUnitDbId(Utilities.getExternalReference(o.getExternalReferences(), observationUnitSource).get().getReferenceId());
+                    // Translate ObservationId.
+                    o.setObservationDbId(Utilities.getExternalReference(o.getExternalReferences(), observationSource).get().getReferenceId());
+                    // TODO: do we need to translate germplasmDbId?
+                }).collect(Collectors.toList());
     }
 
     @NotNull

--- a/src/main/java/org/breedinginsight/services/TraitService.java
+++ b/src/main/java/org/breedinginsight/services/TraitService.java
@@ -491,4 +491,15 @@ public class TraitService {
 
         return traitDAO.getTraitsByTraitName(programId, names.stream().map(name -> Trait.builder().observationVariableName(name).build()).collect(Collectors.toList()));
     }
+
+    public Trait getByObservationVariableDbId(UUID programId, String observationVariableDbId) throws DoesNotExistException {
+        if (!programService.exists(programId)) {
+            throw new DoesNotExistException("Program does not exist");
+        }
+
+        return traitDAO.getTraitsFullByProgramId(programId).stream()
+                .filter(t -> t.getObservationVariableDbId().equals(observationVariableDbId))
+                .findFirst().orElseThrow(() -> new DoesNotExistException("Trait not found for observationVariableDbId: " + observationVariableDbId));
+
+    }
 }

--- a/src/main/java/org/breedinginsight/services/TraitService.java
+++ b/src/main/java/org/breedinginsight/services/TraitService.java
@@ -502,4 +502,18 @@ public class TraitService {
                 .findFirst().orElseThrow(() -> new DoesNotExistException("Trait not found for observationVariableDbId: " + observationVariableDbId));
 
     }
+
+    public HashMap<String, String> getIdsByObservationVariableDbIds(UUID programId, List<String> observationVariableDbIds) throws DoesNotExistException {
+        if (!programService.exists(programId)) {
+            throw new DoesNotExistException("Program does not exist");
+        }
+        return traitDAO.getTraitsFullByProgramId(programId).stream()
+                .filter(t -> observationVariableDbIds.contains(t.getObservationVariableDbId()))
+                .collect(Collectors.toMap(
+                        Trait::getObservationVariableDbId,
+                        (t) -> t.getId().toString(),
+                        (existing, replacement) -> existing,
+                        HashMap::new
+                ));
+    }
 }

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPIObservationsControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPIObservationsControllerIntegrationTest.java
@@ -341,6 +341,9 @@ public class BrAPIObservationsControllerIntegrationTest extends BrAPITest {
 
         // Check no pagination.
         checkPagination(null, null, HttpStatus.OK, 4, 4, 1);
+        // Check page and pageSize defaults.
+        checkPagination(null, 2, HttpStatus.OK, 2, 4, 2);
+        checkPagination(0, null, HttpStatus.OK, 4, 4, 1);
         // Check valid pagination, including last page edge case.
         checkPagination(0, 1, HttpStatus.OK, 1, 4, 4);
         checkPagination(1, 2, HttpStatus.OK, 2, 4, 2);
@@ -360,10 +363,10 @@ public class BrAPIObservationsControllerIntegrationTest extends BrAPITest {
         String requestURL = String.format("/programs/%s/brapi/v2/observations", program.getId());
         if (page != null) {
             requestURL = requestURL + "?page=" + page;
-        } else {
-            page = 0;
         }
-        if (pageSize != null) {
+        if (pageSize != null && page == null) {
+            requestURL = requestURL + "?pageSize=" + pageSize;
+        } else if (pageSize != null) {
             requestURL = requestURL + "&pageSize=" + pageSize;
         }
 
@@ -386,7 +389,8 @@ public class BrAPIObservationsControllerIntegrationTest extends BrAPITest {
             // Get metadata.
             JsonObject pagination = responseObj.getAsJsonObject("metadata").getAsJsonObject("pagination");
             assertEquals(expectedSize, pagination.get("pageSize").getAsInt());
-            assertEquals(page, pagination.get("currentPage").getAsInt());
+            int expectedPage = page == null ? 0 : page;
+            assertEquals(expectedPage, pagination.get("currentPage").getAsInt());
             assertEquals(expectedTotalPages, pagination.get("totalPages").getAsInt());
             assertEquals(expectedTotalCount, pagination.get("totalCount").getAsInt());
             // Get observations.

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPIObservationsControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPIObservationsControllerIntegrationTest.java
@@ -385,8 +385,7 @@ public class BrAPIObservationsControllerIntegrationTest extends BrAPITest {
             JsonObject responseObj = gson.fromJson(response.body(), JsonObject.class);
             // Get metadata.
             JsonObject pagination = responseObj.getAsJsonObject("metadata").getAsJsonObject("pagination");
-            // TODO: Per BrAPI docs, pageSize (metadata) should always be the
-            assertEquals(expectedSize, pagination.get("pageSize").getAsInt());  // TODO: check... BJTS does something different.
+            assertEquals(expectedSize, pagination.get("pageSize").getAsInt());
             assertEquals(page, pagination.get("currentPage").getAsInt());
             assertEquals(expectedTotalPages, pagination.get("totalPages").getAsInt());
             assertEquals(expectedTotalCount, pagination.get("totalCount").getAsInt());

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPIObservationsControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPIObservationsControllerIntegrationTest.java
@@ -178,6 +178,7 @@ public class BrAPIObservationsControllerIntegrationTest extends BrAPITest {
             //  A float is returned from the backend instead of double. there is a separate card to fix this.
             int valueIndex = i % values.size();  // Prevent overflow.
             row1.put(traits.get(i).getObservationVariableName(), values.get(valueIndex));
+            row2.put(traits.get(i).getObservationVariableName(), values.get(valueIndex));
         }
 
         rows.add(row1);
@@ -333,6 +334,71 @@ public class BrAPIObservationsControllerIntegrationTest extends BrAPITest {
         Float value2 = observations.get(1).getAsJsonObject().get("value").getAsFloat();
         assertTrue(values.contains(value1), "Observation with value " + value1 + " not found.");
         assertTrue(values.contains(value2), "Observation with value " + value2 + " not found.");
+    }
+
+    @Test
+    public void testGetObsPagination() {
+
+        // Check no pagination.
+        checkPagination(null, null, HttpStatus.OK, 4, 4, 1);
+        // Check valid pagination, including last page edge case.
+        checkPagination(0, 1, HttpStatus.OK, 1, 4, 4);
+        checkPagination(1, 2, HttpStatus.OK, 2, 4, 2);
+        checkPagination(0, 3, HttpStatus.OK, 3, 4, 2);
+        checkPagination(1, 3, HttpStatus.OK, 1, 4, 2);
+        checkPagination(0, 100, HttpStatus.OK, 4, 4, 1);
+        // Check invalid pagination.
+        checkPagination(2, 2, HttpStatus.BAD_REQUEST, null, null, null);
+        checkPagination(0, 0, HttpStatus.BAD_REQUEST, null, null, null);
+        checkPagination(1, 0, HttpStatus.BAD_REQUEST, null, null, null);
+        checkPagination(10, 100, HttpStatus.BAD_REQUEST, null, null, null);
+
+    }
+
+    private void checkPagination(Integer page, Integer pageSize, HttpStatus expectedStatus, Integer expectedSize, Integer expectedTotalCount, Integer expectedTotalPages) {
+        // Build request URL.
+        String requestURL = String.format("/programs/%s/brapi/v2/observations", program.getId());
+        if (page != null) {
+            requestURL = requestURL + "?page=" + page;
+        } else {
+            page = 0;
+        }
+        if (pageSize != null) {
+            requestURL = requestURL + "&pageSize=" + pageSize;
+        }
+
+        // Make a GET request to the /observations endpoint with the supplied pagination parameters.
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET(requestURL).bearerAuth("test-registered-user"),
+                String.class
+        );
+
+        // Check for expected response.
+        try {
+            HttpResponse<String> response = call.blockingFirst();
+            assertEquals(expectedStatus, response.getStatus());
+
+            // If call.blockingFirst() doesn't throw, expect a 200 OK.
+            assertEquals(HttpStatus.OK, response.getStatus());
+
+            // Parse and check body and metadata.
+            JsonObject responseObj = gson.fromJson(response.body(), JsonObject.class);
+            // Get metadata.
+            JsonObject pagination = responseObj.getAsJsonObject("metadata").getAsJsonObject("pagination");
+            // TODO: Per BrAPI docs, pageSize (metadata) should always be the
+            assertEquals(expectedSize, pagination.get("pageSize").getAsInt());  // TODO: check... BJTS does something different.
+            assertEquals(page, pagination.get("currentPage").getAsInt());
+            assertEquals(expectedTotalPages, pagination.get("totalPages").getAsInt());
+            assertEquals(expectedTotalCount, pagination.get("totalCount").getAsInt());
+            // Get observations.
+            JsonArray observations = responseObj.getAsJsonObject("result").getAsJsonArray("data");
+            assertEquals(expectedSize, observations.size());
+
+        } catch (HttpClientResponseException e) {
+            // call.blockingFirst() will throw in the case of a non-200 code.
+            assertEquals(expectedStatus, e.getStatus());
+        }
+
     }
 
     private File writeDataToFile(List<Map<String, Object>> data, List<Trait> traits) throws IOException {

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPIObservationsControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPIObservationsControllerIntegrationTest.java
@@ -63,6 +63,7 @@ import java.time.OffsetDateTime;
 import java.util.*;
 
 import static io.micronaut.http.HttpRequest.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @MicronautTest
@@ -71,8 +72,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class BrAPIObservationsControllerIntegrationTest extends BrAPITest {
 
     private Program program;
-    private String experimentId;
+    private String  experimentId;
     private List<String> envIds = new ArrayList<>();
+    // Use hardcoded values for more deterministic test runs and easier assertions.
+    private List<Float> values = List.of(0.125F, 12.415F);
     private final List<Map<String, Object>> rows = new ArrayList<>();
     private final List<Column> columns = ExperimentFileColumns.getOrderedColumns();
     private List<Trait> traits;
@@ -170,15 +173,11 @@ public class BrAPIObservationsControllerIntegrationTest extends BrAPITest {
         Map<String, Object> row2 = makeExpImportRow("Env2");
 
         // Add test observation data
-        for (Trait trait : traits) {
-            Random random = new Random();
-
+        for (int i = 0; i < traits.size(); i++) {
             // TODO: test for sending obs data as double.
             //  A float is returned from the backend instead of double. there is a separate card to fix this.
-            // Double val1 = Math.random();
-
-            Float val1 = random.nextFloat();
-            row1.put(trait.getObservationVariableName(), val1);
+            int valueIndex = i % values.size();  // Prevent overflow.
+            row1.put(traits.get(i).getObservationVariableName(), values.get(valueIndex));
         }
 
         rows.add(row1);
@@ -273,7 +272,7 @@ public class BrAPIObservationsControllerIntegrationTest extends BrAPITest {
     }
 
     @Test
-    @Disabled("Disabled until fetching of observations is implemented")
+    @Disabled("Disabled until fetching of observations is implemented in BI-2506.")
     public void testGetObsListByExpId() {
         Flowable<HttpResponse<String>> call = client.exchange(
                 GET(String.format("/programs/%s/brapi/v2/observations?trialDbId=%s", program.getId(), experimentId))
@@ -286,7 +285,7 @@ public class BrAPIObservationsControllerIntegrationTest extends BrAPITest {
     }
 
     @Test
-    @Disabled("Disabled until fetching of observations is implemented")
+    @Disabled("Disabled until fetching of observations is implemented in BI-2506.")
     public void testGetOUById() {
         Flowable<HttpResponse<String>> call = client.exchange(
                 GET(String.format("/programs/%s/brapi/v2/observations?trialDbId=%s", program.getId(), experimentId))
@@ -309,6 +308,31 @@ public class BrAPIObservationsControllerIntegrationTest extends BrAPITest {
 
         HttpResponse<String> ouResponse = ouCall.blockingFirst();
         assertEquals(HttpStatus.OK, ouResponse.getStatus());
+    }
+
+    @Test
+    public void testGetObsByStudyDbId() {
+        // Make a GET request to the /observations endpoint with the studyDbId query parameter.
+        Flowable<HttpResponse<String>> call = client.exchange(
+                GET(String.format("/programs/%s/brapi/v2/observations?studyDbId=%s", program.getId(), envIds.get(0)))
+                        .bearerAuth("test-registered-user"),
+                String.class
+        );
+
+        // Check for 200 OK response.
+        HttpResponse<String> response = call.blockingFirst();
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+        // Check that two observations were returned.
+        JsonObject responseObj = gson.fromJson(response.body(), JsonObject.class);
+        JsonArray observations = responseObj.getAsJsonObject("result").getAsJsonArray("data");
+        assertEquals(2, observations.size());
+
+        // Check the observation values, keep in mind the order of results is not guaranteed.
+        Float value1 = observations.get(0).getAsJsonObject().get("value").getAsFloat();
+        Float value2 = observations.get(1).getAsJsonObject().get("value").getAsFloat();
+        assertTrue(values.contains(value1), "Observation with value " + value1 + " not found.");
+        assertTrue(values.contains(value2), "Observation with value " + value2 + " not found.");
     }
 
     private File writeDataToFile(List<Map<String, Object>> data, List<Trait> traits) throws IOException {


### PR DESCRIPTION
# Description
**Story:** [BI-2047](https://breedinginsight.atlassian.net/browse/BI-2047)

Partially implemented the BrAPI /observations GET endpoint to support pulling existing observation values into Field Book. The endpoint only supports `studyDbId` and pagination (`pageSize`, `page`) query parameters. The use of other query parameters will result in a `501 Not Implemented` response. The use of invalid ***pagination*** query parameters will result in a `400 Bad Request` response.

**Valid pagination query parameters must satisfy the following conditions.**
- ~~Either both or neither of `page` and `pageSize` must be present, one is invalid without the other.~~ (BrAPI specifies default values).
- If present, `pageSize` must be greater than zero. If omitted, `pageSize` defaults to `1000`.
- If present, `page` must be greater than or equal to zero and less than the total number of pages (`page` is zero-indexed). If omitted, `page` defaults to 0.

There is a story to add support for all query params, [BI-2506](https://breedinginsight.atlassian.net/browse/BI-2506).


# Testing

### Part 1: Field Book Integration

> To test with Delta Breed running locally and Field Book running in an android emulator, follow the [Connect to Local DeltaBreed from Field Book](https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/2017001585/Field-Book+Development+Guide#Connect-to-local-DeltaBreed-from-Field-Book) section of the [Field Book Development Guide](https://breedinginsight.atlassian.net/wiki/x/cQA5e).

1. Upload an experiment with observations to DeltaBreed.
2. Pull the experiment into Field Book (I recommend enabling the new BrAPI import UI in **Settings > Experimental**.
3. On the Field Book "Field Detail" page, use the "Sync" activity to pull existing observations into Field Book.
4. The data collected should be visualized in the "Data" section of the "Field Detail" page.
5. Go to the "Collect" activity, and confirm that the values uploaded to DeltaBreed are in the Field Book collection UI.


### Part 2: 501 Not Implemented

- Using the /observations GET endpoint with query parameters other than `studyDbId` should result in a [501 status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/501).

> For example a request to `{{baseURL}}/v1/programs/{{programId}}/brapi/v2/observations?trialDbId={{trialDbId}}` with all variables substituted with valid values should result in a 501 response. The story to implement support other query parameters is BI-2506.

### Part 3: Pagination

Test pagination, by providing both valid and invalid `pageSize` and `page` query parameters to the `{{baseURL}}/v1/programs/{{programId}}/brapi/v2/observations` endpoint. Invalid pagination query parameters should result in a `400 Bad Request` response. Valid pagination query parameters should result in data and metadata consistent with [the BrAPI documentation on pagination](https://plant-breeding-api.readthedocs.io/en/latest/docs/best_practices/Pagination.html). Note: the BrAPI Java Server is inconsistent with the docs, this is [an open issue](https://github.com/plantbreeding/brapi-Java-ProdServer/issues/6).


<div align="center"><strong>OR</strong></div>
<br/>

Review the test cases in `BrAPIObservationsControllerIntegrationTest::testGetObsPagination` for logical correctness.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2047]: https://breedinginsight.atlassian.net/browse/BI-2047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2506]: https://breedinginsight.atlassian.net/browse/BI-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ