### PR TITLE
BI-2656 - Append with Prior Observations Blank Edge Case

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/factory/data/OverwrittenData.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/factory/data/OverwrittenData.java
@@ -135,7 +135,7 @@ public class OverwrittenData extends VisitedObservationData {
             original = observation.getValue();
         }
 
-        if (!isTimestampMatched() && timestamp != null) {
+        if (!isTimestampMatched() && StringUtils.isNotBlank(timestamp)) {
             // Update the timestamp
             DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
             String formattedTimeStampValue = formatter.format(observationService.parseDateTime(timestamp));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/middleware/process/ImportTableProcess.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/middleware/process/ImportTableProcess.java
@@ -398,11 +398,8 @@ public class ImportTableProcess extends AppendOverwriteMiddleware {
         if (!cellData.isBlank() && !cellData.equals(observation.getValue())){
             return true;
         }
-        // Only check timestamp if the TS:<trait> column was present in the uploaded file.
-        if (timestampColumnPresent) {
-            if (StringUtils.isBlank(newTimestamp)) {
-                return (observation.getObservationTimeStamp()!=null);
-            }
+        // Only check timestamp if the TS:<trait> column was present in the uploaded file and there's a valid timestamp.
+        if (timestampColumnPresent && !StringUtils.isBlank(newTimestamp)) {
             return !observationService.parseDateTime(newTimestamp).equals(observation.getObservationTimeStamp());
         }
         return false;


### PR DESCRIPTION
# Description
**Story:** [BI-2656](https://breedinginsight.atlassian.net/browse/BI-2656)

This fixes a bug discovered in QA while testing BI-2656.

# Testing
> Optionally run through this procedure on `release/1.1.1` first to reproduce the bug.

1. Upload [germplasm](https://github.com/user-attachments/files/21740770/100_germplasm_QUICK.csv), [ontology](https://github.com/user-attachments/files/21740775/A_Ontology_main.xlsx) and [this experiment](https://github.com/user-attachments/files/21740785/TWO_ROW.xlsx) with two observation units and one observation value plus timestamp.
2. Download the experiment, and edit the file.
    - **Row 1**: Delete the observation value and timestamp (make those cells blank).
    - **Row 2**: Add a new observation value and timestamp.
    - Save file.
3. Upload the edited file using the "Append" workflow.
    - Ensure the preview shows the correct statistics and does not indicate that data is being overwritten.
    - Ensure the upload completes successfully on confirm.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_


[BI-2656]: https://breedinginsight.atlassian.net/browse/BI-2656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ