### PR TITLE
[BI-2755] - improve default sub-unit sort

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -935,8 +935,16 @@ public class BrAPITrialService {
 
     private void sortDefaultForObservationUnit(List<BrAPIObservationUnit> ous) {
         Comparator<BrAPIObservationUnit> studyNameComparator = Comparator.comparing(BrAPIObservationUnit::getStudyName, new IntOrderComparator());
-        Comparator<BrAPIObservationUnit> ouNameComparator = Comparator.comparing(BrAPIObservationUnit::getObservationUnitName, new IntOrderComparator());
-        ous.sort( (studyNameComparator).thenComparing(ouNameComparator));
+
+        if (isSubEntityDataset(ous)) {
+            Comparator<BrAPIObservationUnit> subUnitComparator = Comparator.comparing(BrAPIObservationUnit::getObservationUnitName, new IntOrderComparator());
+            Comparator<BrAPIObservationUnit> ouNameComparator = Comparator.comparing(row -> (row.getAdditionalInfo().get(BrAPIAdditionalInfoFields.EXP_UNIT_ID).toString()), new IntOrderComparator());
+            ous.sort((studyNameComparator).thenComparing(ouNameComparator).thenComparing(subUnitComparator));
+        }
+        else {
+            Comparator<BrAPIObservationUnit> ouNameComparator = Comparator.comparing(BrAPIObservationUnit::getObservationUnitName, new IntOrderComparator());
+            ous.sort((studyNameComparator).thenComparing(ouNameComparator));
+        }
     }
 
     private void sortDefaultForExportRows(@NotNull List<Map<String, Object>> exportRows) {


### PR DESCRIPTION
# Description
**Story:** [BI-2755 - improve default sub-unit sort](https://breedinginsight.atlassian.net/browse/BI-2755)

Updated BrAPITrialService:sortDefaultForObservationUnit to conditionally sort data depending on whether the dataset is top level or sub entity, and in the case of sub-entity sort by environment > experimental unit id > sub unit id

# Dependencies
[bi-web: BI-2755](https://github.com/Breeding-Insight/bi-web/pull/452)

# Testing
Create an experiment with multiple environments and a sub-entity dataset
On the top level dataset tab: ensure table is sorted by Env > Exp Unit ID
On the sub entity tab: ensure table is sorted by Env > Exp Unit ID > Sub Unit ID

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
