### PR TITLE
[BI-2579] Refresh cache after import completes

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -296,11 +296,9 @@ public class BrAPIGermplasmDAO {
         var program = programDAO.fetchOneById(programId);
         try {
             if (!postBrAPIGermplasmList.isEmpty()) {
-                Callable<Map<String, BrAPIGermplasm>> postFunction = () -> {
                     List<BrAPIGermplasm> postResponse = brAPIDAOUtil.post(postBrAPIGermplasmList, upload, api::germplasmPost, importDAO::update);
-                    return processGermplasmForDisplay(postResponse, program.getKey());
-                };
-                return programGermplasmCache.post(programId, postFunction);
+                    processGermplasmForDisplay(postResponse, program.getKey());
+                    return postResponse;
             }
             return new ArrayList<>();
         } catch (Exception e) {

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -315,8 +315,7 @@ public class BrAPIGermplasmDAO {
         try {
             if (!postBrAPIGermplasmList.isEmpty()) {
                     List<BrAPIGermplasm> postResponse = brAPIDAOUtil.post(postBrAPIGermplasmList, upload, api::germplasmPost, importDAO::update);
-                    processGermplasmForDisplay(postResponse, program.getKey());
-                    return postResponse;
+                    return new ArrayList<>(processGermplasmForDisplay(postResponse, program.getKey()).values());
             }
             return new ArrayList<>();
         } catch (Exception e) {

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -162,6 +162,10 @@ public class BrAPIGermplasmDAO {
         }
     }
 
+    public void repopulateGermplasmCacheForProgram(UUID programId) {
+        programGermplasmCache.populate(programId);
+    }
+
     /**
      * Process germplasm into a format for display
      * @param programGermplasm

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -630,6 +630,8 @@ public class GermplasmProcessor implements Processor {
             try {
                 // Create germplasm list
                 brAPIListDAO.createBrAPILists(List.of(importList), program.getId(), upload);
+                // Now that we have finished uploading, fetch all the data posted to BrAPI to the cache so it is up-to-date.
+                brAPIGermplasmDAO.repopulateGermplasmCacheForProgram(program.getId());
             } catch (ApiException e) {
                 throw new InternalServerException(e.toString(), e);
             }

--- a/src/main/resources/brapi/properties/application.properties
+++ b/src/main/resources/brapi/properties/application.properties
@@ -25,12 +25,24 @@ spring.datasource.password=${BRAPI_DB_PASSWORD}
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 
+# This property when set to true makes it so that a DB transaction is open through the body of a request, nullifying the use of @Transactional.
+# It is generally recommended that this be set to false, and methods are properly annotated and release the transactions when complete.
+# However, many of the endpoints already rely on this kind of connection infrastructure and changing is more trouble than it's worth.
+spring.jpa.open-in-view=true
+
+spring.jpa.properties.hibernate.jdbc.batch_size=50
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.hibernate.ddl-auto=validate
+
+# Use these to help debug queries.
+# The stats will tell you how long hibernate transactions are taking, how many queries occur, how many entities are being flushed/accessed, etc.
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.generate_statistics=false
+
 spring.flyway.locations=classpath:db/migration,classpath:db/sql,classpath:org/brapi/test/BrAPITestServer/db/migration
 spring.flyway.schemas=public
 spring.flyway.baselineOnMigrate=true
-
-spring.jpa.hibernate.ddl-auto=validate
-spring.jpa.show-sql=false
 
 spring.mvc.dispatch-options-request=true
 


### PR DESCRIPTION
# Description
**Story:**[ BI-2579](https://breedinginsight.atlassian.net/browse/BI-2579)

To optimize the importing experience for germs, I've changed the code so that the cache only refreshes one time during the import process, at the end.

This idea of posting and refresing the cache from the response of a batch chunk being imported confuses me.  Why would we not just refresh at the end of the process, or, since the cache refreshes everytime you view germplasm, is it done at all?

Maybe someone here can tell me a little bit more, but, when disabling this refreshing process, I found the performance of the import drastically improves. This is another problem that would also not exist if the cache were removed entirely and replaced with paginated requests for the data that needs to be viewed, but this can work as a stop-gap as the cache still exists.

# Dependencies
This should be merged once the corresponding brapi prod server branch is merged.

# Testing
Simply run a Germplasm import on a large dataset, and note the performance difference when enabled vs. disabled.  Germs are still able to load when you view the Germplasm tab since it asks for a refresh anyways.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
