### PR TITLE
BI-2639 - List referencing existing germplasm - very slow and impacting jobs timer

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -155,7 +155,19 @@ public class Germplasm implements BrAPIObject {
         return String.format("%s [%s-germplasm]", listName, program.getKey());
     }
 
-    public void updateBrAPIGermplasm(BrAPIGermplasm germplasm, Program program, UUID listId, boolean commit, boolean updatePedigree) {
+    /**
+     * Will mutate synonym and pedigree fields if changed and meet change criteria
+     *
+     * @param germplasm germplasm object
+     * @param program program
+     * @param listId list id
+     * @param commit flag indicating if commit changes should be made
+     * @param updatePedigree flag indicating if pedigree should be updated
+     * @return mutated indicator
+     */
+    public boolean updateBrAPIGermplasm(BrAPIGermplasm germplasm, Program program, UUID listId, boolean commit, boolean updatePedigree) {
+
+        boolean mutated = false;
 
         if (updatePedigree) {
             if (!StringUtils.isBlank(getFemaleParentAccessionNumber())) {
@@ -170,6 +182,7 @@ public class Germplasm implements BrAPIObject {
             if (!StringUtils.isBlank(getMaleParentEntryNo())) {
                 germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_ENTRY_NO, getMaleParentEntryNo());
             }
+            mutated = true;
         }
 
         // Append synonyms to germplasm that don't already exist
@@ -181,6 +194,7 @@ public class Germplasm implements BrAPIObject {
                 brapiSynonym.setSynonym(synonym);
                 if (!existingSynonyms.contains(brapiSynonym)) {
                     germplasm.addSynonymsItem(brapiSynonym);
+                    mutated = true;
                 }
             }
         }
@@ -193,6 +207,8 @@ public class Germplasm implements BrAPIObject {
         if (commit) {
             setUpdateCommitFields(germplasm, program.getKey());
         }
+
+        return mutated;
     }
 
 

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/germplasm/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/germplasm/GermplasmProcessor.java
@@ -383,6 +383,9 @@ public class GermplasmProcessor implements Processor {
     private boolean processExistingGermplasm(Germplasm germplasm, ValidationErrors validationErrors, List<BrAPIImport> importRows, Program program, UUID importListId, boolean commit, PendingImport mappedImportRow, int rowIndex) {
         BrAPIGermplasm existingGermplasm;
         String gid = germplasm.getAccessionNumber();
+        boolean mutated = false;
+        boolean updatePedigree = false;
+
         if (germplasmByAccessionNumber.containsKey(gid)) {
             existingGermplasm = germplasmByAccessionNumber.get(gid).getBrAPIObject();
             // Serialize and deserialize to deep copy
@@ -410,15 +413,20 @@ public class GermplasmProcessor implements Processor {
 
         if(germplasm.pedigreeExists()) {
             validatePedigree(germplasm, rowIndex + 2, validationErrors);
+            updatePedigree = true;
         }
 
-        germplasm.updateBrAPIGermplasm(existingGermplasm, program, importListId, commit, true);
+        mutated = germplasm.updateBrAPIGermplasm(existingGermplasm, program, importListId, commit, updatePedigree);
 
-        updatedGermplasmList.add(existingGermplasm);
-        mappedImportRow.setGermplasm(new PendingImportObject<>(ImportObjectState.MUTATED, existingGermplasm));
+        if (mutated) {
+            updatedGermplasmList.add(existingGermplasm);
+            mappedImportRow.setGermplasm(new PendingImportObject<>(ImportObjectState.MUTATED, existingGermplasm));
+        } else {
+            mappedImportRow.setGermplasm(new PendingImportObject<>(ImportObjectState.EXISTING, existingGermplasm));
+        }
+
+        // add to list regardless of mutated or not
         importList.addDataItem(existingGermplasm.getGermplasmName());
-
-
         return true;
     }
 
@@ -631,7 +639,8 @@ public class GermplasmProcessor implements Processor {
         }
 
         // Create list
-        if (!newGermplasmList.isEmpty() || !updatedGermplasmList.isEmpty()) {
+        // create & update flows both unconditionally add germplasm names to importList so use that for check
+        if (!importList.getData().isEmpty()) {
             try {
                 // Create germplasm list
                 brAPIListDAO.createBrAPILists(List.of(importList), program.getId(), upload);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/germplasm/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/germplasm/GermplasmProcessor.java
@@ -87,6 +87,8 @@ public class GermplasmProcessor implements Processor {
     List<List<BrAPIGermplasm>> postOrder = new ArrayList<>();
     BrAPIListNewRequest importList = new BrAPIListNewRequest();
 
+    private int numNewPedigreeConnections = 0;
+
     public static String missingGIDsMsg = "The following GIDs were not found in the database: %s";
     public static String missingParentalGIDsMsg = "The following parental GIDs were not found in the database: %s";
     public static String missingParentalEntryNoMsg = "The following parental entry numbers were not found in the database: %s";
@@ -332,7 +334,7 @@ public class GermplasmProcessor implements Processor {
         createPostOrder();
 
         // Construct our response object
-        return getStatisticsMap(importRows);
+        return getStatisticsMap();
     }
 
     private void processNewGermplasm(Germplasm germplasm, ValidationErrors validationErrors, Map<String, ProgramBreedingMethodEntity> breedingMethods,
@@ -358,6 +360,10 @@ public class GermplasmProcessor implements Processor {
         }
 
         validatePedigree(germplasm, i + 2, validationErrors);
+
+        if (germplasm.pedigreeExists()) {
+            numNewPedigreeConnections++;
+        }
 
         BrAPIGermplasm newGermplasm = germplasm.constructBrAPIGermplasm(program, breedingMethod, user, commit, BRAPI_REFERENCE_SOURCE, nextVal, importListId);
 
@@ -421,6 +427,9 @@ public class GermplasmProcessor implements Processor {
         if (mutated) {
             updatedGermplasmList.add(existingGermplasm);
             mappedImportRow.setGermplasm(new PendingImportObject<>(ImportObjectState.MUTATED, existingGermplasm));
+            if (updatePedigree) {
+                numNewPedigreeConnections++;
+            }
         } else {
             mappedImportRow.setGermplasm(new PendingImportObject<>(ImportObjectState.EXISTING, existingGermplasm));
         }
@@ -529,20 +538,17 @@ public class GermplasmProcessor implements Processor {
                 germplasm.pedigreeExists();
     }
 
-    private Map<String, ImportPreviewStatistics> getStatisticsMap(List<BrAPIImport> importRows) {
+    private Map<String, ImportPreviewStatistics> getStatisticsMap() {
 
         ImportPreviewStatistics germplasmStats = ImportPreviewStatistics.builder()
                 .newObjectCount(newGermplasmList.size())
                 .ignoredObjectCount(germplasmByAccessionNumber.size())
                 .build();
 
-        //Modified logic here to check for female parent accession number or entry no, removed check for male due to assumption that shouldn't have only male parent
-        int newObjectCount = newGermplasmList.stream().filter(newGermplasm -> newGermplasm != null).collect(Collectors.toList()).size();
+        // TODO: numNewPedigreeConnections is global modified in existing and new flows, refactor at some point
         ImportPreviewStatistics pedigreeConnectStats = ImportPreviewStatistics.builder()
-                .newObjectCount(importRows.stream().filter(germplasmImport ->
-                        germplasmImport.getGermplasm() != null &&
-                                (germplasmImport.getGermplasm().getFemaleParentAccessionNumber() != null || germplasmImport.getGermplasm().getFemaleParentEntryNo() != null)
-                ).collect(Collectors.toList()).size()).build();
+                .newObjectCount(numNewPedigreeConnections)
+                .build();
 
         return Map.of(
                 "Germplasm", germplasmStats,

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/germplasm/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/germplasm/GermplasmProcessor.java
@@ -417,7 +417,8 @@ public class GermplasmProcessor implements Processor {
             }
         }
 
-        if(germplasm.pedigreeExists()) {
+        // if no existing pedigree and file has pedigree then validate and update
+        if(germplasm.pedigreeExists() && !hasPedigree(existingGermplasm)) {
             validatePedigree(germplasm, rowIndex + 2, validationErrors);
             updatePedigree = true;
         }


### PR DESCRIPTION
# Description
**Story:** [BI-2639](https://breedinginsight.atlassian.net/browse/BI-2639?atlOrigin=eyJpIjoiZTM1ZjVjNTJjNjNhNDE0MTk1NWI1OWI1NWUzYjQ2NmEiLCJwIjoiaiJ9)

- Only make PUT calls when germplasm are actually mutated
- Update pedigree connection count so it's correct for update case

# Dependencies
- release/1.1.1 bi-web and brapi-server

# Testing
- See JIRA card for acceptance criteria test cases

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2639]: https://breedinginsight.atlassian.net/browse/BI-2639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ