### PR TITLE
BI-2656 - Append Workflow Requires Timestamps 

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/factory/data/OverwrittenData.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/factory/data/OverwrittenData.java
@@ -135,15 +135,11 @@ public class OverwrittenData extends VisitedObservationData {
             original = observation.getValue();
         }
 
-        if (!isTimestampMatched()) {
+        if (!isTimestampMatched() && timestamp != null) {
             // Update the timestamp
-            if (timestamp == null) {
-                update.setObservationTimeStamp(null);
-            } else {
-                DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
-                String formattedTimeStampValue = formatter.format(observationService.parseDateTime(timestamp));
-                update.setObservationTimeStamp(OffsetDateTime.parse(formattedTimeStampValue));
-            }
+            DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
+            String formattedTimeStampValue = formatter.format(observationService.parseDateTime(timestamp));
+            update.setObservationTimeStamp(OffsetDateTime.parse(formattedTimeStampValue));
 
             // Add original timestamp to changelog entry
             original = Optional.ofNullable(original).map(o -> o + " " + observation.getObservationTimeStamp()).orElse(String.valueOf(observation.getObservationTimeStamp()));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/factory/data/OverwrittenData.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/factory/data/OverwrittenData.java
@@ -137,9 +137,13 @@ public class OverwrittenData extends VisitedObservationData {
 
         if (!isTimestampMatched()) {
             // Update the timestamp
-            DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
-            String formattedTimeStampValue = formatter.format(observationService.parseDateTime(timestamp));
-            update.setObservationTimeStamp(OffsetDateTime.parse(formattedTimeStampValue));
+            if (timestamp == null) {
+                update.setObservationTimeStamp(null);
+            } else {
+                DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
+                String formattedTimeStampValue = formatter.format(observationService.parseDateTime(timestamp));
+                update.setObservationTimeStamp(OffsetDateTime.parse(formattedTimeStampValue));
+            }
 
             // Add original timestamp to changelog entry
             original = Optional.ofNullable(original).map(o -> o + " " + observation.getObservationTimeStamp()).orElse(String.valueOf(observation.getObservationTimeStamp()));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/middleware/process/ImportTableProcess.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/middleware/process/ImportTableProcess.java
@@ -284,7 +284,7 @@ public class ImportTableProcess extends AppendOverwriteMiddleware {
                         BrAPIObservation observation = gson.fromJson(gson.toJson(observationByObsHash.get(observationHash)), BrAPIObservation.class);
 
                         // Is there a change to the prior data?
-                        if (isChanged(cellData, observation, cell.timestamp)) {
+                        if (isChanged(cellData, observation, cell.timestamp, tsColByPheno.containsKey(phenoColumnName))) {
 
                             // Is prior data protected?
                             /**
@@ -394,14 +394,18 @@ public class ImportTableProcess extends AppendOverwriteMiddleware {
         }
     }
 
-    private boolean isChanged(String cellData, BrAPIObservation observation, String newTimestamp) {
+    private boolean isChanged(String cellData, BrAPIObservation observation, String newTimestamp, boolean timestampColumnPresent) {
         if (!cellData.isBlank() && !cellData.equals(observation.getValue())){
             return true;
         }
-        if (StringUtils.isBlank(newTimestamp)) {
-            return (observation.getObservationTimeStamp()!=null);
+        // Only check timestamp if the TS:<trait> column was present in the uploaded file.
+        if (timestampColumnPresent) {
+            if (StringUtils.isBlank(newTimestamp)) {
+                return (observation.getObservationTimeStamp()!=null);
+            }
+            return !observationService.parseDateTime(newTimestamp).equals(observation.getObservationTimeStamp());
         }
-        return !observationService.parseDateTime(newTimestamp).equals(observation.getObservationTimeStamp());
+        return false;
     }
 
     /**

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -1173,6 +1173,82 @@ public class ExperimentFileImportTest extends BrAPITest {
     }
 
     /*
+   Scenario:
+   - an experiment was created with observations and timestamps
+   - do a second upload with additional observations for the experiment, but without the timestamp column
+   - verify the second set of observations get uploaded successfully
+    */
+    @Test
+    @SneakyThrows
+    public void importNewObsAfterFirstExpWithObsAndTimestamps() {
+        log.debug("importNewObsAfterFirstExpWithObsAndTimestamps");
+        List<Trait> traits = importTestUtils.createTraits(2);
+        Program program = createProgram("Exp with TS and additional Uploads ", "EXTSAU", "EXTSAU", BRAPI_REFERENCE_SOURCE, createGermplasm(1), traits);
+        Map<String, Object> newExp = new HashMap<>();
+        newExp.put(Columns.GERMPLASM_GID, Integer.valueOf("1"));
+        newExp.put(Columns.TEST_CHECK, "T");
+        newExp.put(Columns.EXP_TITLE, "Test Exp");
+        newExp.put(Columns.EXP_UNIT, "Plot");
+        newExp.put(Columns.EXP_TYPE, "Phenotyping");
+        newExp.put(Columns.ENV, "New Env");
+        newExp.put(Columns.ENV_LOCATION, "Location A");
+        newExp.put(Columns.ENV_YEAR, Integer.valueOf("2025"));
+        newExp.put(Columns.EXP_UNIT_ID, "a-1");
+        newExp.put(Columns.REP_NUM, Integer.valueOf("1"));
+        newExp.put(Columns.BLOCK_NUM, Integer.valueOf("1"));
+        newExp.put(Columns.ROW, Integer.valueOf("1"));
+        newExp.put(Columns.COLUMN, Integer.valueOf("1"));
+        newExp.put(traits.get(0).getObservationVariableName(), "1");
+        newExp.put("TS:" + traits.get(0).getObservationVariableName(), "2019-12-19T12:14:50Z");
+
+        // In the first upload, only 1 trait should be present.
+        List<Trait> initialTraits = List.of(traits.get(0));
+        importTestUtils.uploadAndFetchWorkflow(importTestUtils.writeExperimentDataToFile(List.of(newExp), initialTraits), null, true, client, program, mappingId, newExperimentWorkflowId);
+
+        BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
+        Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
+        assertTrue(trialIdXref.isPresent());
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
+
+        BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
+        Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
+        assertTrue(ouIdXref.isPresent());
+
+        Map<String, Object> newObservation = new HashMap<>();
+        newObservation.put(Columns.GERMPLASM_GID, Integer.valueOf("1"));
+        newObservation.put(Columns.TEST_CHECK, "T");
+        newObservation.put(Columns.EXP_TITLE, "Test Exp");
+        newObservation.put(Columns.EXP_UNIT, "Plot");
+        newObservation.put(Columns.EXP_TYPE, "Phenotyping");
+        newObservation.put(Columns.ENV, "New Env");
+        newObservation.put(Columns.ENV_LOCATION, "Location A");
+        newObservation.put(Columns.ENV_YEAR, Integer.valueOf("2025"));
+        newObservation.put(Columns.EXP_UNIT_ID, "a-1");
+        newObservation.put(Columns.REP_NUM, Integer.valueOf("1"));
+        newObservation.put(Columns.BLOCK_NUM, Integer.valueOf("1"));
+        newObservation.put(Columns.ROW, Integer.valueOf("1"));
+        newObservation.put(Columns.COLUMN, Integer.valueOf("1"));
+        newObservation.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceId());
+        newObservation.put(traits.get(0).getObservationVariableName(), "1");
+        newObservation.put(traits.get(1).getObservationVariableName(), "1");
+
+        // Pass overwrite in request body to allow append workflow to work normally.
+        Map<String, String> userData = Map.of("overwrite", "true", "overwriteReason", "testing");
+        JsonObject result = importTestUtils.uploadAndFetchWorkflow(importTestUtils.writeExperimentDataToFile(List.of(newObservation), traits), userData, true, client, program, mappingId, appendOverwriteWorkflowId);
+
+        JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
+        assertEquals(1, previewRows.size());
+        JsonObject row = previewRows.get(0).getAsJsonObject();
+
+        assertEquals("EXISTING", row.getAsJsonObject("trial").get("state").getAsString());
+        assertEquals("EXISTING", row.getAsJsonObject("location").get("state").getAsString());
+        assertEquals("EXISTING", row.getAsJsonObject("study").get("state").getAsString());
+        assertEquals("EXISTING", row.getAsJsonObject("observationUnit").get("state").getAsString());
+        assertRowSaved(newObservation, program, traits);
+
+    }
+
+    /*
     Scenario:
     - Create an experiment with valid observations.
     - Upload a second file with (1) a blank observation, (2) a changed valid observation, and (3) a new observation for the experiment.

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -1185,19 +1185,19 @@ public class ExperimentFileImportTest extends BrAPITest {
         List<Trait> traits = importTestUtils.createTraits(2);
         Program program = createProgram("Exp with TS and additional Uploads ", "EXTSAU", "EXTSAU", BRAPI_REFERENCE_SOURCE, createGermplasm(1), traits);
         Map<String, Object> newExp = new HashMap<>();
-        newExp.put(Columns.GERMPLASM_GID, Integer.valueOf("1"));
+        newExp.put(Columns.GERMPLASM_GID, "1");
         newExp.put(Columns.TEST_CHECK, "T");
         newExp.put(Columns.EXP_TITLE, "Test Exp");
         newExp.put(Columns.EXP_UNIT, "Plot");
         newExp.put(Columns.EXP_TYPE, "Phenotyping");
         newExp.put(Columns.ENV, "New Env");
         newExp.put(Columns.ENV_LOCATION, "Location A");
-        newExp.put(Columns.ENV_YEAR, Integer.valueOf("2025"));
+        newExp.put(Columns.ENV_YEAR, "2025");
         newExp.put(Columns.EXP_UNIT_ID, "a-1");
-        newExp.put(Columns.REP_NUM, Integer.valueOf("1"));
-        newExp.put(Columns.BLOCK_NUM, Integer.valueOf("1"));
-        newExp.put(Columns.ROW, Integer.valueOf("1"));
-        newExp.put(Columns.COLUMN, Integer.valueOf("1"));
+        newExp.put(Columns.REP_NUM, "1");
+        newExp.put(Columns.BLOCK_NUM, "1");
+        newExp.put(Columns.ROW, "1");
+        newExp.put(Columns.COLUMN, "1");
         newExp.put(traits.get(0).getObservationVariableName(), "1");
         newExp.put("TS:" + traits.get(0).getObservationVariableName(), "2019-12-19T12:14:50Z");
 
@@ -1215,24 +1215,24 @@ public class ExperimentFileImportTest extends BrAPITest {
         assertTrue(ouIdXref.isPresent());
 
         Map<String, Object> newObservation = new HashMap<>();
-        newObservation.put(Columns.GERMPLASM_GID, Integer.valueOf("1"));
+        newObservation.put(Columns.GERMPLASM_GID, "1");
         newObservation.put(Columns.TEST_CHECK, "T");
         newObservation.put(Columns.EXP_TITLE, "Test Exp");
         newObservation.put(Columns.EXP_UNIT, "Plot");
         newObservation.put(Columns.EXP_TYPE, "Phenotyping");
         newObservation.put(Columns.ENV, "New Env");
         newObservation.put(Columns.ENV_LOCATION, "Location A");
-        newObservation.put(Columns.ENV_YEAR, Integer.valueOf("2025"));
+        newObservation.put(Columns.ENV_YEAR, "2025");
         newObservation.put(Columns.EXP_UNIT_ID, "a-1");
-        newObservation.put(Columns.REP_NUM, Integer.valueOf("1"));
-        newObservation.put(Columns.BLOCK_NUM, Integer.valueOf("1"));
-        newObservation.put(Columns.ROW, Integer.valueOf("1"));
-        newObservation.put(Columns.COLUMN, Integer.valueOf("1"));
+        newObservation.put(Columns.REP_NUM, "1");
+        newObservation.put(Columns.BLOCK_NUM, "1");
+        newObservation.put(Columns.ROW, "1");
+        newObservation.put(Columns.COLUMN, "1");
         newObservation.put(Columns.OBS_UNIT_ID, ouIdXref.get().getReferenceId());
         newObservation.put(traits.get(0).getObservationVariableName(), "1");
         newObservation.put(traits.get(1).getObservationVariableName(), "1");
 
-        // Pass overwrite in request body to allow append workflow to work normally.
+        // Send overwrite parameters in request body to allow the append workflow to work normally.
         Map<String, String> userData = Map.of("overwrite", "true", "overwriteReason", "testing");
         JsonObject result = importTestUtils.uploadAndFetchWorkflow(importTestUtils.writeExperimentDataToFile(List.of(newObservation), traits), userData, true, client, program, mappingId, appendOverwriteWorkflowId);
 


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2656

### Changes:
- Added a null check in `OverwrittenData`.
- Added a parameter to `ImportTableProcess::isChanged` to distinguish between the case when a timestamp column in present in the uploaded file but the value is null and when the timestamp column is absent from the file.
- Added an integration test to cover this edge case.


# Dependencies
bi-web branch: release/1.1.1

# Testing
### Set Up
- Upload [germplasm](https://github.com/user-attachments/files/21166157/100_germplasm_QUICK.csv), [ontology](https://github.com/user-attachments/files/21166159/bi_lettuce_ontology_v1.xlsx), and [experiment](https://github.com/user-attachments/files/21166166/SCY.RIL.exp.tiny.xlsx).

### Test Procedure
> Optionally test the following with the `release/1.1.1` branch of bi-api first to repoduce the bug.
 
- Download the KRSP22-j experiment without timestamps.
- Open the file and add a phenotypic data column, for example `INCW8SUM`. <img width="448" height="146" alt="image" src="https://github.com/user-attachments/assets/8d384397-30e5-45be-84c4-264ec2026ee6" />
- Save and upload the file using the append workflow.
    - If using `release/1.1.1` this will result in an error.
    - If using `bug/BI-2656-release` this will succeed.
        - Ensure that there is no overwrite warning (pictured below) after upload.  <img width="1118" height="320" alt="image" src="https://github.com/user-attachments/assets/23834585-b533-4f63-abff-f2195eedafb9" />



# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
