### PR TITLE
[BI-2632] Germplasm download from single list no longer working

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIGermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIGermplasmController.java
@@ -221,6 +221,25 @@ public class BrAPIGermplasmController {
             return HttpResponse.status(HttpStatus.UNPROCESSABLE_ENTITY, "Error parsing requested date format");
         }
     }
+    @Get("/programs/{programId}/germplasm/lists/{listDbId}/export{?fileExtension}")
+    @Produces(value = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.PROGRAM_SCOPED_ROLES})
+    public HttpResponse<StreamedFile> germplasmListExport(
+            @PathVariable("programId") UUID programId, @PathVariable("listDbId") String listDbId, @QueryValue(defaultValue = "XLSX") String fileExtension) {
+        String downloadErrorMessage = "An error occurred while generating the download file. Contact the development team at bidevteam@cornell.edu.";
+        try {
+            FileType extension = Enum.valueOf(FileType.class, fileExtension);
+            DownloadFile germplasmListFile = germplasmService.exportGermplasmList(programId, listDbId, extension);
+            HttpResponse<StreamedFile> germplasmListExport = HttpResponse.ok(germplasmListFile.getStreamedFile()).header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename="+germplasmListFile.getFileName()+extension.getExtension());
+            return germplasmListExport;
+        }
+        catch (Exception e) {
+            log.info(e.getMessage(), e);
+            e.printStackTrace();
+            HttpResponse response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, downloadErrorMessage).contentType(MediaType.TEXT_PLAIN).body(downloadErrorMessage);
+            return response;
+        }
+    }
 
     @Get("/programs/{programId}/germplasm/export{?fileExtension,list}")
     @Produces(value = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")

--- a/src/test/java/org/breedinginsight/brapi/v2/GermplasmControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/GermplasmControllerIntegrationTest.java
@@ -25,16 +25,22 @@ import org.breedinginsight.daos.UserDAO;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.Species;
 import org.breedinginsight.services.SpeciesService;
+import org.breedinginsight.utilities.FileUtil;
 import org.breedinginsight.utilities.response.mappers.GermplasmQueryMapper;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import tech.tablesaw.api.Table;
 
 import javax.inject.Inject;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static io.micronaut.http.HttpRequest.GET;
 import static io.micronaut.http.HttpRequest.POST;
@@ -237,7 +243,38 @@ public class GermplasmControllerIntegrationTest extends BrAPITest {
             }
         }
     }
+    @ParameterizedTest
+    @CsvSource(value = {"CSV", "XLSX", "XLS"})
+    @SneakyThrows
+    public void germplasmListExport(String extension) {
+        String programId = validProgram.getId().toString();
+        String germplasmListDbId = fetchGermplasmListDbId(programId);
 
+        // Build the endpoint to get germplasm by germplasm list.
+        String endpoint = String.format("/programs/%s/germplasm/lists/%s/export?fileExtension=%s", programId, germplasmListDbId, extension);
+
+        // Get germplasm by list.
+        Flowable<HttpResponse<byte[]>> call = client.exchange(
+                GET(endpoint).cookie(new NettyCookie("phylo-token", "test-registered-user")), byte[].class
+        );
+
+        HttpResponse<byte[]> response = call.blockingFirst();
+
+        assertEquals(HttpStatus.OK, response.getStatus());
+
+
+        ByteArrayInputStream bodyStream = new ByteArrayInputStream(Objects.requireNonNull(response.body()));
+
+        Table download = Table.create();
+        if (extension.equals("CSV")) {
+            download = FileUtil.parseTableFromCsv(bodyStream);
+        }
+        if (extension.equals("XLS") || extension.equals("XLSX")) {
+            download = FileUtil.parseTableFromExcel(bodyStream, 0);
+        }
+        int dataSize = download.rowCount();
+        assertEquals(3, dataSize, "Wrong number of germplasm were returned");
+    }
     @Test
     @SneakyThrows
     public void getAllGermplasmByListSuccess() {


### PR DESCRIPTION
[BI-2632](https://breedinginsight.atlassian.net/browse/BI-2632) Germplasm download from single list no longer working

# Description
Attempting to download a Germplasm List results in a 403 error.


_Please include a summary of the change that was made._
The endpoint  @Get("/programs/{programId}/germplasm/lists/{listDbId}/export{?fileExtension}") was removed,  but is still being called.  The endpoint was restored.



# Dependencies
bi-web: release/1.1

# Testing
_Please include any details needed for reviewers to test this code_
- Select Germplasm from the side bar menu.
- Select the Lists tab.
-  Select Download for any of the Lists (on the right hand side of the table).
-  Select any file format from the modal screen.
-  Press the Download button.

EXPECTED RESULT
    File downloads successfully.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2632]: https://breedinginsight.atlassian.net/browse/BI-2632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ