### PR TITLE
BI-2594 - Germplasm list table wrong when duplicate names are included

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -187,13 +187,13 @@ public class BrAPIGermplasmService {
             // get list BrAPI germplasm variables
             List<String> germplasmNames = listResponse.getResult().getData();
             List<BrAPIGermplasm> germplasm = germplasmDAO.getGermplasmByRawName(germplasmNames, programId);
-            Map<String, BrAPIGermplasm> germplasmByName = new HashMap<>();
+            Map<String, BrAPIGermplasm> germplasmByGid = new HashMap<>();
 
             for (BrAPIGermplasm g : germplasm) {
                 // set the list ID in the germplasm additional info
                 g.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_LIST_ID, listId);
                 // Add to map.
-                germplasmByName.put(g.getGermplasmName(), g);
+                germplasmByGid.put(g.getAccessionNumber(), g);
             }
 
             // Get the program key.
@@ -201,12 +201,15 @@ public class BrAPIGermplasmService {
                     .orElseThrow(ApiException::new)
                     .getKey();
 
+            // Extract gids from list names
+            List<String> gids = germplasmNames.stream().map(Utilities::extractGid).collect(Collectors.toList());
+
             // Build list from BrAPI list that preserves ordering and duplicates and assigns sequential entry numbers.
             List<BrAPIGermplasm> germplasmList = new ArrayList<>();
             int entryNumber = 0;
-            for (String germplasmName : germplasmNames) {
+            for (String gid : gids) {
                 ++entryNumber;
-                BrAPIGermplasm listEntry = cloneBrAPIGermplasm(germplasmByName.get(Utilities.removeProgramKeyAndUnknownAdditionalData(germplasmName, programKey)));
+                BrAPIGermplasm listEntry = cloneBrAPIGermplasm(germplasmByGid.get(gid));
                 // Set entry number.
                 listEntry.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER, entryNumber);
                 germplasmList.add(listEntry);

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -196,11 +196,6 @@ public class BrAPIGermplasmService {
                 germplasmByGid.put(g.getAccessionNumber(), g);
             }
 
-            // Get the program key.
-            String programKey = programService.getById(programId)
-                    .orElseThrow(ApiException::new)
-                    .getKey();
-
             // Extract gids from list names
             List<String> gids = germplasmNames.stream().map(Utilities::extractGid).collect(Collectors.toList());
 

--- a/src/main/java/org/breedinginsight/utilities/Utilities.java
+++ b/src/main/java/org/breedinginsight/utilities/Utilities.java
@@ -29,6 +29,7 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.*;
 import java.util.function.Function;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Utilities {
@@ -181,6 +182,37 @@ public class Utilities {
         String keyValueRegEx = String.format("\\s*\\[%s-.*?\\]\\s*", programKey);
         String stripped =  original.replaceAll(keyValueRegEx, "");
         return stripped;
+    }
+
+    /**
+     * Extracts the germplasm identifier (GID) from a germplasm name string that contains
+     * a key in the format "[PROGKEY-NUMBER]".
+     *
+     * <p>This method searches for a pattern matching "[anything-digits]" in the input string
+     * and returns the numeric portion if found. The prefix before the hyphen can be any sequence
+     * of characters.</p>
+     *
+     * @param germplasmNameWithKey The germplasm name string containing the identifier in the format
+     *                            "[PROGKEY-NUMBER]", e.g., "TestDup [DEMO-12]"
+     * @return The numeric portion after the hyphen as a String if the pattern is found,
+     *         or null if the pattern is not found in the input string
+     * @throws NullPointerException If the input string is null
+     *
+     * @example
+     * <pre>
+     * String gid = extractGid("TestDup [DEMO-12]"); // Returns "12"
+     * String gid = extractGid("Wheat [BRC-789]");   // Returns "789"
+     * String gid = extractGid("NoPattern");         // Returns null
+     * </pre>
+     */
+    public static String extractGid(String germplasmNameWithKey) {
+        Pattern pattern = Pattern.compile("\\[(.*?)-(\\d+)\\]");
+        Matcher matcher = pattern.matcher(germplasmNameWithKey);
+
+        if (matcher.find()) {
+            return matcher.group(2);
+        }
+        return null;
     }
 
     public static String generateApiExceptionLogMessage(ApiException e) {


### PR DESCRIPTION
# Description
**Story:** [BI-2594](https://breedinginsight.atlassian.net/browse/BI-2594?atlOrigin=eyJpIjoiMDY1OGFjZTgwYTU4NDU1YjgyZWI5ZjIyNzgxOTU3ZGEiLCJwIjoiaiJ9)

- Switched to using gids instead of germplasm names for tracking germplasm

# Dependencies
- release/1.1 bi-web

# Testing
- Import a germplasm file with duplicate names and pedigree. Verify that the germplasm list table shows the data in agreement with the file

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2594]: https://breedinginsight.atlassian.net/browse/BI-2594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ