### PR TITLE
BI-2680 - BrAPI Prod PR bi-api test ci minimal starting point

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -37,6 +37,7 @@ CACHE_BRAPI_FETCH_PAGE_SIZE=65000
 
 # BrAPI Server Variables
 BRAPI_SERVER_PORT=8083
+BRAPI_DOCKER_IMAGE=breedinginsight/brapi-java-server:develop
 
 # Brapi Server Variables
 BRAPI_DEFAULT_URL=http://localhost:8083

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,17 @@ name: maven build
 
 on:
   pull_request:
-    type: [opened, edited]
+    types: [opened, edited]
+  workflow_dispatch:
+    inputs:
+      brapi_server_image:
+        description: 'BrAPI Server Docker Image'
+        required: false
+        default: 'breedinginsight/brapi-java-server:develop'
+      bi_api_branch:
+        description: 'BI API Branch'
+        required: false
+        default: 'develop'
 
 jobs:
   build:
@@ -38,7 +48,10 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout BI API
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.bi_api_branch || github.ref }}
       - name: Set up JDK 13
         uses: actions/setup-java@v1.4.3
         with:
@@ -60,3 +73,4 @@ jobs:
           OAUTH_CLIENT_ID: 123abc
           OAUTH_CLIENT_SECRET: asdfljkhalkbaldsfjasdfi238497098asdf
           BRAPI_REFERENCE_SOURCE: breedinginsight.org
+          BRAPI_DOCKER_IMAGE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.brapi_server_image || 'breedinginsight/brapi-java-server:develop' }}

--- a/src/test/java/org/breedinginsight/BrAPITest.java
+++ b/src/test/java/org/breedinginsight/BrAPITest.java
@@ -49,7 +49,12 @@ public class BrAPITest extends DatabaseTest {
     public BrAPITest() {
         super();
 
-        brapiContainer = new GenericContainer<>("breedinginsight/brapi-java-server:develop")
+        String dockerImage = System.getenv("BRAPI_DOCKER_IMAGE");
+        if (dockerImage == null || dockerImage.isEmpty()) {
+            dockerImage = "breedinginsight/brapi-java-server:develop";
+        }
+
+        brapiContainer = new GenericContainer<>(dockerImage)
                 .withNetwork(super.getNetwork())
                 .withImagePullPolicy(PullPolicy.ageBased(Duration.ofMinutes(60)))
                 .withExposedPorts(8080)


### PR DESCRIPTION
# Description
**Story:** [BI-2680](https://breedinginsight.atlassian.net/browse/BI-2680?atlOrigin=eyJpIjoiMTZlMjBhNjEwM2ExNDUyZTk1ODFkZmRkNzYwYTI2NmUiLCJwIjoiaiJ9)

- I've allowed the BrAPITest Docker image to be configured via the BRAPI_DOCKER_IMAGE environment variable.
- I've updated .env.template with BRAPI_DOCKER_IMAGE.
- I've added workflow_dispatch to the build.yml GH Action.
  - This allows you to specify brapi_server_image and bi_api_branch inputs.
  - PR builds will use the default image and checkout the PR branch.
  - Workflow_dispatch builds will use the specified inputs or defaults.

# Dependencies
- none or brapi pr image if you'd like

# Testing
- can run tests locally as normal even without adding the new env
- can reference a custom brapi server image by setting the new env
- github actions work


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2680]: https://breedinginsight.atlassian.net/browse/BI-2680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ