### PR TITLE
BI-2796 - Autocompletions for dataset names in the program including other experiments displayed but unable to select

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -465,9 +465,11 @@ public class BrAPITrialService {
 
                 String programDbId = program.getBrapiProgram() != null ? program.getBrapiProgram().getProgramDbId() : null;
                 HttpResponse<String> levelResponse = observationLevelDAO.createObservationLevelName(program, datasetName, DatasetLevel.SUB_OBS_UNIT, programDbId);
-                if (levelResponse.getStatus() == HttpStatus.CONFLICT) {
-                    throw new AlreadyExistsException("Dataset name already exists in this experiment");
-                } else if (levelResponse.getStatus().getCode() < 200 || levelResponse.getStatus().getCode() >= 300) {
+
+                // 409 and 200 are expected response codes, anything else error out
+                // 409 means level already exists so we just use the name in OUs
+                // 200 means level was created successfully and can use the name in OUs
+                if (levelResponse.getStatus() != HttpStatus.CONFLICT && levelResponse.getStatus() != HttpStatus.OK) {
                     throw new ApiException(levelResponse.getStatus().getCode(), "Unable to create observation level: " + levelResponse.getStatus().getReason());
                 }
 


### PR DESCRIPTION
# Description
**Story:** [BI-2796](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2796)

- Fix status code check that was resulting in incorrect duplicate dataset error

# Dependencies
-  develop on bi-web, brapi-server

# Testing
- Follow Shawn's procedure in JIRA ticket
- Don't use plant level

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2796]: https://breedinginsight.atlassian.net/browse/BI-2796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ