### PR TITLE
BI-2573 Germplasm file import assigns pedigree incorrectly

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -285,7 +285,6 @@ public class GermplasmProcessor implements Processor {
             Germplasm germplasm = brapiImport.getGermplasm();
 
             // Assign the entry number
-            // entryno is assigned if germplasm from file does not have an entryno
             if (germplasm.getEntryNo() == null) {
                 germplasm.setEntryNo(Integer.toString(i + 1));
             } else {
@@ -705,11 +704,6 @@ public class GermplasmProcessor implements Processor {
                 }
                 else if (germplasmIndexByEntryNo.containsKey(germplasm.getFemaleParentEntryNo())) {
                     Integer femaleParentInd = germplasmIndexByEntryNo.get(femaleParentFile);
-                    // TODO:
-                    // mappedImport 0-based indices ordered by entry number, not file order
-                    // germplasmIndexByEntroNo gives 0-based index in file order
-                    // wrong parent information is grabbed and incorrect pedigree because indexing is not consistent
-
                     femaleParent = mappedBrAPIImport.get(femaleParentInd).getGermplasm().getBrAPIObject();
                     pedigreeString.append(commit ? femaleParent.getGermplasmName() : femaleParent.getDefaultDisplayName());
                     femaleParentFound = true;
@@ -731,7 +725,6 @@ public class GermplasmProcessor implements Processor {
                     }
                     if (germplasmIndexByEntryNo.containsKey(germplasm.getMaleParentEntryNo())) {
                         Integer maleParentInd = germplasmIndexByEntryNo.get(maleParentFile);
-                        // TODO: same here
                         maleParent = mappedBrAPIImport.get(maleParentInd).getGermplasm().getBrAPIObject();
                         pedigreeString.append(String.format("/%s", commit ? maleParent.getGermplasmName() : maleParent.getDefaultDisplayName()));
                     }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/GermplasmProcessor.java
@@ -115,6 +115,17 @@ public class GermplasmProcessor implements Processor {
 
     public void getExistingBrapiData(List<BrAPIImport> importRows, Program program) throws ApiException {
 
+        // BI-2573 - sort by entry no here so ordering is consistent everywhere in processor
+        importRows.sort((left, right) -> {
+            if (left.getGermplasm().getEntryNo() == null || right.getGermplasm().getEntryNo() == null) {
+                return 0;
+            } else {
+                Integer leftEntryNo = Integer.parseInt(left.getGermplasm().getEntryNo());
+                Integer rightEntryNo = Integer.parseInt(right.getGermplasm().getEntryNo());
+                return leftEntryNo.compareTo(rightEntryNo);
+            }
+        });
+
         // Get all of our objects specified in the data file by their unique attributes
         Map<String, Boolean> germplasmAccessionNumbers = new HashMap<>();
         for (int i = 0; i < importRows.size(); i++) {
@@ -265,16 +276,7 @@ public class GermplasmProcessor implements Processor {
         Map<String, Integer> entryNumberCounts = new HashMap<>();
         List<String> userProvidedEntryNumbers = new ArrayList<>();
         ValidationErrors validationErrors = new ValidationErrors();
-        // Sort importRows by entry number (if present).
-        importRows.sort((left, right) -> {
-            if (left.getGermplasm().getEntryNo() == null || right.getGermplasm().getEntryNo() == null) {
-                return 0;
-            } else {
-                Integer leftEntryNo = Integer.parseInt(left.getGermplasm().getEntryNo());
-                Integer rightEntryNo = Integer.parseInt(right.getGermplasm().getEntryNo());
-                return leftEntryNo.compareTo(rightEntryNo);
-            }
-        });
+
         for (int i = 0; i < importRows.size(); i++) {
             log.debug("processing germplasm row: " + (i+1));
             BrAPIImport brapiImport = importRows.get(i);
@@ -283,6 +285,7 @@ public class GermplasmProcessor implements Processor {
             Germplasm germplasm = brapiImport.getGermplasm();
 
             // Assign the entry number
+            // entryno is assigned if germplasm from file does not have an entryno
             if (germplasm.getEntryNo() == null) {
                 germplasm.setEntryNo(Integer.toString(i + 1));
             } else {
@@ -702,6 +705,11 @@ public class GermplasmProcessor implements Processor {
                 }
                 else if (germplasmIndexByEntryNo.containsKey(germplasm.getFemaleParentEntryNo())) {
                     Integer femaleParentInd = germplasmIndexByEntryNo.get(femaleParentFile);
+                    // TODO:
+                    // mappedImport 0-based indices ordered by entry number, not file order
+                    // germplasmIndexByEntroNo gives 0-based index in file order
+                    // wrong parent information is grabbed and incorrect pedigree because indexing is not consistent
+
                     femaleParent = mappedBrAPIImport.get(femaleParentInd).getGermplasm().getBrAPIObject();
                     pedigreeString.append(commit ? femaleParent.getGermplasmName() : femaleParent.getDefaultDisplayName());
                     femaleParentFound = true;
@@ -723,6 +731,7 @@ public class GermplasmProcessor implements Processor {
                     }
                     if (germplasmIndexByEntryNo.containsKey(germplasm.getMaleParentEntryNo())) {
                         Integer maleParentInd = germplasmIndexByEntryNo.get(maleParentFile);
+                        // TODO: same here
                         maleParent = mappedBrAPIImport.get(maleParentInd).getGermplasm().getBrAPIObject();
                         pedigreeString.append(String.format("/%s", commit ? maleParent.getGermplasmName() : maleParent.getDefaultDisplayName()));
                     }

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
@@ -809,7 +809,7 @@ public class GermplasmFileImportTest extends BrAPITest {
                 checkEntryNoPreviewFields(fileData, previewRows, i, motherName, fatherName);
             } else {
                 // commit checks
-                checkEntryNoCommitFields(fileData, previewRows, i);
+                checkEntryNoCommitFields(fileData, previewRows, i, motherName, fatherName);
             }
         }
 
@@ -869,7 +869,7 @@ public class GermplasmFileImportTest extends BrAPITest {
      * @param previewRows processed preview rows
      * @param i row index
      */
-    private void checkEntryNoCommitFields(Table fileData, JsonArray previewRows, int i) {
+    private void checkEntryNoCommitFields(Table fileData, JsonArray previewRows, int i, String motherName, String fatherName) {
         JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
         // Check commit specific items
         // Germplasm name (display name)
@@ -892,20 +892,20 @@ public class GermplasmFileImportTest extends BrAPITest {
             assertEquals(1, currentGid-lastGid, "Expected GID to be monotonically increasing");
         }
 
-        // TODO: pedigree
-        /*
-        // Pedigree (germplasm names)
-        String pedigree = germplasm.get("pedigree").getAsString();
-        String mother = !pedigree.isBlank() ? pedigree.split("/")[0] : null;
-        String father = !pedigree.isBlank() && pedigree.split("/").length > 1 ? pedigree.split("/")[1] : null;
-        String regexMatcher = "^(.*\\b) \\[([A-Z]{2,6})-(\\d+)\\]$";
-        assertTrue(mother.matches(String.format(regexMatcher, femaleParents.get(i))), "Wrong mother");
-        if (!maleParents.get(i).isBlank()) {
-            assertTrue(father.matches(String.format(regexMatcher, maleParents.get(i))), "Wrong father");
-        } else {
-            assertNull(father, "Wrong father");
+        // pedigree check just for single germplasm in file with pedigree info
+        String fileFemaleEntryNo = fileData.getString(i, "Female Parent Entry No");
+        String fileMaleEntryNo = fileData.getString(i, "Male Parent Entry No");
+
+        // only care about entry nos for this test case, not using GIDs
+        if (isNotBlank(fileFemaleEntryNo) && isNotBlank(fileMaleEntryNo)) {
+            String pedigree = germplasm.get("pedigree").getAsString();
+            String[] pedigreeParts = pedigree.split("/");
+            String mother = pedigreeParts[0];
+            String father = pedigreeParts[1];
+            String regexMatcher = "^(.*\\b) \\[([A-Z]{2,6})-(\\d+)\\]$";
+            assertTrue(mother.matches(String.format(regexMatcher, motherName)), "Wrong mother");
+            assertTrue(father.matches(String.format(regexMatcher, fatherName)), "Wrong father");
         }
-         */
 
         // External Reference germplasm
         JsonArray externalReferences = germplasm.getAsJsonArray("externalReferences");

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
@@ -735,6 +735,7 @@ public class GermplasmFileImportTest extends BrAPITest {
     }
 
     /**
+     *
      * Verify GID assignment order when germplasm entry numbers are sorted ascending in file
      * Preview shows Germplasm Name in file order, Entry No ascending (also file order in this case), no GID at this stage
      * Germplasm view shows GID asc, Test1 lowest, Test 3 highest
@@ -778,7 +779,7 @@ public class GermplasmFileImportTest extends BrAPITest {
     @ValueSource(booleans = {false, true})
     @SneakyThrows
     public void entryNoDescending(boolean commit) {
-        String pathname = "src/test/resources/files/germplasm_import/entry_no_desc_pedigree.csv";
+        String pathname = "src/test/resources/files/germplasm_import/entry_no_desc.csv";
         Table fileData = Table.read().file(pathname);
         String listName = "EntryNoDesc";
         String listDescription = "Entry numbers in descending order with pedigree";
@@ -900,19 +901,6 @@ public class GermplasmFileImportTest extends BrAPITest {
             }
         }
         assertTrue(referenceFound, "Germplasm UUID reference not found");
-
-        // TODO: add synonyms?
-        /*
-        // Synonyms
-        String[] splitGermplasmName = germplasm.get("germplasmName").getAsString().split(" ");
-        String scope = splitGermplasmName[splitGermplasmName.length - 1];
-        JsonArray synonyms = germplasm.getAsJsonArray("synonyms");
-        for (JsonElement synonym: synonyms) {
-            String synonymName = synonym.getAsJsonObject().get("synonym").getAsString();
-            assertNotNull(synonymName);
-            assertTrue(synonymName.contains(scope), "Germplasm synonym was not properly scoped");
-        }
-        */
     }
 
     private JsonObject importGermplasm(String pathname, String listName, String listDescription, Boolean commit) throws InterruptedException {

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
@@ -822,6 +822,7 @@ public class GermplasmFileImportTest extends BrAPITest {
 
     /**
      * Check fields relevant to preview for descending entry no tests
+     *
      * @param fileData
      * @param previewRows
      */
@@ -857,6 +858,17 @@ public class GermplasmFileImportTest extends BrAPITest {
         }
     }
 
+    /**
+     * Check properties of processed and committed germplasm objects match what would be expected based on file contents.
+     * Of particular importance are:
+     * - germplasm are in entry no order
+     * - gids are assigned in entry no order
+     * - correct pedigree was assigned to germplasm based on file specification
+     *
+     * @param fileData raw file data
+     * @param previewRows processed preview rows
+     * @param i row index
+     */
     private void checkEntryNoCommitFields(Table fileData, JsonArray previewRows, int i) {
         JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
         // Check commit specific items
@@ -868,12 +880,17 @@ public class GermplasmFileImportTest extends BrAPITest {
         assertTrue(additionalInfo.has(BrAPIAdditionalInfoFields.CREATED_DATE), "createdDate is missing");
         // Accession Number
         assertTrue(germplasm.has("accessionNumber"), "accessionNumber missing");
-        // TODO: check that gids are assigned in entry no order
-        /*
+
+        // check that gids are assigned in entry no order
         if (i > 0) {
-            int lastEntryNo = previewRows.get(i-1).
+            JsonObject previousGermplasm = previewRows.get(i-1).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
+            int lastEntryNo = previousGermplasm.getAsJsonObject("additionalInfo").get("importEntryNumber").getAsInt();
+            int lastGid = previousGermplasm.get("accessionNumber").getAsInt();
+            int currentEntryNo = additionalInfo.get("importEntryNumber").getAsInt();
+            int currentGid = germplasm.get("accessionNumber").getAsInt();
+            assertEquals(1, currentEntryNo-lastEntryNo, "Expected entry number to be monotonically increasing");
+            assertEquals(1, currentGid-lastGid, "Expected GID to be monotonically increasing");
         }
-         */
 
         // TODO: pedigree
         /*

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
@@ -735,14 +735,10 @@ public class GermplasmFileImportTest extends BrAPITest {
     }
 
     /**
+     * Test preview and commit data when entry numbers are in ascending order in file. This is the normal case and here
+     * to catch any possible regressions
      *
-     * Verify GID assignment order when germplasm entry numbers are sorted ascending in file
-     * Preview shows Germplasm Name in file order, Entry No ascending (also file order in this case), no GID at this stage
-     * Germplasm view shows GID asc, Test1 lowest, Test 3 highest
-     * Germplasm List shows GID asc, Entry No asc
-     *
-     * Preview table ordered by entry number ascending regardless of file order
-     *
+     * @param commit controls whether import is preview or commit
      */
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
@@ -764,16 +760,13 @@ public class GermplasmFileImportTest extends BrAPITest {
     }
 
     /**
-     * Verify GID assignment order when germplasm entry numbers are sorted descending in file
-     * Preview shows Germplasm Name in entry no order, Entry No ascending (also file order in this case), no GID at this stage
-     * Germplasm view shows GID desc, Test1 highest, Test 3 lowest GIDs in entry no order, not file order
-     * Germplasm List shows GID asc, Entry No asc
-     */
-
-    /**
      * Prior to BI-2573 this file would result in a false positive circular dependency error. The reason is that when
      * entry no order did not match germplasm file order, pedigree information was assigned to the wrong germplasm
      * record due to inconsistencies in sorting during processing.
+     *
+     * Test preview and commit data when entry numbers are in descending order in file
+     *
+     * @param commit controls whether import is preview or commit
      */
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
@@ -794,6 +787,17 @@ public class GermplasmFileImportTest extends BrAPITest {
         checkEntryNoFields(fileData, previewRows, commit, listName, listDescription, "EntryNoDescGerm 2", "EntryNoDescGerm 1");
     }
 
+    /**
+     * Shared method to perform entry number order tests for preview and commit
+     *
+     * @param fileData raw file data
+     * @param previewRows processed preview rows
+     * @param commit whether checking preview or commit fields
+     * @param listName name of list when committing data
+     * @param listDescription list description when committing data
+     * @param motherName name of mother for pedigree check (from file)
+     * @param fatherName name of father for pedigree check (from file)
+     */
     private void checkEntryNoFields(Table fileData, JsonArray previewRows, boolean commit,
                                     String listName, String listDescription,
                                     String motherName, String fatherName) {
@@ -815,16 +819,17 @@ public class GermplasmFileImportTest extends BrAPITest {
 
         if (commit) {
             // Check the germplasm list
-            // TODO: check germplasm list order
             checkGermplasmList(Germplasm.constructGermplasmListName(listName, validProgram), listDescription, germplasmNames);
         }
     }
 
     /**
-     * Check fields relevant to preview for descending entry no tests
+     * Check important field in preview data beyond basic info
+     * - entry number assignment
+     * - pedigree assignment
      *
-     * @param fileData
-     * @param previewRows
+     * @param fileData raw file data
+     * @param previewRows processed preview rows
      */
     private void checkEntryNoPreviewFields(Table fileData, JsonArray previewRows, int i, String motherName, String fatherName) {
         JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
@@ -30,18 +30,19 @@ import org.breedinginsight.services.SpeciesService;
 import org.breedinginsight.utilities.Utilities;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import tech.tablesaw.api.Row;
 import tech.tablesaw.api.Table;
 
 import javax.inject.Inject;
 import java.io.File;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static io.micronaut.http.HttpRequest.GET;
 import static io.micronaut.http.HttpRequest.POST;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.junit.jupiter.api.Assertions.*;
 
 @MicronautTest
@@ -731,6 +732,187 @@ public class GermplasmFileImportTest extends BrAPITest {
         JsonObject result = JsonParser.parseString(upload.body()).getAsJsonObject().getAsJsonObject("result");
         assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt());
         assertEquals(GermplasmProcessor.circularDependency, result.getAsJsonObject("progress").get("message").getAsString());
+    }
+
+    /**
+     * Verify GID assignment order when germplasm entry numbers are sorted ascending in file
+     * Preview shows Germplasm Name in file order, Entry No ascending (also file order in this case), no GID at this stage
+     * Germplasm view shows GID asc, Test1 lowest, Test 3 highest
+     * Germplasm List shows GID asc, Entry No asc
+     *
+     * Preview table ordered by entry number ascending regardless of file order
+     *
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    @SneakyThrows
+    public void entryNoAscending(boolean commit) {
+        String pathname = "src/test/resources/files/germplasm_import/entry_no_asc.csv";
+        Table fileData = Table.read().file(pathname);
+        String listName = "EntryNoAsc";
+        String listDescription = "Entry numbers in ascending order with pedigree";
+
+        JsonObject result = importGermplasm(pathname, listName, listDescription, commit);
+        assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt());
+
+        // preview table is sorted by entry number
+        fileData = fileData.sortAscendingOn("Entry No");
+
+        JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
+        checkEntryNoFields(fileData, previewRows, commit, listName, listDescription, "EntryNoAscGerm 2", "EntryNoAscGerm 3");
+    }
+
+    /**
+     * Verify GID assignment order when germplasm entry numbers are sorted descending in file
+     * Preview shows Germplasm Name in entry no order, Entry No ascending (also file order in this case), no GID at this stage
+     * Germplasm view shows GID desc, Test1 highest, Test 3 lowest GIDs in entry no order, not file order
+     * Germplasm List shows GID asc, Entry No asc
+     */
+
+    /**
+     * Prior to BI-2573 this file would result in a false positive circular dependency error. The reason is that when
+     * entry no order did not match germplasm file order, pedigree information was assigned to the wrong germplasm
+     * record due to inconsistencies in sorting during processing.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    @SneakyThrows
+    public void entryNoDescending(boolean commit) {
+        String pathname = "src/test/resources/files/germplasm_import/entry_no_desc_pedigree.csv";
+        Table fileData = Table.read().file(pathname);
+        String listName = "EntryNoDesc";
+        String listDescription = "Entry numbers in descending order with pedigree";
+
+        JsonObject result = importGermplasm(pathname, listName, listDescription, commit);
+        assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt());
+
+        // preview table is sorted by entry number
+        fileData = fileData.sortAscendingOn("Entry No");
+
+        JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
+        checkEntryNoFields(fileData, previewRows, commit, listName, listDescription, "EntryNoDescGerm 2", "EntryNoDescGerm 1");
+    }
+
+    private void checkEntryNoFields(Table fileData, JsonArray previewRows, boolean commit,
+                                    String listName, String listDescription,
+                                    String motherName, String fatherName) {
+        List<String> germplasmNames = new ArrayList<>();
+
+        for (int i = 0; i < previewRows.size(); i++) {
+            JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
+            germplasmNames.add(germplasm.get("germplasmName").getAsString());
+            checkBasicResponse(germplasm, fileData, i);
+
+            if (!commit) {
+                // preview checks
+                checkEntryNoPreviewFields(fileData, previewRows, i, motherName, fatherName);
+            } else {
+                // commit checks
+                checkEntryNoCommitFields(fileData, previewRows, i);
+            }
+        }
+
+        if (commit) {
+            // Check the germplasm list
+            // TODO: check germplasm list order
+            checkGermplasmList(Germplasm.constructGermplasmListName(listName, validProgram), listDescription, germplasmNames);
+        }
+    }
+
+    /**
+     * Check fields relevant to preview for descending entry no tests
+     * @param fileData
+     * @param previewRows
+     */
+    private void checkEntryNoPreviewFields(Table fileData, JsonArray previewRows, int i, String motherName, String fatherName) {
+        JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
+
+        // Check preview specific items
+        // Germplasm name (display name)
+        assertEquals(fileData.getString(i, "Germplasm Name"), germplasm.get("germplasmName").getAsString());
+        JsonObject additionalInfo = germplasm.getAsJsonObject("additionalInfo");
+
+        // check entry number assignment
+        assertEquals(fileData.getString(i, "Entry No"), additionalInfo.get("importEntryNumber").getAsString(), "Wrong entry number");
+        // check pedigree entry number assignment
+        String fileFemaleEntryNo = fileData.getString(i, "Female Parent Entry No");
+        if (isNotBlank(fileFemaleEntryNo)) {
+            assertEquals(fileFemaleEntryNo, additionalInfo.get("femaleParentEntryNo").getAsString(), "Wrong female parent entry number");
+        }
+        String fileMaleEntryNo = fileData.getString(i, "Male Parent Entry No");
+        if (isNotBlank(fileMaleEntryNo)) {
+            assertEquals(fileMaleEntryNo, additionalInfo.get("maleParentEntryNo").getAsString(), "Wrong male parent entry number");
+        }
+
+        // check preview pedigree values
+        // only care about entry nos for this test case, not using GIDs
+        if (isNotBlank(fileFemaleEntryNo) && isNotBlank(fileMaleEntryNo)) {
+            String pedigree = germplasm.get("pedigree").getAsString();
+            String[] pedigreeParts = pedigree.split("/");
+            String mother = pedigreeParts[0];
+            String father = pedigreeParts[1];
+            assertEquals(motherName, mother, "Wrong mother");
+            assertEquals(fatherName, father, "Wrong father");
+        }
+    }
+
+    private void checkEntryNoCommitFields(Table fileData, JsonArray previewRows, int i) {
+        JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
+        // Check commit specific items
+        // Germplasm name (display name)
+        String expectedGermplasmName = String.format("%s [%s-%s]", fileData.getString(i, "Germplasm Name"), validProgram.getKey(), germplasm.get("accessionNumber").getAsString());
+        assertEquals(expectedGermplasmName, germplasm.get("germplasmName").getAsString());
+        // Created Date
+        JsonObject additionalInfo = germplasm.getAsJsonObject("additionalInfo");
+        assertTrue(additionalInfo.has(BrAPIAdditionalInfoFields.CREATED_DATE), "createdDate is missing");
+        // Accession Number
+        assertTrue(germplasm.has("accessionNumber"), "accessionNumber missing");
+        // TODO: check that gids are assigned in entry no order
+        /*
+        if (i > 0) {
+            int lastEntryNo = previewRows.get(i-1).
+        }
+         */
+
+        // TODO: pedigree
+        /*
+        // Pedigree (germplasm names)
+        String pedigree = germplasm.get("pedigree").getAsString();
+        String mother = !pedigree.isBlank() ? pedigree.split("/")[0] : null;
+        String father = !pedigree.isBlank() && pedigree.split("/").length > 1 ? pedigree.split("/")[1] : null;
+        String regexMatcher = "^(.*\\b) \\[([A-Z]{2,6})-(\\d+)\\]$";
+        assertTrue(mother.matches(String.format(regexMatcher, femaleParents.get(i))), "Wrong mother");
+        if (!maleParents.get(i).isBlank()) {
+            assertTrue(father.matches(String.format(regexMatcher, maleParents.get(i))), "Wrong father");
+        } else {
+            assertNull(father, "Wrong father");
+        }
+         */
+
+        // External Reference germplasm
+        JsonArray externalReferences = germplasm.getAsJsonArray("externalReferences");
+        boolean referenceFound = false;
+        for (JsonElement reference: externalReferences) {
+            String referenceSource = reference.getAsJsonObject().get("referenceSource").getAsString();
+            if (referenceSource.equals(BRAPI_REFERENCE_SOURCE)) {
+                referenceFound = true;
+                break;
+            }
+        }
+        assertTrue(referenceFound, "Germplasm UUID reference not found");
+
+        // TODO: add synonyms?
+        /*
+        // Synonyms
+        String[] splitGermplasmName = germplasm.get("germplasmName").getAsString().split(" ");
+        String scope = splitGermplasmName[splitGermplasmName.length - 1];
+        JsonArray synonyms = germplasm.getAsJsonArray("synonyms");
+        for (JsonElement synonym: synonyms) {
+            String synonymName = synonym.getAsJsonObject().get("synonym").getAsString();
+            assertNotNull(synonymName);
+            assertTrue(synonymName.contains(scope), "Germplasm synonym was not properly scoped");
+        }
+        */
     }
 
     private JsonObject importGermplasm(String pathname, String listName, String listDescription, Boolean commit) throws InterruptedException {

--- a/src/test/resources/files/germplasm_import/entry_no_asc.csv
+++ b/src/test/resources/files/germplasm_import/entry_no_asc.csv
@@ -1,0 +1,4 @@
+GID,Germplasm Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID,Synonyms
+,EntryNoAscGerm 1,BCR,Test,,,1,2,3,1,
+,EntryNoAscGerm 2,BCR,Test,,,2,,,2,
+,EntryNoAscGerm 3,BCR,Test,,,3,,,3,

--- a/src/test/resources/files/germplasm_import/entry_no_desc.csv
+++ b/src/test/resources/files/germplasm_import/entry_no_desc.csv
@@ -1,0 +1,4 @@
+GID,Germplasm Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID,Synonyms
+,EntryNoDescGerm 1,BCR,Test,,,3,,,3,
+,EntryNoDescGerm 2,BCR,Test,,,2,,,2,
+,EntryNoDescGerm 3,BCR,Test,,,1,2,3,1,


### PR DESCRIPTION
# Description
**Story:** [BI-2573](https://breedinginsight.atlassian.net/browse/BI-2573?atlOrigin=eyJpIjoiYjdhOWM5YmQ4NWNhNDUxYmI1ZGY0YWI0YmFmNjM2NmIiLCJwIjoiaiJ9)

- Sorted germplasm records by entry number at entry point of processor so all processing was done consistently in entry number order
- Added automated tests to validate correct pedigree assignment regardless of entry number order in the import file

# Dependencies
- develop branch on other repos

# Testing
- Verify that germplasm files with entry numbers any order besides entry number ascending with pedigree import without a circular dependency error if there is no circular dependency in the pedigree connections. Also verify that the germplasm records have the correct pedigree information assigned.

Some test files are available that resulted in incorrect circular dependency errors due to out of order entry numbers prior to the fix are included below:

 
[Germ-syno.xls](https://github.com/user-attachments/files/19552561/Germ-syno.xls) [BI-2418](https://breedinginsight.atlassian.net/browse/BI-2418?atlOrigin=eyJpIjoiZmZlNjBjZWE4YzkwNGVhMGEyODZlNTJmYWJjY2U2MTMiLCJwIjoiaiJ9)

Have file available w/ 37k germplasm but github won't let me upload [BI-2543](https://breedinginsight.atlassian.net/browse/BI-2543?atlOrigin=eyJpIjoiNzI0YzQ0NWIwMWViNDdlNGJhMjJjMDhlZjEyYTAxMDAiLCJwIjoiaiJ9)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_

[BI-2573]: https://breedinginsight.atlassian.net/browse/BI-2573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2418]: https://breedinginsight.atlassian.net/browse/BI-2418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ