### PR TITLE
[BI-2234] - Improve exp dataset export file

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -36,10 +36,7 @@ import org.breedinginsight.model.*;
 import org.breedinginsight.services.TraitService;
 import org.breedinginsight.services.exceptions.DoesNotExistException;
 import org.breedinginsight.services.parsers.experiment.ExperimentFileColumns;
-import org.breedinginsight.utilities.DatasetUtil;
-import org.breedinginsight.utilities.IntOrderComparator;
-import org.breedinginsight.utilities.FileUtil;
-import org.breedinginsight.utilities.Utilities;
+import org.breedinginsight.utilities.*;
 import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;
@@ -154,9 +151,6 @@ public class BrAPITrialService {
                 new ArrayList<>(Arrays.asList(params.getEnvironments().split(","))) : new ArrayList<>();
         FileType fileType = params.getFileExtension();
 
-        // make columns present in all exports
-        List<Column> columns = ExperimentFileColumns.getOrderedColumns();
-
         // add columns for requested dataset obsvars and timestamps
         log.debug(logHash + ": fetching experiment for export");
         BrAPITrial experiment = getExperiment(program, experimentId);
@@ -188,8 +182,29 @@ public class BrAPITrialService {
                     Utilities.generateApiExceptionLogMessage(err), err);
         }
 
+        boolean isSubObs = isSubEntityDataset(ous);
+
+        List<Column> columns;
+
+        //make columns present in all exports
+        if (isSubObs){
+            columns = ExperimentFileColumns.getOrderedColumnsSubEntity();
+        } else {
+            columns = ExperimentFileColumns.getOrderedColumns();
+        }
+
         //add obsUnitID as dynamic column with observation level appended to header
-        String observationLvl =  ous.get(0).getAdditionalInfo().get(BrAPIAdditionalInfoFields.OBSERVATION_LEVEL).getAsString();
+        if (isSubObs) {
+            //need to add top level obs unit ids as well
+            BrAPIObservationUnitLevelRelationship topLevel = ous.get(0).getObservationUnitPosition()
+                    .getObservationLevelRelationships().stream()
+                    .filter(x -> (x.getLevelOrder() != null && x.getLevelOrder().equals(0))).findFirst().orElse(null);
+            if (topLevel != null) {
+                String topObservationLvl = StringUtils.capitalize(topLevel.getLevelName());
+                columns = dynamicUpdateObsUnitIDLabel(columns, topObservationLvl);
+            }
+        }
+        String observationLvl = ous.get(0).getAdditionalInfo().get(BrAPIAdditionalInfoFields.OBSERVATION_LEVEL).getAsString();
         columns = dynamicUpdateObsUnitIDLabel(columns, observationLvl);
 
         if (params.getDatasetId() != null) {
@@ -220,7 +235,8 @@ public class BrAPITrialService {
                 params.isIncludeTimestamps(),
                 obsVars,
                 studyDbIdByOUId,
-                programGermplasmByDbId
+                programGermplasmByDbId,
+                isSubObs
         );
 
         // make export rows for OUs without observations
@@ -230,7 +246,7 @@ public class BrAPITrialService {
                 // Map Observation Unit to the Study it belongs to.
                 studyDbIdByOUId.put(ouId, ou.getStudyDbId());
                 if (!rowByOUId.containsKey(ouId)) {
-                    rowByOUId.put(ouId, createExportRow(experiment, program, ou, studyByDbId, programGermplasmByDbId));
+                    rowByOUId.put(ouId, createExportRow(experiment, program, ou, studyByDbId, programGermplasmByDbId, isSubObs));
                 }
             }
         }
@@ -591,7 +607,8 @@ public class BrAPITrialService {
             boolean includeTimestamp,
             List<Trait> obsVars,
             Map<String, String> studyDbIdByOUId,
-            Map<String, BrAPIGermplasm> programGermplasmByDbId) throws ApiException, DoesNotExistException {
+            Map<String, BrAPIGermplasm> programGermplasmByDbId,
+            boolean isSubObs) throws ApiException, DoesNotExistException {
         Map<String, Trait> varByDbId = new HashMap<>();
         obsVars.forEach(var -> varByDbId.put(var.getObservationVariableDbId(), var));
         for (BrAPIObservation obs: dataset) {
@@ -609,7 +626,7 @@ public class BrAPITrialService {
             } else {
 
                 // otherwise make a new row
-                Map<String, Object> row = createExportRow(experiment, program, ou, studyByDbId, programGermplasmByDbId);
+                Map<String, Object> row = createExportRow(experiment, program, ou, studyByDbId, programGermplasmByDbId, isSubObs);
                 addObsVarDataToRow(row, obs, includeTimestamp, var, program);
                 rowByOUId.put(ouId, row);
             }
@@ -727,7 +744,8 @@ public class BrAPITrialService {
             Program program,
             BrAPIObservationUnit ou,
             Map<String, BrAPIStudy> studyByDbId,
-            Map<String, BrAPIGermplasm> programGermplasmByDbId) throws ApiException, DoesNotExistException {
+            Map<String, BrAPIGermplasm> programGermplasmByDbId,
+            boolean isSubEntity) throws ApiException, DoesNotExistException {
         HashMap<String, Object> row = new HashMap<>();
 
         // get OU id, germplasm, and study
@@ -750,7 +768,6 @@ public class BrAPITrialService {
         row.put(ExperimentObservation.Columns.TEST_CHECK, testCheck);
         row.put(ExperimentObservation.Columns.EXP_TITLE, Utilities.removeProgramKey(experiment.getTrialName(), program.getKey()));
         row.put(ExperimentObservation.Columns.EXP_DESCRIPTION, experiment.getTrialDescription());
-        row.put(ExperimentObservation.Columns.EXP_UNIT, ou.getAdditionalInfo().getAsJsonObject().get(BrAPIAdditionalInfoFields.OBSERVATION_LEVEL).getAsString());
         row.put(ExperimentObservation.Columns.EXP_TYPE, experiment.getAdditionalInfo().getAsJsonObject().get(BrAPIAdditionalInfoFields.EXPERIMENT_TYPE).getAsString());
         row.put(ExperimentObservation.Columns.ENV, Utilities.removeProgramKeyAndUnknownAdditionalData(study.getStudyName(), program.getKey()));
         row.put(ExperimentObservation.Columns.ENV_LOCATION, Utilities.removeProgramKey(study.getLocationName(), program.getKey()));
@@ -776,7 +793,6 @@ public class BrAPITrialService {
 
         BrAPISeason season = seasonDAO.getSeasonById(study.getSeasons().get(0), program.getId());
         row.put(ExperimentObservation.Columns.ENV_YEAR, season.getYear());
-        row.put(ExperimentObservation.Columns.EXP_UNIT_ID, Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getObservationUnitName(), program.getKey()));
 
         // get replicate number
         Optional<BrAPIObservationUnitLevelRelationship> repLevel = ou.getObservationUnitPosition()
@@ -809,6 +825,28 @@ public class BrAPITrialService {
         //Append observation level to obsUnitID
         String observationLvl = ou.getAdditionalInfo().getAsJsonObject().get(BrAPIAdditionalInfoFields.OBSERVATION_LEVEL).getAsString();
         row.put(observationLvl + " " + OBSERVATION_UNIT_ID_SUFFIX, ouId);
+
+        if (isSubEntity) {
+            BrAPIObservationUnitLevelRelationship topLevel = ou.getObservationUnitPosition()
+                    .getObservationLevelRelationships().stream()
+                    .filter(x -> (x.getLevelOrder() != null && x.getLevelOrder().equals(0))).findFirst().orElse(null);
+
+            if (topLevel != null) {
+                String topLvlName = StringUtils.capitalize(topLevel.getLevelName());
+                row.put(ExperimentObservation.Columns.EXP_UNIT, topLvlName);
+
+                String topLvlOuId = Utilities.removeProgramKeyAndUnknownAdditionalData(topLevel.getLevelCode(), program.getKey());
+                row.put(topLvlName + " " + OBSERVATION_UNIT_ID_SUFFIX, topLvlOuId);
+            }
+            row.put(ExperimentObservation.Columns.EXP_UNIT_ID, ou.getAdditionalInfo().get(BrAPIAdditionalInfoFields.EXP_UNIT_ID).getAsString());
+
+            row.put(ExperimentObservation.Columns.SUB_OBS_UNIT, ou.getAdditionalInfo().getAsJsonObject().get(BrAPIAdditionalInfoFields.OBSERVATION_LEVEL).getAsString());
+            row.put(ExperimentObservation.Columns.SUB_UNIT_ID, Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getObservationUnitName(), program.getKey()));
+
+        } else {
+            row.put(ExperimentObservation.Columns.EXP_UNIT, ou.getAdditionalInfo().getAsJsonObject().get(BrAPIAdditionalInfoFields.OBSERVATION_LEVEL).getAsString());
+            row.put(ExperimentObservation.Columns.EXP_UNIT_ID, Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getObservationUnitName(), program.getKey()));
+        }
 
         return row;
     }
@@ -888,6 +926,10 @@ public class BrAPITrialService {
                 .collect(Collectors.toList());
     }
 
+    private boolean isSubEntityDataset(List<BrAPIObservationUnit> ous){
+        return (ous.get(0).getObservationUnitPosition().getObservationLevelRelationships().size() > 2);
+    }
+
     private void sortDefaultForObservationUnit(List<BrAPIObservationUnit> ous) {
         Comparator<BrAPIObservationUnit> studyNameComparator = Comparator.comparing(BrAPIObservationUnit::getStudyName, new IntOrderComparator());
         Comparator<BrAPIObservationUnit> ouNameComparator = Comparator.comparing(BrAPIObservationUnit::getObservationUnitName, new IntOrderComparator());
@@ -899,7 +941,9 @@ public class BrAPITrialService {
         Comparator<Map<String, Object>> expUnitIdComparator =
                 Comparator.comparing(row -> (row.get(Columns.EXP_UNIT_ID).toString()), new IntOrderComparator());
 
-        exportRows.sort(envComparator.thenComparing(expUnitIdComparator));
+        Comparator<Map<String,Object>> subUnitIdComparator = Comparator.comparing(row -> (row.get(Columns.SUB_UNIT_ID).toString()), new IntOrderComparator());
+
+        exportRows.sort(envComparator.thenComparing(expUnitIdComparator).thenComparing(subUnitIdComparator));
      }
 
     public BrAPIStudy getEnvironment(Program program, UUID envId) throws ApiException {

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -135,6 +135,13 @@ public class BrAPITrialService {
         return obUnits.stream().map(BrAPIObservationUnit::getGermplasmDbId).distinct().count();
     }
 
+    private BrAPIObservationUnitLevelRelationship getTopLevel(BrAPIObservationUnit ou) {
+        BrAPIObservationUnitLevelRelationship topLevel = ou.getObservationUnitPosition()
+                .getObservationLevelRelationships().stream()
+                .filter(x -> (x.getLevelOrder() != null && x.getLevelOrder().equals(0))).findFirst().orElse(null);
+        return topLevel;
+    }
+
     public DownloadFile exportObservations(
             Program program,
             UUID experimentId,
@@ -196,9 +203,7 @@ public class BrAPITrialService {
         //add obsUnitID as dynamic column with observation level appended to header
         if (isSubObs) {
             //need to add top level obs unit ids as well
-            BrAPIObservationUnitLevelRelationship topLevel = ous.get(0).getObservationUnitPosition()
-                    .getObservationLevelRelationships().stream()
-                    .filter(x -> (x.getLevelOrder() != null && x.getLevelOrder().equals(0))).findFirst().orElse(null);
+            BrAPIObservationUnitLevelRelationship topLevel = getTopLevel(ous.get(0));
             if (topLevel != null) {
                 String topObservationLvl = StringUtils.capitalize(topLevel.getLevelName());
                 columns = dynamicUpdateObsUnitIDLabel(columns, topObservationLvl);
@@ -827,9 +832,7 @@ public class BrAPITrialService {
         row.put(observationLvl + " " + OBSERVATION_UNIT_ID_SUFFIX, ouId);
 
         if (isSubEntity) {
-            BrAPIObservationUnitLevelRelationship topLevel = ou.getObservationUnitPosition()
-                    .getObservationLevelRelationships().stream()
-                    .filter(x -> (x.getLevelOrder() != null && x.getLevelOrder().equals(0))).findFirst().orElse(null);
+            BrAPIObservationUnitLevelRelationship topLevel = getTopLevel(ou);
 
             if (topLevel != null) {
                 String topLvlName = StringUtils.capitalize(topLevel.getLevelName());

--- a/src/main/java/org/breedinginsight/services/parsers/experiment/ExperimentFileColumns.java
+++ b/src/main/java/org/breedinginsight/services/parsers/experiment/ExperimentFileColumns.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.breedinginsight.brapps.importer.services.processors.experiment.model.ExpImportProcessConstants.OBSERVATION_UNIT_ID_SUFFIX;
+import static org.breedinginsight.brapps.importer.services.processors.experiment.model.ExpImportProcessConstants.*;
 
 public enum ExperimentFileColumns {
 
@@ -34,13 +34,13 @@ public enum ExperimentFileColumns {
     EXP_TITLE(ExperimentObservation.Columns.EXP_TITLE, Column.ColumnDataType.STRING),
     EXP_DESCRIPTION(ExperimentObservation.Columns.EXP_DESCRIPTION, Column.ColumnDataType.STRING),
     EXP_UNIT(ExperimentObservation.Columns.EXP_UNIT, Column.ColumnDataType.STRING),
-    //SUB_OBS_UNIT(ExperimentObservation.Columns.SUB_OBS_UNIT, Column.ColumnDataType.STRING),
+    SUB_OBS_UNIT(ExperimentObservation.Columns.SUB_OBS_UNIT, Column.ColumnDataType.STRING),
     EXP_TYPE(ExperimentObservation.Columns.EXP_TYPE, Column.ColumnDataType.STRING),
     ENV(ExperimentObservation.Columns.ENV, Column.ColumnDataType.STRING),
     ENV_LOCATION(ExperimentObservation.Columns.ENV_LOCATION, Column.ColumnDataType.STRING),
     ENV_YEAR(ExperimentObservation.Columns.ENV_YEAR, Column.ColumnDataType.INTEGER),
     EXP_UNIT_ID(ExperimentObservation.Columns.EXP_UNIT_ID, Column.ColumnDataType.STRING),
-    //SUB_UNIT_ID(ExperimentObservation.Columns.SUB_UNIT_ID, Column.ColumnDataType.STRING),
+    SUB_UNIT_ID(ExperimentObservation.Columns.SUB_UNIT_ID, Column.ColumnDataType.STRING),
     REP_NUM(ExperimentObservation.Columns.REP_NUM, Column.ColumnDataType.INTEGER),
     BLOCK_NUM(ExperimentObservation.Columns.BLOCK_NUM, Column.ColumnDataType.INTEGER),
     ROW(ExperimentObservation.Columns.ROW, Column.ColumnDataType.STRING),
@@ -52,6 +52,7 @@ public enum ExperimentFileColumns {
     TREATMENT_FACTORS(ExperimentObservation.Columns.TREATMENT_FACTORS, Column.ColumnDataType.STRING);
 
     private final Column column;
+    private static List<ExperimentFileColumns> subEntityOnlyColumns = Arrays.asList(SUB_OBS_UNIT, SUB_UNIT_ID);
 
     ExperimentFileColumns(String value, Column.ColumnDataType dataType) {
         this.column = new Column(value, dataType);
@@ -63,6 +64,14 @@ public enum ExperimentFileColumns {
     }
 
     public static List<Column> getOrderedColumns() {
+        //Don't include subentity columns
+        return Arrays.stream(ExperimentFileColumns.values())
+                .filter(val -> !(subEntityOnlyColumns.contains(val)))
+                .map(value -> value.column)
+                .collect(Collectors.toList());
+    }
+
+    public static List<Column> getOrderedColumnsSubEntity() {
         return Arrays.stream(ExperimentFileColumns.values())
                 .map(value -> value.column)
                 .collect(Collectors.toList());


### PR DESCRIPTION
# Description
**Story:** [BI-2234 - Improve exp dataset export file](https://breedinginsight.atlassian.net/browse/BI-2234)

Changes to make sub entity dataset export file contain desired columns while not altering the top level export file

- Added backend logic to distinguish between top level and sub entity datasets when exporting and change columns present accordingly
- Updated backend to fill additional sub-entity columns with correct data
- Updated sorting of export file in sub-entity case to also sort by Sub Unit ID (sorting of sub entity dataset UI will be in BI-2755)

# Dependencies
n/a

# Testing
- Create an experiment with both a top level and sub entity dataset
- Download top level dataset: check that file is sorted env > exp unit id, data is correct, and there are no sub-entity columns
- Download sub entity dataset: check that file is sorted env > exp unit id > sub unit id, data is correct, and there are the following columns present
-- Exp Unit
-- Sub-Obs Unit
-- Exp Unit ID
-- Sub Unit ID
-- (Exp Unit Level)  ObsUnitID
-- (Sub-Obs Unit Level) ObsUnitID

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
