### PR TITLE
[BI-2187] Non-sequential GIDs After Circular Dependency Error

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -326,10 +326,9 @@ public class GermplasmProcessor implements Processor {
         // Construct pedigree
         constructPedigreeString(importRows, mappedBrAPIImport, commit);
 
-        // Construct a dependency tree for POSTing order. Dependents on unique germplasm name, (<Name> [<Program Key> - <Accession Number>])
-        if (commit) {
-            createPostOrder();
-        }
+        // for commit:  Construct a dependency tree for POSTing order. Dependents on unique germplasm name, (<Name> [<Program Key> - <Accession Number>])
+        // for !commit: Validate for circular pedigree dependencies.
+        createPostOrder();
 
         // Construct our response object
         return getStatisticsMap(importRows);
@@ -556,6 +555,9 @@ public class GermplasmProcessor implements Processor {
         }
     }
 
+    /*
+    This will set the postOrder and validate for circular pedigree dependencies.
+     */
     private void createPostOrder() {
         // Construct a dependency tree for POSTing order
         Set<String> created = existingGermplasm.stream().map(BrAPIGermplasm::getGermplasmName).collect(Collectors.toSet());

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -328,7 +328,7 @@ public class GermplasmProcessor implements Processor {
 
         // for commit:  Construct a dependency tree for POSTing order. Dependents on unique germplasm name, (<Name> [<Program Key> - <Accession Number>])
         // for !commit: Validate for circular pedigree dependencies.
-        createPostOrder();
+        createPostOrder(commit);
 
         // Construct our response object
         return getStatisticsMap(importRows);
@@ -558,9 +558,15 @@ public class GermplasmProcessor implements Processor {
     /*
     This will set the postOrder and validate for circular pedigree dependencies.
      */
-    private void createPostOrder() {
+    private void createPostOrder(boolean commit) {
+        Set<String> created = null;
         // Construct a dependency tree for POSTing order
-        Set<String> created = existingGermplasm.stream().map(BrAPIGermplasm::getGermplasmName).collect(Collectors.toSet());
+        if(commit){
+            created = existingGermplasm.stream().map(BrAPIGermplasm::getGermplasmName).collect(Collectors.toSet());
+        }
+        else {
+            created = existingGermplasm.stream().map(BrAPIGermplasm::getDefaultDisplayName).collect(Collectors.toSet());
+        }
 
         //todo this gets messy
 
@@ -571,7 +577,7 @@ public class GermplasmProcessor implements Processor {
             for (BrAPIGermplasm germplasm : newGermplasmList) {
 
                 // If we've already planned this germplasm, skip
-                if (created.contains(germplasm.getGermplasmName())) {
+                if ( (commit && created.contains(germplasm.getGermplasmName())) || (!commit && created.contains(germplasm.getDefaultDisplayName())) ) {
                     continue;
                 }
 


### PR DESCRIPTION
[BI-2187](https://breedinginsight.atlassian.net/browse/BI-2187) Non-sequential GIDs After Circular Dependency Error


# Dependencies
bi_web: develop

# Testing

1. Try to import the following Germplasm file [Circ ped.xls](https://github.com/user-attachments/files/18948669/Circ.ped.xls)
        2. EXPECTED RESULT:  it will fail on “Validate & Upload” due to circular dependency.  
3. Next, import the following Germplasm file [No Circ ped.xls](https://github.com/user-attachments/files/18966019/No.Circ.ped.xls)
        4.  EXPECTED RESULT:   it will succeed.
5. Navigate to the Germplasm list view
          6. EXPECTED RESULT:   There will be no gap in the GID sequence

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2187]: https://breedinginsight.atlassian.net/browse/BI-2187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ