### PR TITLE
BI-2654 - Tests Failing with Opaque SQL Syntax Error

### DIFF
--- a/src/test/resources/sql/UserControllerIntegrationTest.sql
+++ b/src/test/resources/sql/UserControllerIntegrationTest.sql
@@ -27,19 +27,19 @@ join bi_user on bi_user.name = 'system' limit 1;
 
 -- name: InsertUserProgramAssociations
 insert into program_user_role (program_id, user_id, role_id, created_by, updated_by)
-select program.id, bi_user.id, role.id, system_user.id, system_user.id
+select program.id, bi_user.id, role.id, bi_system_user.id, bi_system_user.id
 from program
 join bi_user on bi_user.name = 'Test User' or bi_user.name = 'Other Test User'
 join role on role.domain = 'Read Only'
-join bi_user as system_user on system_user.name = 'system'
+join bi_user as bi_system_user on bi_system_user.name = 'system'
 where program.name = 'Test Program';
 
 insert into program_user_role (program_id, user_id, role_id, active, created_by, updated_by)
-select program.id, bi_user.id, role.id, false, system_user.id, system_user.id
+select program.id, bi_user.id, role.id, false, bi_system_user.id, bi_system_user.id
 from program
 join bi_user on bi_user.name = 'Test User' or bi_user.name = 'Other Test User'
 join role on role.domain = 'Read Only'
-join bi_user as system_user on system_user.name = 'system'
+join bi_user as bi_system_user on bi_system_user.name = 'system'
 where program.name = 'Test Program1';
 
 -- name: DeactivateProgram


### PR DESCRIPTION
# Description
**Story:** [BI-2654](https://breedinginsight.atlassian.net/browse/BI-2654)

Updated SQL to avoid using a [reserved keyword](https://www.postgresql.org/docs/current/sql-keywords-appendix.html) as a table alias.

I will [merge](https://github.com/Breeding-Insight/bi-api/pull/468) this into `develop` as well.

# Testing
Ensure `UserControllerIntegrationTest` and `MetadataFilterIntegrationTest` tests pass.


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2654]: https://breedinginsight.atlassian.net/browse/BI-2654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ