### PR TITLE
BI-2567 - Germplasm Lists Tab Slow to Load

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -189,10 +189,9 @@ public class BrAPIGermplasmService {
             List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
             Map<String, BrAPIGermplasm> germplasmByName = new HashMap<>();
 
-            // set the list ID in the germplasm additional info
-            germplasm.forEach(x -> x.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ID, listId));
-
             for (BrAPIGermplasm g : germplasm) {
+                // set the list ID in the germplasm additional info
+                g.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ID, listId);
                 // Add to map.
                 germplasmByName.put(g.getGermplasmName(), g);
             }

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -189,9 +189,10 @@ public class BrAPIGermplasmService {
             List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
             Map<String, BrAPIGermplasm> germplasmByName = new HashMap<>();
 
+            // set the list ID in the germplasm additional info
+            germplasm.forEach(x -> x.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ID, listId));
+
             for (BrAPIGermplasm g : germplasm) {
-                // set the list ID in the germplasm additional info
-                germplasm.forEach(x -> x.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ID, listId));
                 // Add to map.
                 germplasmByName.put(g.getGermplasmName(), g);
             }

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIListService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIListService.java
@@ -1,5 +1,7 @@
 package org.breedinginsight.brapi.v2.services;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.http.HttpResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -9,8 +11,7 @@ import org.brapi.v2.model.core.BrAPIListSummary;
 import org.brapi.v2.model.core.BrAPIListTypes;
 import org.brapi.v2.model.core.request.BrAPIListSearchRequest;
 import org.brapi.v2.model.core.response.BrAPIListsSingleResponse;
-import org.breedinginsight.api.model.v1.response.DataResponse;
-import org.breedinginsight.api.model.v1.response.Response;
+import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapi.v2.dao.BrAPIListDAO;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
@@ -20,9 +21,7 @@ import org.breedinginsight.utilities.Utilities;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -66,27 +65,36 @@ public class BrAPIListService {
             Optional<BrAPIExternalReference> programXrefOptional = Utilities.getExternalReference(list.getExternalReferences(),Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS));
             return programXrefOptional.isPresent() && programXrefOptional.get().getReferenceID().equals(program.getId().toString());
         }).collect(Collectors.toList());
-        for (BrAPIListSummary list: programLists) {
 
+        // Map of <listDbId, GermplasmName> pairs.
+        HashMap<String, String> itemsFromEachList = new HashMap<>();
+        for (BrAPIListSummary list: programLists) {
             // remove the program key from the list name
             list.setListName(Utilities.removeProgramKeyAndUnknownAdditionalData(list.getListName(), program.getKey()));
-
             // set the owner of the list items as the list owner
             BrAPIListsSingleResponse listDetails = listDAO.getListById(list.getListDbId(), program.getId());
-            List<String> listItemNames = listDetails.getResult().getData();
-            if (type != null) {
-                switch (type) {
-                    case GERMPLASM:
-                        String createdBy = germplasmDAO.getGermplasmByRawName(listItemNames, program.getId()).get(0)
+            // Add first item from list to hashmap.
+            itemsFromEachList.put(list.getListDbId(), listDetails.getResult().getData().get(0));
+        }
+        if (type == BrAPIListTypes.GERMPLASM) {
+            // Fetch one germplasm for each list from cache.
+            List<BrAPIGermplasm> germplasmRepresentatives = germplasmDAO.getGermplasmByRawName((new ArrayList<>(itemsFromEachList.values())), program.getId());
+            // Build hashmap of germplasm by name.
+            HashMap<String, BrAPIGermplasm> germplasmByName = new HashMap<>();
+            for (BrAPIGermplasm germplasm: germplasmRepresentatives) {
+                germplasmByName.put(germplasm.getGermplasmName(), germplasm);
+            }
+            // For each list, set list owner name from createdBy stored in germplasm additional info.
+            for (BrAPIListSummary list: programLists) {
+                String strippedName = Utilities.removeProgramKeyAnyAccession(itemsFromEachList.get(list.getListDbId()), program.getKey());
+
+                list.setListOwnerName(
+                        germplasmByName.get(strippedName)
                                 .getAdditionalInfo()
                                 .getAsJsonObject("createdBy")
                                 .get("userName")
-                                .getAsString();
-                        list.setListOwnerName(createdBy);
-                    case OBSERVATIONVARIABLES:
-                    default:
-                        break;
-                }
+                                .getAsString()
+                );
             }
         }
 


### PR DESCRIPTION
# Description
BI-2567 - Germplasm Lists Tab Slow to Load

The Germplasm List Screen and the "Details" Screen for a germplasm list both take too long to load if a germplasm list has (30,000 or more germplasm).  

To fix the the slow Germplasm List Screen, the BrAPIListService::getListSummariesByTypeAndXref() was rewritten to load every germplasm only once (as opposed to once per germplasm list).

To fix the slow "Details" Screen, the BrAPIGermplasmService::getGermplasmByList was modified to remove an unnecessary loop inside a loop.


# Dependencies

# Testing
GIVEN several germplasm list have been imported (3 or more list).
GIVEN at least one of the germplasm list is large (30,000 or more germplasm).

WHEN the user navigates to the `Germplasm` screen.
AND WHEN the user selects the `List` tab.
THEN the Germplasm List Screen should be displayed within 2-minutes.

WHEN the user selects the "Details" link for a Germplasm List that has (30,000 or more germplasm).
THEN the Germplasm Detail Screen should be displayed within 2-minutes.



# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
