### PR TITLE
BI-2694 - Field Book pulling sub-entity observation units

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -501,14 +501,16 @@ public class BrAPITrialService {
         }
 
         // Set treatment factors.
-        List<BrAPIObservationTreatment> treatmentFactors = new ArrayList<>();
-        for (BrAPIObservationTreatment t : expUnit.getTreatments()) {
-            BrAPIObservationTreatment treatment = new BrAPIObservationTreatment();
-            treatment.setFactor(t.getFactor());
-            treatment.setModality(t.getModality());
-            treatmentFactors.add(treatment);
+        if (!expUnit.getTreatments().isEmpty()) {
+            List<BrAPIObservationTreatment> treatmentFactors = new ArrayList<>();
+            for (BrAPIObservationTreatment t : expUnit.getTreatments()) {
+                BrAPIObservationTreatment treatment = new BrAPIObservationTreatment();
+                treatment.setFactor(t.getFactor());
+                treatment.setModality(t.getModality());
+                treatmentFactors.add(treatment);
+            }
+            observationUnit.setTreatments(treatmentFactors);
         }
-        observationUnit.setTreatments(treatmentFactors);
 
         // Put level in additional info: keep this in case we decide to rename levels in future.
         observationUnit.putAdditionalInfoItem(BrAPIAdditionalInfoFields.OBSERVATION_LEVEL, subEntityDatasetName);


### PR DESCRIPTION
# Description
**Story:** [BI-2694](https://breedinginsight.atlassian.net/browse/BI-2694?atlOrigin=eyJpIjoiNzQ4YmIyYzZiOTY1NGNhYjllMjgzNmRjMzcxNzM3MTciLCJwIjoiaiJ9)

- No longer include empty treatments array in sub obs units additionalInfo
- treatments will not work until Field Book json parsing issue is fixed

# Dependencies
- Field Book v6.2.5

# Testing
- Create an experiment with a sub-entity dataset. Import a field from the experiment into Field Book. Verify that the field imports without error.
- Sub-entity datasets will not show up as selectable observation levels until the work Jason is doing on the BrAPI server is ready. Only existing observation levels like plot, plant, etc. will show up.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2694]: https://breedinginsight.atlassian.net/browse/BI-2694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ