### PR TITLE
[BI-2578][BI-2489] - Optimize BrAPI Germplasm Search 

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -31,6 +31,10 @@ BRAPI_READ_TIMEOUT=60m
 # Max number of records to POST to the BrAPI service per request
 POST_CHUNK_SIZE=1000
 
+# Request cache records paginating through available records per program by CACHE_BRAPI_FETCH_PAGE_SIZE
+CACHE_PAGINATE_GERMPLASM=false
+CACHE_BRAPI_FETCH_PAGE_SIZE=65000
+
 # BrAPI Server Variables
 BRAPI_SERVER_PORT=8083
 

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -141,7 +141,7 @@ public class BrAPIGermplasmDAO {
         BrAPIGermplasmSearchRequest germplasmSearch = new BrAPIGermplasmSearchRequest();
         germplasmSearch.externalReferenceIDs(List.of(programId.toString()));
         germplasmSearch.externalReferenceSources(List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS)));
-        return processGermplasmForDisplay(brAPIDAOUtil.search(
+        return processGermplasmForDisplay(brAPIDAOUtil.searchNoPaging(
                 api::searchGermplasmPost,
                 api::searchGermplasmSearchResultsDbIdGet,
                 germplasmSearch

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -65,6 +65,9 @@ public class BrAPIGermplasmDAO {
     @Property(name = "micronaut.bi.api.run-scheduled-tasks")
     private boolean runScheduledTasks;
 
+    @Property(name = "brapi.paginate.germplasm")
+    private boolean paginateGermplasm;
+
     private final ProgramCache<BrAPIGermplasm> programGermplasmCache;
 
     private final BrAPIEndpointProvider brAPIEndpointProvider;
@@ -141,11 +144,22 @@ public class BrAPIGermplasmDAO {
         BrAPIGermplasmSearchRequest germplasmSearch = new BrAPIGermplasmSearchRequest();
         germplasmSearch.externalReferenceIDs(List.of(programId.toString()));
         germplasmSearch.externalReferenceSources(List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS)));
-        return processGermplasmForDisplay(brAPIDAOUtil.searchNoPaging(
-                api::searchGermplasmPost,
-                api::searchGermplasmSearchResultsDbIdGet,
-                germplasmSearch
-        ), program.getKey());
+
+        if (paginateGermplasm) {
+            log.debug("Fetching germplasm with pagination to BrAPI");
+            return processGermplasmForDisplay(brAPIDAOUtil.search(
+                            api::searchGermplasmPost,
+                            api::searchGermplasmSearchResultsDbIdGet,
+                            germplasmSearch),
+                    program.getKey());
+        } else {
+            log.debug("Fetching germplasm without pagination to BrAPI");
+            return processGermplasmForDisplay(brAPIDAOUtil.searchNoPaging(
+                    api::searchGermplasmPost,
+                    api::searchGermplasmSearchResultsDbIdGet,
+                    germplasmSearch),
+                    program.getKey());
+        }
     }
 
     /**

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -60,21 +60,21 @@ public class BrAPIDAOUtil {
     private final Duration searchTimeout;
     private final int pageSize;
     private final int postGroupSize;
+    private final int brapiFetchPageSize;
     private final ProgramService programService;
-
-    @Property(name = "brapi.cache.fetch-page-size")
-    private int brapiFetchPageSize;
 
     @Inject
     public BrAPIDAOUtil(@Property(name = "brapi.search.wait-time") int searchWaitTime,
                         @Property(name = "brapi.read-timeout") Duration searchTimeout,
                         @Property(name = "brapi.page-size") int pageSize,
                         @Property(name = "brapi.post-group-size") int postGroupSize,
+                        @Property(name = "brapi.cache.fetch-page-size") int brapiFetchPageSize,
                         ProgramService programService) {
         this.searchWaitTime = searchWaitTime;
         this.searchTimeout = searchTimeout;
         this.pageSize = pageSize;
         this.postGroupSize = postGroupSize;
+        this.brapiFetchPageSize = brapiFetchPageSize;
         this.programService = programService;
     }
 

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -79,26 +79,37 @@ public class BrAPIDAOUtil {
                                                                                Function3<String, Integer, Integer, ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>>> searchGetMethod,
                                                                                U searchBody
     ) throws ApiException {
-        return searchInternal(searchMethod, searchGetMethod, null, searchBody);
+        return searchInternal(searchMethod, searchGetMethod, null, searchBody, true);
     }
 
     public <T, U extends BrAPISearchRequestParametersPaging, V> List<V> search(Function<U, ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>>> searchMethod,
                                                                                Function4<BrAPIWSMIMEDataTypes, String, Integer, Integer, ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>>> searchGetMethod,
                                                                                U searchBody
     ) throws ApiException {
-        return searchInternal(searchMethod, null, searchGetMethod, searchBody);
+        return searchInternal(searchMethod, null, searchGetMethod, searchBody, true);
+    }
+
+    public <T, U extends BrAPISearchRequestParametersPaging, V> List<V> searchNoPaging(Function<U, ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>>> searchMethod,
+                                                                               Function3<String, Integer, Integer, ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>>> searchGetMethod,
+                                                                               U searchBody
+    ) throws ApiException {
+        return searchInternal(searchMethod, searchGetMethod, null, searchBody, false);
     }
 
     private <T, U extends BrAPISearchRequestParametersPaging, V> List<V> searchInternal(Function<U, ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>>> searchMethod,
                                                                                         Function3<String, Integer, Integer, ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>>> searchGetMethod,
                                                                                         Function4<BrAPIWSMIMEDataTypes, String, Integer, Integer, ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>>> searchGetMethodWithMimeType,
-                                                                                U searchBody) throws ApiException {
+                                                                                        U searchBody, boolean sendPaging) throws ApiException {
         try {
             List<V> listResult = new ArrayList<>();
             //NOTE: Because of the way Breedbase implements BrAPI searches, the page size is initially set to an
             //arbitrary, large value to ensure that in the event that a 202 response is returned, the searchDbId
             //stored will refer to all records of the BrAPI variable.
-            searchBody.pageSize(10000000);
+
+            if (sendPaging) {
+                searchBody.pageSize(65000);
+            }
+
             ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>> response = searchMethod.apply(searchBody);
             if (response.getBody().getLeft().isPresent()) {
                 BrAPIResponse listResponse = (BrAPIResponse) response.getBody().getLeft().get();
@@ -108,7 +119,7 @@ public class BrAPIDAOUtil {
                 pagination params are handled for POST search endpoints or the corresponding endpoints in Breedbase are
                 changed or updated
              */
-                if(hasMorePages(listResponse)) {
+                if(sendPaging && hasMorePages(listResponse)) {
                     int currentPage = listResponse.getMetadata().getPagination().getCurrentPage() + 1;
                     int totalPages = listResponse.getMetadata().getPagination().getTotalPages();
 
@@ -137,7 +148,7 @@ public class BrAPIDAOUtil {
                         BrAPIResponse listResponse = (BrAPIResponse) searchGetResponse.getBody().getLeft().get();
                         listResult = getListResult(searchGetResponse);
 
-                        if(hasMorePages(listResponse)) {
+                        if(sendPaging && hasMorePages(listResponse)) {
                             currentPage++;
                             int totalPages = listResponse.getMetadata()
                                     .getPagination()

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -102,11 +102,11 @@ public class BrAPIDAOUtil {
                                                                                         U searchBody, boolean sendPaging) throws ApiException {
         try {
             List<V> listResult = new ArrayList<>();
-            //NOTE: Because of the way Breedbase implements BrAPI searches, the page size is initially set to an
-            //arbitrary, large value to ensure that in the event that a 202 response is returned, the searchDbId
-            //stored will refer to all records of the BrAPI variable.
 
             if (sendPaging) {
+                // This should be set to whatever the maximum allowable value is configured in the brapi test server,
+                // perhaps it should be configurable on bi side as well.
+                // For reference, that prop name is paging.page-size.max-allowed
                 searchBody.pageSize(65000);
             }
 

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -62,6 +62,9 @@ public class BrAPIDAOUtil {
     private final int postGroupSize;
     private final ProgramService programService;
 
+    @Property(name = "brapi.cache.fetch-page-size")
+    private int brapiFetchPageSize;
+
     @Inject
     public BrAPIDAOUtil(@Property(name = "brapi.search.wait-time") int searchWaitTime,
                         @Property(name = "brapi.read-timeout") Duration searchTimeout,
@@ -107,7 +110,7 @@ public class BrAPIDAOUtil {
                 // This should be set to whatever the maximum allowable value is configured in the brapi test server,
                 // perhaps it should be configurable on bi side as well.
                 // For reference, that prop name is paging.page-size.max-allowed
-                searchBody.pageSize(65000);
+                searchBody.pageSize(brapiFetchPageSize);
             }
 
             ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>> response = searchMethod.apply(searchBody);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -173,6 +173,19 @@ brapi:
   search:
     wait-time: 1000
   post-group-size: ${POST_CHUNK_SIZE:1000}
+  paginate:
+    # These props are used as flippers for specific cache entities to be fetched all at once or paginated.
+    # If the props are set to true, there's a possibility the BrAPI server could run out of memory grabbing all the
+    # data and assigning it to entities in memory given a program that has a large amount of those types of entities.
+    # At that point these flippers should be set to true.
+    germplasm: ${CACHE_PAGINATE_GERMPLASM:false}
+  cache:
+    # This prop sets how many program cache entity records can be fetched at a time from BrAPI. Today, if over 65000 is used,
+    # a SQL error can happen for programs that have more than this page size, because to fetch these certain entities
+    # the same amount of IDs must be passed for any collections that need to be fetched in the entity, and SQL has a max of ~65355 params.
+    # The ProgramCache will iterate through all pages of an entity to retrieve all the data from BrAPI.
+    fetch-page-size: ${CACHE_BRAPI_FETCH_PAGE_SIZE:65000}
+
 
 email:
   relay-server:

--- a/src/main/resources/brapi/properties/application.properties
+++ b/src/main/resources/brapi/properties/application.properties
@@ -36,3 +36,13 @@ spring.mvc.dispatch-options-request=true
 
 security.oidc_discovery_url=https://example.com/auth/.well-known/openid-configuration
 security.enabled=false
+security.issuer_url=http://example.com/issuerurl
+
+# This should either be set in accordance with a maximum number of SQL parameters (on JOIN FETCHES of collections,
+# if there is more than one collection the IDs of each entity need to be passed through as parameters, and there is a SQL
+# maximum of 65535.  See GermplasmService.findGermplasmEntities()),
+# whatever returns in a reasonable amount of time,
+# or if you want to limit for the sake of server efficiency.
+paging.page-size.max-allowed=65000
+
+paging.page-size.default=1000

--- a/src/test/java/org/breedinginsight/daos/BrAPIDAOUtilUnitTest.java
+++ b/src/test/java/org/breedinginsight/daos/BrAPIDAOUtilUnitTest.java
@@ -70,7 +70,7 @@ public class BrAPIDAOUtilUnitTest {
     @BeforeEach
     void setup() {
         //Create instance of DAO
-        brAPIDAOUtil = new BrAPIDAOUtil(1000, Duration.of(10, ChronoUnit.MINUTES), 1, 100, programService());
+        brAPIDAOUtil = new BrAPIDAOUtil(1000, Duration.of(10, ChronoUnit.MINUTES), 1, 100, 65000, programService());
 
         //Set the page size field
         Field pageSize = BrAPIDAOUtil.class.getDeclaredField("pageSize");

--- a/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
@@ -141,9 +141,9 @@ public class BrAPIGermplasmServiceUnitTest extends DatabaseTest {
         when(programDAO.getAll()).thenReturn(Arrays.asList(Program.builder().id(testProgramId).name("Test Program").active(true).build()));
         when(programDAO.fetchOneById(any(UUID.class))).thenReturn(testProgram);
         when(programDAO.get(any(UUID.class))).thenReturn(Arrays.asList(testProgram));
-        when(brAPIDAOUtil.search(any(Function.class),
-                                     any(Function3.class),
-                                     any(BrAPIGermplasmSearchRequest.class))).thenReturn(germplasm);
+        when(brAPIDAOUtil.searchNoPaging(any(Function.class),
+                any(Function3.class),
+                any(BrAPIGermplasmSearchRequest.class))).thenReturn(germplasm);
 
         //Create germplasm cache of stub data
         Method setupMethod = BrAPIGermplasmDAO.class.getDeclaredMethod("setup");

--- a/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
@@ -201,7 +201,7 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
 
     @MockBean(BrAPIDAOUtil.class)
     BrAPIDAOUtil brAPIDAOUtil() {
-        return spy(new BrAPIDAOUtil(1000, Duration.of(10, ChronoUnit.MINUTES), 1000, 100, programService()));
+        return spy(new BrAPIDAOUtil(1000, Duration.of(10, ChronoUnit.MINUTES), 1000, 100, 65000, programService()));
     }
 
     @MockBean(SimpleStorageService.class)


### PR DESCRIPTION
# Description
[BI-2578](https://breedinginsight.atlassian.net/browse/BI-2578)

* Updated the `BrAPIGermplasmDAO` and the `BrAPIDAOUtil` to fetch all existing germplasm records at once for a program, without pagination.  This will allow the BrAPI server to handle the request and it will resolve [BI-2489](https://breedinginsight.atlassian.net/browse/BI-2489) for Germplasm cache fetches.  This feature is configurable via the new `CACHE_PAGINATE_GERMPLASM` env var, added to the template and application.yml.  If the memory gets exhausted for a particular programs germplasm records, this var should be = `true`.
* Updated the BrAPIDAOUtil so that for all other entities, it fetches the cache 65000 records at a time to potentially avoid any other SQL errors that could come up as a result of BI-2489.  If this ends up being slow for these entities, we can potentially increase this amount, but a better solution IMO would be to get rid of the cache entirely for all entities and hit the BrAPI test server correctly with smaller pages so users only hit the test server when they need it (and hit it much less harder), with less data being transmitted.  The max number of records allowable in a page fetch for the program cache is now configurable via the env var added `CACHE_BRAPI_FETCH_PAGE_SIZE`.  Whatever the value of this is should match the `paging.page-size.max-allowed` application.property for the test server.  If it's over the test server value, all requests will result in a 400.

# Dependencies
This code is tied to this MR on the [BrAPI Prod server](https://github.com/plantbreeding/brapi-Java-ProdServer/pull/7).  Once that code is merged, this code can be merged and the feature can be tested end to end.

I've also added new configurable variables, [and created an MR for the docker stack](https://github.com/Breeding-Insight/bi-docker-stack/pull/55) with those same variables.
# Testing
With a substantial database of germplasm records (more than 65k), start the application to load the cache.  The cache should be able to load without fail thanks to the solving of BI-2489, and all germplasm data will be retrieved at once per program.  There is a limit to this amount per program of 250k records.  If clients get around that number, it will be time to move to a cacheless, request-based implementation of the germplasm fetch in the cache. (At that point, would recommend doing a cacheless impl for all entities).

There is other testing to be done with BI-2578, but that is more on the prod server side than bi-api so will leave it to you guys to look at that and test there.


[BI-2578]: https://breedinginsight.atlassian.net/browse/BI-2578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2489]: https://breedinginsight.atlassian.net/browse/BI-2489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ