### PR TITLE
Bug/bi 2656

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -370,8 +370,10 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
                 }
                 updatedObservations.add(updatedObservation);
 
-                if (!Objects.equals(observation.getValue(), updatedObservation.getValue())
-                        || !Objects.equals(observation.getObservationTimeStamp(), updatedObservation.getObservationTimeStamp())) {
+                if (
+                        observation.getObservationTimeStamp() != null
+                        && (!Objects.equals(observation.getValue(), updatedObservation.getValue())
+                        || !Objects.equals(observation.getObservationTimeStamp(), updatedObservation.getObservationTimeStamp()))) {
                     String message;
                     if (!Objects.equals(observation.getValue(), updatedObservation.getValue())) {
                         message = String.format("Updated observation, %s, from BrAPI service does not match requested update %s.", updatedObservation.getValue(), observation.getValue());

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/factory/data/OverwrittenData.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/factory/data/OverwrittenData.java
@@ -138,8 +138,12 @@ public class OverwrittenData extends VisitedObservationData {
         if (!isTimestampMatched()) {
             // Update the timestamp
             DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
-            String formattedTimeStampValue = formatter.format(observationService.parseDateTime(timestamp));
-            update.setObservationTimeStamp(OffsetDateTime.parse(formattedTimeStampValue));
+            OffsetDateTime offsetDateTime = observationService.parseDateTime(timestamp);
+            String formattedTimeStampValue = " ";
+            if(offsetDateTime!=null) {
+                formattedTimeStampValue = formatter.format(offsetDateTime);
+            }
+            update.setObservationTimeStamp(offsetDateTime);
 
             // Add original timestamp to changelog entry
             original = Optional.ofNullable(original).map(o -> o + " " + observation.getObservationTimeStamp()).orElse(String.valueOf(observation.getObservationTimeStamp()));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/middleware/process/ImportTableProcess.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/middleware/process/ImportTableProcess.java
@@ -408,7 +408,7 @@ public class ImportTableProcess extends AppendOverwriteMiddleware {
      * Updates the preview statistics for processed observation data.
      *
      * This method updates various statistical metrics related to the processed
-     * observation data and stores them in the provided context.
+     * observation data and stores them in the provided context.x
      *
      * @param processedData The VisitedObservationData object containing the processed observation data.
      * @param context The AppendOverwriteMiddlewareContext object where the updated statistics will be stored.

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationService.java
@@ -107,6 +107,7 @@ public class ObservationService {
     public OffsetDateTime parseDateTime(String dateString) {
         // Try parsing as ISO-8601
         try {
+            if(dateString==null){ return null; }
             return OffsetDateTime.parse(dateString);
         } catch (DateTimeParseException e) {
             // If ISO-8601 parsing fails, try YY-MM-DD format

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationService.java
@@ -107,7 +107,7 @@ public class ObservationService {
     public OffsetDateTime parseDateTime(String dateString) {
         // Try parsing as ISO-8601
         try {
-            if(dateString==null){ return null; }
+            if(dateString==null){ dateString = " "; }
             return OffsetDateTime.parse(dateString);
         } catch (DateTimeParseException e) {
             // If ISO-8601 parsing fails, try YY-MM-DD format

--- a/src/main/java/org/breedinginsight/utilities/FileUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/FileUtil.java
@@ -93,7 +93,9 @@ public class FileUtil {
                     Cell cell = row.getCell(k, Row.MissingCellPolicy.RETURN_BLANK_AS_NULL);
                     String header = formatter.formatCellValue(headerRow.getCell(k));
                     if (cell == null) {
-                        columns.get(header).add(null);
+                        if(!header.isBlank()) {
+                            columns.get(header).add(null);
+                        }
                     } else if (cell.getCellType() == CellType.NUMERIC) {
                         //Distinguish between date and numeric
                         DataFormatter dataFormatter = new DataFormatter();
@@ -116,6 +118,7 @@ public class FileUtil {
         }
         catch (Exception e) {
             log.error(e.toString());
+            e.printStackTrace();
             throw new ParsingException(ParsingExceptionType.ERROR_READING_FILE);
         }
 

--- a/src/main/java/org/breedinginsight/utilities/FileUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/FileUtil.java
@@ -79,21 +79,28 @@ public class FileUtil {
             columns = new HashMap<>();
             headerRow = sheet.getRow(headerRowIndex);
             // Build column map, throw if duplicate (non-blank) column header values are found.
+            int headerRowSize = 0;
             for (Cell cell: headerRow) {
+                headerRowSize++;
                 if (columns.containsKey(formatter.formatCellValue(cell)) && !formatter.formatCellValue(cell).isBlank()) {
                     // Duplicate (non-blank) column header found.
                     throw new ParsingException(ParsingExceptionType.DUPLICATE_COLUMN_NAMES);
                 }
-                columns.put(formatter.formatCellValue(cell), new ArrayList<>());
+                String header_key = formatter.formatCellValue(cell);
+                columns.put(header_key, new ArrayList<>());
             }
             for (int i = headerRowIndex + 1; i <= sheet.getLastRowNum(); i++) {
                 Row row = sheet.getRow(i);
                 Iterator<Cell> cellIterator = row.cellIterator();
-                for (int k=0; k < columns.values().size(); k++) {
+//                for (int k=0; k <= columns.values().size(); k++) {
+                for (int k=0; k <= headerRowSize; k++) {
+                    if (k==headerRowSize){
+                        String debug = "debug";
+                    }
                     Cell cell = row.getCell(k, Row.MissingCellPolicy.RETURN_BLANK_AS_NULL);
                     String header = formatter.formatCellValue(headerRow.getCell(k));
-                    if (cell == null) {
-                        if(!header.isBlank()) {
+                        if (cell == null) {
+                        if(!header.isBlank()) { //guard against blank columns
                             columns.get(header).add(null);
                         }
                     } else if (cell.getCellType() == CellType.NUMERIC) {


### PR DESCRIPTION
This is a work in progress.  It does not handle the case where the TS:<ontology> column is missing.  (I assume that in that case, the TS data should remain unchanged).  

More to the point, currently, as it is coded in this draft PR, if a cell in the TS:<ontology> column cell is blank, the system will not update the cell.  In some cases it should. If the TS:<ontology> column _header_ is present, then it the cell should be updated.  If the TS:<ontology> column _header_ is missing, then it is assumed that the entire column is missing, and no data it that row should be updated.
