### PR TITLE
BI-2623 - BI-API processing of observation dependencies taking too long

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
@@ -366,7 +366,6 @@ public class CommitPendingImportObjectsStep {
         if (matchingObservations != null) {
             for (PendingImportObject<BrAPIObservation> obsPio : matchingObservations) {
                 BrAPIObservation obs = obsPio.getBrAPIObject();
-                // FILTER LOGIC is now implicitly handled by the map structure and the key lookup
 
                 if (StringUtils.isBlank(obs.getObservationUnitDbId())) {
                     obs.setObservationUnitDbId(obsUnit.getObservationUnitDbId());

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
@@ -320,10 +320,24 @@ public class CommitPendingImportObjectsStep {
         Map<String, PendingImportObject<BrAPIObservationUnit>> observationUnitByNameNoScope = pendingData.getObservationUnitByNameNoScope();
         Map<String, PendingImportObject<BrAPIObservation>> observationByHash = pendingData.getObservationByHash();
 
+        // Create a lookup map for observations
+        // Key: studyName_observationUnitName (composite key)
+        // Value: List of observations matching the key
+        Map<String, List<PendingImportObject<BrAPIObservation>>> observationsByStudyAndUnit = new java.util.HashMap<>();
+        for (PendingImportObject<BrAPIObservation> obsPio : observationByHash.values()) {
+            BrAPIObservation obs = obsPio.getBrAPIObject();
+            if (obs.getAdditionalInfo() != null && obs.getAdditionalInfo().get(BrAPIAdditionalInfoFields.STUDY_NAME) != null) {
+                String studyName = Utilities.removeProgramKeyAndUnknownAdditionalData(obs.getAdditionalInfo().get(BrAPIAdditionalInfoFields.STUDY_NAME).getAsString(), programKey);
+                String obsUnitName = Utilities.removeProgramKeyAndUnknownAdditionalData(obs.getObservationUnitName(), programKey);
+                String key = studyName + "_" + obsUnitName;
+                observationsByStudyAndUnit.computeIfAbsent(key, k -> new ArrayList<>()).add(obsPio);
+            }
+        }
+
         // update the observations study DbIds, Observation Unit DbIds and Germplasm DbIds
         observationUnitByNameNoScope.values().stream()
                 .map(PendingImportObject::getBrAPIObject)
-                .forEach(obsUnit -> updateObservationDbIds(pendingData, obsUnit, programKey));
+                .forEach(obsUnit -> updateObservationDbIds(observationsByStudyAndUnit, obsUnit, programKey)); // Pass the new map
 
         // Update ObservationVariable DbIds
         List<Trait> traits = getTraitList(program);
@@ -340,33 +354,27 @@ public class CommitPendingImportObjectsStep {
         }
     }
 
-    // Update each ovservation's observationUnit DbId, study DbId, and germplasm DbId
-    private void updateObservationDbIds(PendingData pendingData, BrAPIObservationUnit obsUnit, String programKey) {
-        Map<String, PendingImportObject<BrAPIObservation>> observationByHash = pendingData.getObservationByHash();
+    // Update each observation's observationUnit DbId, study DbId, and germplasm DbId
+    private void updateObservationDbIds(Map<String, List<PendingImportObject<BrAPIObservation>>> observationsByStudyAndUnit, BrAPIObservationUnit obsUnit, String programKey) { // Modified signature
 
-        // FILTER LOGIC: Match on Env and Exp Unit ID
-        observationByHash.values()
-                .stream()
-                .filter(obs -> obs.getBrAPIObject()
-                        .getAdditionalInfo() != null
-                        && obs.getBrAPIObject()
-                        .getAdditionalInfo()
-                        .get(BrAPIAdditionalInfoFields.STUDY_NAME) != null
-                        && obs.getBrAPIObject()
-                        .getAdditionalInfo()
-                        .get(BrAPIAdditionalInfoFields.STUDY_NAME)
-                        .getAsString()
-                        .equals(Utilities.removeProgramKeyAndUnknownAdditionalData(obsUnit.getStudyName(), programKey))
-                        && Utilities.removeProgramKeyAndUnknownAdditionalData(obs.getBrAPIObject().getObservationUnitName(), programKey)
-                        .equals(Utilities.removeProgramKeyAndUnknownAdditionalData(obsUnit.getObservationUnitName(), programKey))
-                )
-                .forEach(obs -> {
-                    if (StringUtils.isBlank(obs.getBrAPIObject().getObservationUnitDbId())) {
-                        obs.getBrAPIObject().setObservationUnitDbId(obsUnit.getObservationUnitDbId());
-                    }
-                    obs.getBrAPIObject().setStudyDbId(obsUnit.getStudyDbId());
-                    obs.getBrAPIObject().setGermplasmDbId(obsUnit.getGermplasmDbId());
-                });
+        String studyName = Utilities.removeProgramKeyAndUnknownAdditionalData(obsUnit.getStudyName(), programKey);
+        String obsUnitName = Utilities.removeProgramKeyAndUnknownAdditionalData(obsUnit.getObservationUnitName(), programKey);
+        String key = studyName + "_" + obsUnitName;
+
+        List<PendingImportObject<BrAPIObservation>> matchingObservations = observationsByStudyAndUnit.get(key);
+
+        if (matchingObservations != null) {
+            for (PendingImportObject<BrAPIObservation> obsPio : matchingObservations) {
+                BrAPIObservation obs = obsPio.getBrAPIObject();
+                // FILTER LOGIC is now implicitly handled by the map structure and the key lookup
+
+                if (StringUtils.isBlank(obs.getObservationUnitDbId())) {
+                    obs.setObservationUnitDbId(obsUnit.getObservationUnitDbId());
+                }
+                obs.setStudyDbId(obsUnit.getStudyDbId());
+                obs.setGermplasmDbId(obsUnit.getGermplasmDbId());
+            }
+        }
     }
 
     private List<Trait> getTraitList(Program program) {


### PR DESCRIPTION
# Description
**Story:** [BI-2623](https://breedinginsight.atlassian.net/browse/BI-2623?atlOrigin=eyJpIjoiOTc1ZTM1MmNiZGYxNDhhZjlmOGY1ODMyMmZlMGE3YTUiLCJwIjoiaiJ9)

Optimized the `updateObservationDependencyValues` method in `CommitPendingImportObjectsStep.java` to improve performance during large data imports.

The previous implementation used a nested loop (O(N*M) complexity) to update dependency DbIds on BrAPIObservation objects. This has been changed to use a lookup map, reducing the complexity to O(N+M).

This change aims to address significant slowdowns experienced when importing large experiment files, such as the Mr. Bean dataset.

For the Mr. Bean file:

    N = 12,000 (approx. number of BrAPIObservationUnit objects)
    M = 112,000 (approx. number of BrAPIObservation objects)

Original Complexity (O(N*M)): Operations ~ N * M = 12,000 * 112,000 = 1,344,000,000 (1.344 billion operations)

Optimized Complexity (O(N+M)): Operations ~ N + M = 12,000 + 112,000 = 124,000 operations

Anticipated Speedup:

The reduction in operations for this specific part of the code is from ~1.344 billion to ~124,000. This is a reduction of over 99.99%.

If this updateObservationDependencyValues step was taking 30-45 minutes (let's say 30 minutes = 1800 seconds for calculation), and this step is now virtually instantaneous due to the optimization (going from billions of operations to tens of thousands), then you could expect the time spent in this specific method to drop from 30-45 minutes to likely less than a second.

Important Considerations:

**Overall Import Time:**
This optimization targets only the updateObservationDependencyValues method. The total import time includes other steps (file reading, validation, database insertions for other objects, etc.). So, while this specific 30-45 minute bottleneck should be eliminated, the overall import won't necessarily be 30-45 minutes faster if other steps also take significant time. However, it will be faster by at least the time that was previously spent in this bottleneck, minus a negligible new processing time for this step.

**Overhead:**
There's always some fixed overhead in method calls, stream processing, map creation, etc. For the optimized version, creating the initial lookup map will take some time (proportional to M, the number of observations). However, this is a single pass, which is vastly better than M passes over N items.

**System Factors:**
Actual speedup can also be influenced by other factors like database performance for other operations, server load, I/O speeds, etc.

# Dependencies
- [brapi server PR](https://github.com/plantbreeding/brapi-Java-ProdServer/pull/11)

# Testing
- Test with Mr Bean experiment dataset and verify that it's significantly faster (https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/2611413029/Common+Bean+Full+13+environment+MET)
  - I'm seeing ~10 mins w/ post size 5000 for complete import of the full Mr Bean experiment
- Verify all brapi observation data still looks good (ids are set as expected in brapi observations)
- Saw a memory related issue when refreshing jobs during import & made card for this: https://breedinginsight.atlassian.net/browse/BI-2692

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2623]: https://breedinginsight.atlassian.net/browse/BI-2623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ