### PR TITLE
[BI-2450]BrAPI Server DB connections exhausted on biapi startup caching

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -64,9 +64,9 @@ BRAPI_VENDOR_SUBMISSION_ENABLED=false #can a submission be sent to a vendor via 
 BRAPI_VENDOR_CHECK_FREQUENCY=1d #how often to check for vendor updates for sample submissions
 
 #The initial caching of each type of object needs to be staggered by the prescribed number of seconds
-germplasm_start_delay=5s
-study_start_delay=10s
-trial_start_delay=15s
-trait_start_delay=20s
-observation_start_delay=25s
-observation_unit_start_delay=30s
+GERMPLASM_START_DELAY=5s
+STUDY_START_DELAY=10s
+TRIAL_START_DELAY=15s
+TRAIT_START_DELAY=20s
+OBSERVATION_START_DELAY=25s
+OBSERVATION_UNIT_START_DELAY=30s

--- a/.env.template
+++ b/.env.template
@@ -62,3 +62,11 @@ AWS_S3_ENDPOINT=<s3 endpoint, default https://s3.us-east-1.amazonaws.com>
 
 BRAPI_VENDOR_SUBMISSION_ENABLED=false #can a submission be sent to a vendor via BrAPI
 BRAPI_VENDOR_CHECK_FREQUENCY=1d #how often to check for vendor updates for sample submissions
+
+#The initial caching of each type of object needs to be staggered by the prescribed number of seconds
+germplasm_start_delay=5s
+study_start_delay=10s
+trial_start_delay=15s
+trait_start_delay=20s
+observation_start_delay=25s
+observation_unit_start_delay=30s

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -78,7 +78,7 @@ public class BrAPIGermplasmDAO {
         this.brAPIEndpointProvider = brAPIEndpointProvider;
     }
 
-    @Scheduled(initialDelay = "2s")
+    @Scheduled(initialDelay = "${startup.delay.germplasm}")
     public void setup() {
         if(!runScheduledTasks) {
             return;

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -87,7 +87,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
         this.programCache = programCacheProvider.getProgramCache(this::fetchProgramObservations, BrAPIObservation.class);
     }
 
-    @Scheduled(initialDelay = "3s")
+    @Scheduled(initialDelay = "${startup.delay.observation}")
     public void setup() {
         if(!runScheduledTasks) {
             return;

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
@@ -95,7 +95,7 @@ public class BrAPIObservationUnitDAO extends BrAPICachedDAO<BrAPIObservationUnit
         this.programCache = programCacheProvider.getProgramCache(this::fetchProgramObservationUnits, BrAPIObservationUnit.class);
     }
 
-    @Scheduled(initialDelay = "3s")
+    @Scheduled(initialDelay = "${startup.delay.observation_unit}")
     public void setup() {
         if(!runScheduledTasks) {
             return;

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIStudyDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIStudyDAO.java
@@ -65,7 +65,7 @@ public class BrAPIStudyDAO extends BrAPICachedDAO<BrAPIStudy> {
         this.programCache = programCacheProvider.getProgramCache(this::fetchProgramStudy, BrAPIStudy.class);
     }
 
-    @Scheduled(initialDelay = "2s")
+    @Scheduled(initialDelay = "${startup.delay.study}")
     public void setup() {
         if(!runScheduledTasks) {
             return;

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -81,7 +81,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
     }
 
 
-    @Scheduled(initialDelay = "2s")
+    @Scheduled(initialDelay = "${startup.delay.trial}")
     public void setup() {
         if(!runScheduledTasks) {
             return;

--- a/src/main/java/org/breedinginsight/daos/impl/TraitDAOImpl.java
+++ b/src/main/java/org/breedinginsight/daos/impl/TraitDAOImpl.java
@@ -109,7 +109,7 @@ public class TraitDAOImpl extends TraitDao implements TraitDAO {
         this.runScheduledTasks = runScheduledTasks;
     }
 
-    @Scheduled(initialDelay = "2s")
+    @Scheduled(initialDelay = "${startup.delay.trait}")
     public void setup() {
         if(!runScheduledTasks) {
             return;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -205,3 +205,11 @@ aws:
     buckets:
       genotype:
         bucket: ${AWS_GENO_BUCKET}
+startup:
+  delay:
+    germplasm: ${germplasm_start_delay:2s}
+    study: ${study_start_delay:2s}
+    trial: ${trial_start_delay:2s}
+    trait: ${trait_start_delay:2s}
+    observation: ${observation_start_delay:3s}
+    observation_unit: ${observation_unit_start_delay:3s}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -207,9 +207,9 @@ aws:
         bucket: ${AWS_GENO_BUCKET}
 startup:
   delay:
-    germplasm: ${germplasm_start_delay:2s}
-    study: ${study_start_delay:2s}
-    trial: ${trial_start_delay:2s}
-    trait: ${trait_start_delay:2s}
-    observation: ${observation_start_delay:3s}
-    observation_unit: ${observation_unit_start_delay:3s}
+    germplasm: ${GERMPLASM_START_DELAY:2s}
+    study: ${STUDY_START_DELAY:2s}
+    trial: ${TRIAL_START_DELAY:2s}
+    trait: ${TRAIT_START_DELAY:2s}
+    observation: ${OBSERVATION_START_DELAY:3s}
+    observation_unit: ${OBSERVATION_UNIT_START_DELAY:3s}


### PR DESCRIPTION
[BI-2450](https://breedinginsight.atlassian.net/browse/BI-2450) - BrAPI Server DB connections exhausted on biapi startup caching

# Description
The scheduled delay in creating the cache from the  DOA's is now driven by the .env file.  That way the expensive calls to the BrAPI server (that are called when bi-api is first started). can be staggered.  The timing can be changed in a config file (.env), so that it can be fine tuned in each environment.  

# Testing

- If the new parameters are NOT added to your local .env-file then there should be no change to the system's behavior.
- If the new parameters are added, then the caching should be scheduled accordingly.  
  - FOR EXAMPLE:
    - if the parameters are:
    - `germplasm_start_delay=5s
        study_start_delay=10s
         trial_start_delay=15s
         trait_start_delay=20s
         observation_start_delay=25s
         observation_unit_start_delay=30s`
       - THEN you should see line in you bi-api log that look something like:
       - 
 `2025-02-17 15:16:29.987-0500 [scheduled-executor-thread-1] DEBUG o.b.brapi.v2.dao.BrAPIGermplasmDAO - populating germplasm cache`

`2025-02-17 15:16:35.559-0500 [scheduled-executor-thread-3] DEBUG o.b.brapi.v2.dao.BrAPIStudyDAO - populating study cache`

`2025-02-17 15:16:40.548-0500 [scheduled-executor-thread-7] DEBUG o.b.b.v2.dao.impl.BrAPITrialDAOImpl - populating experiment cache`

`2025-02-17 15:16:50.548-0500 [scheduled-executor-thread-6] DEBUG o.b.brapi.v2.dao.BrAPIObservationDAO - populating observation cache`

`2025-02-17 15:16:55.551-0500 [scheduled-executor-thread-8] DEBUG o.b.b.v2.dao.BrAPIObservationUnitDAO - populating observation unit cache`

Note:  there is at least 5-seconds between each line.


# Checklist:

- [x] I have performed a self-review of my own code
- [ x I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2450]: https://breedinginsight.atlassian.net/browse/BI-2450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ