### PR TITLE
BI-2650 - Re-enable disabled tests for brapi server uuid update

### DIFF
--- a/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
@@ -748,11 +748,9 @@ public class ExperimentControllerIntegrationTest extends BrAPITest {
     *   3. hard delete without obs - success
     *   4. soft delete without obs - success
     */
-    // TODO: Re-enable after brapi server fixes
     @ParameterizedTest
     @CsvSource(value = {"true,true", "false,true", "true,false", "false,false"})
     @SneakyThrows
-    @Disabled
     public void deleteExperimentSuccess(boolean hardDelete, boolean withObservations) {
         // Set up a test trial and get the trialDbId.
         String trialDbId;

--- a/src/test/java/org/breedinginsight/api/v1/controller/SampleSubmissionControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/SampleSubmissionControllerIntegrationTest.java
@@ -223,9 +223,7 @@ public class SampleSubmissionControllerIntegrationTest extends BrAPITest {
         assertNull(retrievedSubmission.getVendorStatusLastCheck());
     }
 
-    // TODO: Re-enable after brapi server fixes
     @Test
-    @Disabled
     public void testSubmitViaBrAPI() throws IOException, InterruptedException {
         Pair<SampleSubmission, List<Map<String, Object>>> uploadedSubmission = createSubmission(program);
 
@@ -247,9 +245,7 @@ public class SampleSubmissionControllerIntegrationTest extends BrAPITest {
         assertNull(retrievedSubmission.getVendorStatusLastCheck());
     }
 
-    // TODO: Re-enable after brapi server fixes
     @Test
-    @Disabled
     public void testCheckVendorStatus() throws IOException, InterruptedException {
         Pair<SampleSubmission, List<Map<String, Object>>> uploadedSubmission = createSubmission(program);
 

--- a/src/test/java/org/breedinginsight/brapi/v2/ListControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/ListControllerIntegrationTest.java
@@ -198,10 +198,7 @@ public class ListControllerIntegrationTest extends BrAPITest {
         }
     }
 
-
-    // TODO: Re-enable after brapi server fixes
     @Test
-    //@Disabled
     @SneakyThrows
     @Order(2)
     public void deleteListSuccess() {

--- a/src/test/java/org/breedinginsight/brapi/v2/ListControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/ListControllerIntegrationTest.java
@@ -201,7 +201,7 @@ public class ListControllerIntegrationTest extends BrAPITest {
 
     // TODO: Re-enable after brapi server fixes
     @Test
-    @Disabled
+    //@Disabled
     @SneakyThrows
     @Order(2)
     public void deleteListSuccess() {
@@ -233,7 +233,7 @@ public class ListControllerIntegrationTest extends BrAPITest {
 
         // A DELETE request to the brapi/v2/lists/<listDbId> endpoint with invalid dbId.
         Flowable<HttpResponse<String>> invalidDeleteCall = client.exchange(
-                DELETE(String.format("/programs/%s/brapi/v2/lists/%s", program.getId().toString(), "NOT-VALID-DBID"))
+                DELETE(String.format("/programs/%s/brapi/v2/lists/%s", program.getId().toString(), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
                         .cookie(new NettyCookie("phylo-token", "test-registered-user")), String.class
         );
 


### PR DESCRIPTION
# Description
**Story:** [BI-2650](https://breedinginsight.atlassian.net/browse/BI-2650?atlOrigin=eyJpIjoiMjUwYTM5YWJlMzQyNDI5NWE0NjgwODM3MDQ5MmJjYmIiLCJwIjoiaiJ9)

- Re-enabled temporarily disabled tests
- Updated id to be uuid format now required by brapi server


# Dependencies
- brapi server bug/BI-2650

# Testing
_Please include any details needed for reviewers to test this code_


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2650]: https://breedinginsight.atlassian.net/browse/BI-2650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ