### PR TITLE
BI-2664 - Add missing Honey Bee entry to species migration

### DIFF
--- a/src/main/resources/brapi/sql/R__species.sql
+++ b/src/main/resources/brapi/sql/R__species.sql
@@ -52,10 +52,10 @@ BEGIN
         ('Blueberry'), ('Salmon'), ('Grape'), ('Alfalfa'),
         ('Sweet Potato'), ('Trout'), ('Soybean'), ('Cranberry'),
         ('Cucumber'), ('Oat'), ('Citrus'), ('Sugar Cane'),
-        ('Strawberry'), ('Pecan'), ('Lettuce'), ('Cotton'),
-        ('Sorghum'), ('Hemp'), ('Hop'), ('Hydrangea'),
-        ('Red Clover'), ('Potato'), ('Blackberry'), ('Raspberry'),
-        ('Sugar Beet'), ('Coffee')
+        ('Strawberry'), ('Honey Bee'), ('Pecan'), ('Lettuce'),
+        ('Cotton'), ('Sorghum'), ('Hemp'), ('Hop'),
+        ('Hydrangea'), ('Red Clover'), ('Potato'), ('Blackberry'),
+        ('Raspberry'), ('Sugar Beet'), ('Coffee')
     ) AS src(crop_name)
     ON CONFLICT (id) DO
         -- want case changes or space changes to overwrite existing

--- a/src/test/resources/sql/brapi/species.sql
+++ b/src/test/resources/sql/brapi/species.sql
@@ -23,17 +23,9 @@ DO $$
 DECLARE
 v_auth_id CONSTANT uuid := 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
 BEGIN
-    /* ------------------------------------------------------------------------------------------
-       • uuid_generate_v5(namespace, crop_name)  → deterministic UUID can be used for idempotency
-       • Do it this way so no schema changes are required
-       • Removed the Honey Bee special case because all systems will be starting fresh
-       ------------------------------------------------------------------------------------------ */
 INSERT INTO crop (id, auth_user_id, crop_name)
 SELECT
     uuid_generate_v5('9a4deca9-4068-46a3-9efe-db0c181f491a'::uuid,
-        -- 1) lower‑case
-        -- 2) trim leading/trailing space
-        -- 3) REMOVE every space or tab
                      regexp_replace(lower(trim(crop_name)), '\s', '', 'g')),
     v_auth_id,
     crop_name
@@ -47,8 +39,6 @@ FROM (VALUES
           ('Raspberry'), ('Sugar Beet'), ('Coffee')
      ) AS src(crop_name)
     ON CONFLICT (id) DO
--- want case changes or space changes to overwrite existing
--- Only rewrite the row if name changed
 UPDATE SET crop_name = EXCLUDED.crop_name
 WHERE crop.crop_name IS DISTINCT FROM EXCLUDED.crop_name;
 END $$;

--- a/src/test/resources/sql/brapi/species.sql
+++ b/src/test/resources/sql/brapi/species.sql
@@ -1,31 +1,50 @@
--- name: CopyrightNotice
-/*
- * See the NOTICE file distributed with this work for additional information
- * regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
 
--- name: InsertSpecies
+-- See the NOTICE file distributed with this work for additional information
+-- regarding copyright ownership.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 DO $$
 DECLARE
 v_auth_id CONSTANT uuid := 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
 BEGIN
+    /* ------------------------------------------------------------------------------------------
+       • uuid_generate_v5(namespace, crop_name)  → deterministic UUID can be used for idempotency
+       • Do it this way so no schema changes are required
+       • Removed the Honey Bee special case because all systems will be starting fresh
+       ------------------------------------------------------------------------------------------ */
 INSERT INTO crop (id, auth_user_id, crop_name)
 SELECT
     uuid_generate_v5('9a4deca9-4068-46a3-9efe-db0c181f491a'::uuid,
+        -- 1) lower‑case
+        -- 2) trim leading/trailing space
+        -- 3) REMOVE every space or tab
                      regexp_replace(lower(trim(crop_name)), '\s', '', 'g')),
     v_auth_id,
     crop_name
@@ -33,12 +52,14 @@ FROM (VALUES
           ('Blueberry'), ('Salmon'), ('Grape'), ('Alfalfa'),
           ('Sweet Potato'), ('Trout'), ('Soybean'), ('Cranberry'),
           ('Cucumber'), ('Oat'), ('Citrus'), ('Sugar Cane'),
-          ('Strawberry'), ('Pecan'), ('Lettuce'), ('Cotton'),
-          ('Sorghum'), ('Hemp'), ('Hop'), ('Hydrangea'),
-          ('Red Clover'), ('Potato'), ('Blackberry'), ('Raspberry'),
-          ('Sugar Beet'), ('Coffee')
+          ('Strawberry'), ('Honey Bee'), ('Pecan'), ('Lettuce'),
+          ('Cotton'), ('Sorghum'), ('Hemp'), ('Hop'),
+          ('Hydrangea'), ('Red Clover'), ('Potato'), ('Blackberry'),
+          ('Raspberry'), ('Sugar Beet'), ('Coffee')
      ) AS src(crop_name)
     ON CONFLICT (id) DO
+-- want case changes or space changes to overwrite existing
+-- Only rewrite the row if name changed
 UPDATE SET crop_name = EXCLUDED.crop_name
 WHERE crop.crop_name IS DISTINCT FROM EXCLUDED.crop_name;
 END $$;

--- a/src/test/resources/sql/brapi/species.sql
+++ b/src/test/resources/sql/brapi/species.sql
@@ -1,33 +1,22 @@
--- See the NOTICE file distributed with this work for additional information
--- regarding copyright ownership.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- name: CopyrightNotice
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
--- See the NOTICE file distributed with this work for additional information
--- regarding copyright ownership.
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
-
+-- name: InsertSpecies
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 DO $$


### PR DESCRIPTION
# Description
**Story:** [BI-2664](https://breedinginsight.atlassian.net/browse/BI-2664?atlOrigin=eyJpIjoiZTg1ZTNkZmI5MDk2NGZiNmIzYzQxZTc3MjIyY2YxOGYiLCJwIjoiaiJ9)

- Added Honey Bee to species migration
  - Ordering of items in program creation selectbox will be different because Honey was added last

# Dependencies
- None

# Testing
- Create new program with Honey Bee as species without error

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2664]: https://breedinginsight.atlassian.net/browse/BI-2664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ