### PR TITLE
BI-2212 - Update Postgres Version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     networks:
       - backend
   bidb:
-    image: postgres:11.4
+    image: postgres:17
     container_name: bidb
     environment:
       - POSTGRES_DB=${DB_NAME}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     networks:
       - backend
   bidb:
-    image: postgres:17
+    image: postgres:17.5
     container_name: bidb
     environment:
       - POSTGRES_DB=${DB_NAME}

--- a/src/test/java/org/breedinginsight/DatabaseTest.java
+++ b/src/test/java/org/breedinginsight/DatabaseTest.java
@@ -62,7 +62,7 @@ public class DatabaseTest implements TestPropertyProvider {
             network = Network.newNetwork();
         }
         if(dbContainer == null) {
-            dbContainer = new GenericContainer<>("postgres:11.4")
+            dbContainer = new GenericContainer<>("postgres:17")
                     .withNetwork(network)
                     .withNetworkAliases("testdb")
                     .withImagePullPolicy(PullPolicy.defaultPolicy())

--- a/src/test/java/org/breedinginsight/DatabaseTest.java
+++ b/src/test/java/org/breedinginsight/DatabaseTest.java
@@ -62,7 +62,7 @@ public class DatabaseTest implements TestPropertyProvider {
             network = Network.newNetwork();
         }
         if(dbContainer == null) {
-            dbContainer = new GenericContainer<>("postgres:17")
+            dbContainer = new GenericContainer<>("postgres:17.5")
                     .withNetwork(network)
                     .withNetworkAliases("testdb")
                     .withImagePullPolicy(PullPolicy.defaultPolicy())


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2212

Update the postgres version to 17.
This change will affect local and the changes to bi-docker-stack ([PR here](https://github.com/Breeding-Insight/bi-docker-stack/pull/56)) will affect qa-test, but not rel-test or production, which use RDS (those are a separate task).
> Note that our CI already uses the `postgres:latest` image (see .github/workflows/build.yml for example).

# Dependencies
None

# Testing

Running this without existing data will work without issues.
To upgrade data locally, you can use `pg_dump` with the old database and then restore to the new postgres instance, but unless you really need that data locally, it's probably not worth it.

The upgrade for rel-test and production will be similar to the process I described, but slightly different because we use RDS, not a local postgres docker container.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
