### PR TITLE
Update species migration to work with new uuids

### DIFF
--- a/src/main/resources/brapi/sql/R__species.sql
+++ b/src/main/resources/brapi/sql/R__species.sql
@@ -13,32 +13,39 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '4', 'Blueberry') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '5', 'Salmon') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '6', 'Grape') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '7', 'Alfalfa') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '8', 'Sweet Potato') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '9', 'Trout') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '10', 'Soybean') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '11', 'Cranberry') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '12', 'Cucumber') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '13', 'Oat') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '14', 'Citrus') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '15', 'Sugar Cane') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '16', 'Strawberry') ON CONFLICT DO NOTHING;
--- for the Honey Bee case, want to overwrite name, not preserve existing
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '17', 'Honey Bee') ON CONFLICT (id) DO UPDATE SET crop_name = EXCLUDED.crop_name;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '18', 'Pecan') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '19', 'Lettuce') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '20', 'Cotton') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '21', 'Sorghum') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '22', 'Hemp') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '23', 'Hop') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '24', 'Hydrangea') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '25', 'Red Clover') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '26', 'Potato') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '27', 'Blackberry') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '28', 'Raspberry') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '29', 'Sugar Beet') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '30', 'Strawberry') ON CONFLICT DO NOTHING;
-INSERT INTO crop (auth_user_id, id, crop_name) VALUES ('anonymousUser', '31', 'Coffee') ON CONFLICT DO NOTHING;
+-- for uuid_generate_v4()
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+DO $$
+DECLARE
+    v_auth_id constant uuid := 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+BEGIN
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Blueberry') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Salmon') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Grape') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Alfalfa') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Sweet Potato') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Trout') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Soybean') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Cranberry') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Cucumber') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Oat') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Citrus') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Sugar Cane') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Strawberry') ON CONFLICT DO NOTHING;
+    -- for the Honey Bee case, want to overwrite name, not preserve existing
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Honey Bee') ON CONFLICT (id) DO UPDATE SET crop_name = EXCLUDED.crop_name;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Pecan') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Lettuce') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Cotton') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Sorghum') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Hemp') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Hop') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Hydrangea') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Red Clover') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Potato') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Blackberry') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Raspberry') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Sugar Beet') ON CONFLICT DO NOTHING;
+    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Coffee') ON CONFLICT DO NOTHING;
+END $$;

--- a/src/main/resources/brapi/sql/R__species.sql
+++ b/src/main/resources/brapi/sql/R__species.sql
@@ -13,39 +13,53 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
--- for uuid_generate_v4()
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 DO $$
 DECLARE
-    v_auth_id constant uuid := 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+    v_auth_id CONSTANT uuid := 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
 BEGIN
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Blueberry') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Salmon') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Grape') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Alfalfa') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Sweet Potato') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Trout') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Soybean') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Cranberry') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Cucumber') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Oat') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Citrus') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Sugar Cane') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Strawberry') ON CONFLICT DO NOTHING;
-    -- for the Honey Bee case, want to overwrite name, not preserve existing
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Honey Bee') ON CONFLICT (id) DO UPDATE SET crop_name = EXCLUDED.crop_name;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Pecan') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Lettuce') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Cotton') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Sorghum') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Hemp') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Hop') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Hydrangea') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Red Clover') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Potato') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Blackberry') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Raspberry') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Sugar Beet') ON CONFLICT DO NOTHING;
-    INSERT INTO crop (id, auth_user_id, crop_name) VALUES (uuid_generate_v4(), v_auth_id, 'Coffee') ON CONFLICT DO NOTHING;
+    /* ------------------------------------------------------------------------------------------
+       • uuid_generate_v5(namespace, crop_name)  → deterministic UUID can be used for idempotency
+       • Do it this way so no schema changes are required
+       • Removed the Honey Bee special case because all systems will be starting fresh
+       ------------------------------------------------------------------------------------------ */
+    INSERT INTO crop (id, auth_user_id, crop_name)
+    SELECT
+        uuid_generate_v5('9a4deca9-4068-46a3-9efe-db0c181f491a'::uuid,
+        -- 1) lower‑case
+        -- 2) trim leading/trailing space
+        -- 3) REMOVE every space or tab
+        regexp_replace(lower(trim(crop_name)), '\s', '', 'g')),
+        v_auth_id,
+        crop_name
+    FROM (VALUES
+        ('Blueberry'), ('Salmon'), ('Grape'), ('Alfalfa'),
+        ('Sweet Potato'), ('Trout'), ('Soybean'), ('Cranberry'),
+        ('Cucumber'), ('Oat'), ('Citrus'), ('Sugar Cane'),
+        ('Strawberry'), ('Pecan'), ('Lettuce'), ('Cotton'),
+        ('Sorghum'), ('Hemp'), ('Hop'), ('Hydrangea'),
+        ('Red Clover'), ('Potato'), ('Blackberry'), ('Raspberry'),
+        ('Sugar Beet'), ('Coffee')
+    ) AS src(crop_name)
+    ON CONFLICT (id) DO
+        -- want case changes or space changes to overwrite existing
+        -- Only rewrite the row if name changed
+        UPDATE SET crop_name = EXCLUDED.crop_name
+        WHERE crop.crop_name IS DISTINCT FROM EXCLUDED.crop_name;
 END $$;


### PR DESCRIPTION
# Description
**Story:** [B-2622](https://breedinginsight.atlassian.net/browse/BI-2622?atlOrigin=eyJpIjoiN2I3ZTIyNTBlZjVmNGNiMGE3MDE4MDcxMWI3NDM4ZjQiLCJwIjoiaiJ9)

This migration change assumes you're starting with a database that has no entries in the crop table or data has been migrated using this:

```
-- cleanup duplicate Strawberry crop record on qa test
delete from crop where id = '30';

-- define utility function to update all user references
CREATE OR REPLACE FUNCTION public.replace_anonymous_user()
    RETURNS void LANGUAGE plpgsql AS $$
DECLARE
    r  record;
    tgt uuid := 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'::uuid;
    src text := 'anonymousUser';
BEGIN
    FOR r IN
        SELECT table_schema, table_name, column_name
        FROM   information_schema.columns
        WHERE  table_schema = 'public'
          AND  column_name  = 'auth_user_id'
          AND  data_type IN ('uuid','text','character varying')
        LOOP
            RAISE NOTICE 'Updating %.% -> %', r.table_schema, r.table_name, r.column_name;
            EXECUTE format('UPDATE %I.%I SET %I = $1 WHERE %I = $2',
                           r.table_schema, r.table_name, r.column_name, r.column_name)
                USING tgt, src;
        END LOOP;
END $$;

-- run function
SELECT public.replace_anonymous_user();

-- create table of crop foreign keys
CREATE TEMP TABLE crop_fk_columns AS
SELECT
    tc.table_schema,
    tc.table_name,
    kcu.column_name,
    tc.constraint_name
FROM   information_schema.table_constraints tc
           JOIN   information_schema.key_column_usage  kcu
                  ON tc.constraint_name = kcu.constraint_name
WHERE  tc.constraint_type = 'FOREIGN KEY'
  AND  tc.table_schema = 'public'
  AND  tc.constraint_schema = 'public'
  AND  tc.constraint_name IN (
    SELECT conname
    FROM   pg_constraint
    WHERE  confrelid = 'public.crop'::regclass
);

-- verify this matches migrate_crops.sql
select * from crop_fk_columns;


CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

-- migrate old crop id references to new uuids
BEGIN;

-- 2.1  Add a uuid column to public.crop
ALTER TABLE public.crop ADD COLUMN new_id uuid;

-- 2.2  Fill new_id with a generated UUID for each row
-- The namespace in the seeding script
DO $$
DECLARE
    ns  constant uuid := '9a4deca9-4068-46a3-9efe-db0c181f491a';
BEGIN
    /* -----------------------------------------------------------
       Normalise names exactly the same way the seeder does:
       1. lower‑case                → lower()
       2. trim leading/trailing     → trim()
       3. remove ALL whitespace     → regexp_replace(...,'\s','','g')
    ----------------------------------------------------------- */
    UPDATE public.crop c
    SET    new_id =
               uuid_generate_v5(
                       ns,
                       regexp_replace(lower(trim(c.crop_name)), '\s', '', 'g')
               )
    WHERE  c.new_id IS NULL;        -- just in case you run it twice
END $$;

-- 2.3  Build a mapping table for easy joins (optional to keep)
CREATE TEMP TABLE crop_id_map AS
SELECT id         AS old_id,
       new_id     AS new_id
FROM   public.crop;

-- 2.4  Drop FK constraints so we can rewrite ids in child tables
DO $drop_fks$
    DECLARE
        r record;
    BEGIN
        FOR r IN SELECT * FROM crop_fk_columns LOOP
                EXECUTE format(
                        'ALTER TABLE %I.%I DROP CONSTRAINT %I;',
                        r.table_schema, r.table_name, r.constraint_name);
            END LOOP;
    END $drop_fks$;

-- 2.5  Rewrite crop_id in every child table
DO $update_children$
    DECLARE
        r record;
    BEGIN
        FOR r IN SELECT * FROM crop_fk_columns LOOP
                RAISE NOTICE 'Updating %.% → %', r.table_schema, r.table_name, r.column_name;
                EXECUTE format(
                        'UPDATE %I.%I AS t
                           SET %I = m.new_id
                          FROM crop_id_map m
                         WHERE t.%I = m.old_id;',
                        r.table_schema, r.table_name, r.column_name, r.column_name);
                -- Change column type to uuid
                EXECUTE format(
                        'ALTER TABLE %I.%I
                           ALTER COLUMN %I TYPE uuid USING %I::uuid;',
                        r.table_schema, r.table_name, r.column_name, r.column_name);
            END LOOP;
    END $update_children$;

-- 2.6  Swap primary key in public.crop
ALTER TABLE public.crop
    DROP CONSTRAINT crop_pkey,
    ALTER COLUMN id DROP DEFAULT,
    ALTER COLUMN id TYPE uuid USING new_id,
    ADD PRIMARY KEY (id);

ALTER TABLE public.crop DROP COLUMN new_id;

-- 2.7  Re‑create FK constraints
DO $add_fks$
DECLARE
    r record;
BEGIN
    FOR r IN SELECT * FROM crop_fk_columns LOOP
            EXECUTE format(
                    'ALTER TABLE %I.%I
                       ADD CONSTRAINT %I
                       FOREIGN KEY (%I) REFERENCES public.crop(id);',
                    r.table_schema, r.table_name, r.constraint_name,
                    r.column_name);
        END LOOP;
END $add_fks$;

-- if looks good
COMMIT;

-- if problems
ROLLBACK;

select * from program;

-- verify there are no duplicates
WITH norm AS (
    SELECT id,
           crop_name,
           regexp_replace(lower(trim(crop_name)), '\s', '', 'g') AS normalised
    FROM   public.crop
)
SELECT normalised, array_agg(id) AS dupe_ids
FROM   norm
GROUP  BY normalised
HAVING count(*) > 1;

```

# Dependencies
- brapi server latest develop

# Testing
- Can create and update species list

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
