### PR TITLE
[BI-2744] DeltaBreed:Create exp, create obs level CI

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/ExperimentUtilities.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/ExperimentUtilities.java
@@ -71,6 +71,7 @@ public class ExperimentUtilities {
     public static final String TIMESTAMP_REGEX = "^"+TIMESTAMP_PREFIX+"\\s*";
     public static final String MIDNIGHT = "T00:00:00-00:00";
     public static final String MULTIPLE_EXP_TITLES = "File contains more than one Experiment Title";
+    public static final String MULTIPLE_EXP_UNITS = "File contains more than one Exp Unit";
     public static final String PREEXISTING_EXPERIMENT_TITLE = "Experiment Title already exists";
     public static final String MISSING_OBS_UNIT_ID_ERROR = "Experimental entities are missing ObsUnitIDs";
     public static final String UNMATCHED_COLUMN = "Ontology term(s) not found: ";

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/model/PendingData.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/model/PendingData.java
@@ -45,7 +45,7 @@ public class PendingData {
     private Map<String, PendingImportObject<ProgramLocation>> locationByName;
     private Map<String, PendingImportObject<BrAPIListDetails>> obsVarDatasetByName;
     private Map<String, PendingImportObject<BrAPIGermplasm>> existingGermplasmByGID;
-
+    private Map<String, String> expUnitByTrialName;
     private Map<String, PendingImportObject<BrAPIObservation>> pendingObservationByHash;
     private Map<String, Column<?>> timeStampColByPheno;
     private ValidationErrors validationErrors;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
@@ -16,6 +16,7 @@
  */
 package org.breedinginsight.brapps.importer.services.processors.experiment.create.workflow.steps;
 
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
@@ -42,6 +43,7 @@ import org.breedinginsight.brapps.importer.services.processors.ProcessorData;
 import org.breedinginsight.brapps.importer.services.processors.experiment.ExperimentUtilities;
 import org.breedinginsight.brapps.importer.services.processors.experiment.create.model.PendingData;
 import org.breedinginsight.brapps.importer.services.processors.experiment.create.model.ProcessContext;
+import org.breedinginsight.model.DatasetLevel;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.ProgramLocation;
 import org.breedinginsight.model.Trait;
@@ -72,6 +74,7 @@ public class CommitPendingImportObjectsStep {
     private final BrAPIObservationUnitDAO brAPIObservationUnitDAO;
     private final ProgramLocationService locationService;
     private final OntologyService ontologyService;
+    private final BrAPIObservationLevelDAO brAPIObservationLevelDAO;
 
     @Inject
     public CommitPendingImportObjectsStep(BrAPIListDAO brAPIListDAO,
@@ -80,7 +83,8 @@ public class CommitPendingImportObjectsStep {
                                           BrAPIObservationDAO brAPIObservationDAO,
                                           BrAPIObservationUnitDAO brAPIObservationUnitDAO,
                                           ProgramLocationService locationService,
-                                          OntologyService ontologyService) {
+                                          OntologyService ontologyService,
+                                          BrAPIObservationLevelDAO brAPIObservationLevelDAO) {
         this.brAPIListDAO = brAPIListDAO;
         this.brapiTrialDAO = brapiTrialDAO;
         this.brAPIStudyDAO = brAPIStudyDAO;
@@ -88,6 +92,7 @@ public class CommitPendingImportObjectsStep {
         this.brAPIObservationUnitDAO = brAPIObservationUnitDAO;
         this.locationService = locationService;
         this.ontologyService = ontologyService;
+        this.brAPIObservationLevelDAO = brAPIObservationLevelDAO;
     }
 
     // TODO: some common code between workflows here that could be broken out, removed append/update specific code
@@ -106,6 +111,7 @@ public class CommitPendingImportObjectsStep {
         Map<String, PendingImportObject<ProgramLocation>> locationByName = pendingData.getLocationByName();
         Map<String, PendingImportObject<BrAPIObservationUnit>> observationUnitByNameNoScope = pendingData.getObservationUnitByNameNoScope();
         Map<String, PendingImportObject<BrAPIObservation>> observationByHash = pendingData.getObservationByHash();
+        Map<String, String> expUnitbyTrialName = pendingData.getExpUnitByTrialName();
 
         List<BrAPITrial> newTrials = ProcessorData.getNewObjects(pendingData.getTrialByNameNoScope());
 
@@ -170,6 +176,8 @@ public class CommitPendingImportObjectsStep {
                 trialByNameNoScope.get(createdTrialName)
                         .getBrAPIObject()
                         .setTrialDbId(createdTrial.getTrialDbId());
+
+                createObservationLevel(createdTrialName, expUnitbyTrialName, program);
             }
 
             List<ProgramLocation> createdLocations = new ArrayList<>(locationService.create(actingUser, program.getId(), newLocations));
@@ -241,6 +249,22 @@ public class CommitPendingImportObjectsStep {
 
         // NOTE: removed mutated observations code
 
+    }
+
+    //Check if the experimental unit associated with the trial does not exist in the system and if so create a new observation level
+    private void createObservationLevel(String trialName, Map<String, String> expUnitByTrialName, Program program) throws ApiException, InternalServerException {
+        String expUnit = expUnitByTrialName.get(trialName).toLowerCase();
+        String programDbId = program.getBrapiProgram() != null ? program.getBrapiProgram().getProgramDbId() : null;
+        HttpResponse<String> levelResponse = brAPIObservationLevelDAO.createObservationLevelName(program, expUnit, DatasetLevel.EXP_UNIT, programDbId);
+
+        if (levelResponse.getStatus().getCode() == 409) {
+            log.info(String.format("Level %s already exists in database", expUnit));
+        } else if (levelResponse.getStatus().getCode() == 200) {
+            log.info(String.format("Level %s created in database", expUnit));
+        } else {
+            log.error("Error saving experiment import: " + levelResponse.getStatus().getReason());
+            throw new InternalServerException("Unable to create observation level: " + levelResponse.getStatus().getReason());
+        }
     }
 
     private void updateStudyDependencyValues(PendingData pendingData, Map<Integer, PendingImport> mappedBrAPIImport, String programKey) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
@@ -260,7 +260,7 @@ public class CommitPendingImportObjectsStep {
         if (levelResponse.getStatus().getCode() == 409) {
             log.info(String.format("Level with name=%s, order=%s, programDbId=%s already exists in database", expUnit, DatasetLevel.EXP_UNIT, programDbId));
         } else if (levelResponse.getStatus().getCode() == 200) {
-            log.info(String.format("Level %s created in database", expUnit));
+            log.info(String.format("Level with name=%s, order=%s, programDbId=%s created in database", expUnit, DatasetLevel.EXP_UNIT, programDbId));
         } else {
             log.error("Error saving experiment import: " + levelResponse.getStatus().getReason());
             throw new InternalServerException("Unable to create observation level: " + levelResponse.getStatus().getReason());

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
@@ -258,7 +258,7 @@ public class CommitPendingImportObjectsStep {
         HttpResponse<String> levelResponse = brAPIObservationLevelDAO.createObservationLevelName(program, expUnit, DatasetLevel.EXP_UNIT, programDbId);
 
         if (levelResponse.getStatus().getCode() == 409) {
-            log.info(String.format("Level %s already exists in database", expUnit));
+            log.info(String.format("Level with name=%s, order=%s, programDbId=%s already exists in database", expUnit, DatasetLevel.EXP_UNIT, programDbId));
         } else if (levelResponse.getStatus().getCode() == 200) {
             log.info(String.format("Level %s created in database", expUnit));
         } else {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/PopulateExistingPendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/PopulateExistingPendingImportObjectsStep.java
@@ -103,6 +103,7 @@ public class PopulateExistingPendingImportObjectsStep {
         Map<String, PendingImportObject<BrAPIListDetails>> obsVarDatasetByName = initializeObsVarDatasetByName(program, experimentImportRows);
         Map<String, PendingImportObject<BrAPIGermplasm>> existingGermplasmByGID = initializeExistingGermplasmByGID(program, experimentImportRows);
         Map<String, BrAPIObservation> existingObsByObsHash = new HashMap<>();
+        Map<String, String> expUnitByTrialName = new HashMap<>();
 
         PendingData existing = PendingData.builder()
                 .observationUnitByNameNoScope(observationUnitByNameNoScope)
@@ -113,6 +114,7 @@ public class PopulateExistingPendingImportObjectsStep {
                 .existingGermplasmByGID(existingGermplasmByGID)
                 .existingObsByObsHash(existingObsByObsHash)
                 .observationByHash(new HashMap<>())
+                .expUnitByTrialName(expUnitByTrialName)
                 .build();
 
         return ProcessContext.builder()

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/PopulateNewPendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/PopulateNewPendingImportObjectsStep.java
@@ -302,7 +302,9 @@ public class PopulateNewPendingImportObjectsStep {
         boolean commit = importContext.isCommit();
         Map<String, PendingImportObject<BrAPITrial>> trialByNameNoScope = pendingData.getTrialByNameNoScope();
         Map<String, PendingImportObject<BrAPIStudy>> studyByNameNoScope = pendingData.getStudyByNameNoScope();
+        Map<String, String> expUnitByTrialName = pendingData.getExpUnitByTrialName();
 
+        //Experiment titles and environment checks
         if (trialByNameNoScope.containsKey(importRow.getExpTitle())) {
             PendingImportObject<BrAPIStudy> envPio;
             trialPio = trialByNameNoScope.get(importRow.getExpTitle());
@@ -325,6 +327,13 @@ public class PopulateNewPendingImportObjectsStep {
             trialPio = new PendingImportObject<>(ImportObjectState.NEW, newTrial, id);
             // NOTE: moved up a level
             //trialByNameNoScope.put(importRow.getExpTitle(), trialPio);
+        }
+
+        //Experiment unit duplicate check
+        if (expUnitByTrialName.get(importRow.getExpTitle()) == null) {
+            expUnitByTrialName.put(importRow.getExpTitle(), importRow.getExpUnit());
+        } else if (!expUnitByTrialName.get(importRow.getExpTitle()).equalsIgnoreCase(importRow.getExpUnit())) {
+            throw new UnprocessableEntityException(MULTIPLE_EXP_UNITS);
         }
 
         return trialPio;


### PR DESCRIPTION
# Description
**Story:** [BI-2744 - DeltaBreed:Create exp, create obs level ](https://breedinginsight.atlassian.net/browse/BI-2744)

Added logic for experimental import to create observation levels for new exp units.

Added validation to check for more than one exp unit in file and return error if so (previous behavior just took the first row exp unit and silently ignored all other rows).

Note: Testing BI-2791 atop experiments made with these changes revealed a niche case where if an import file was made that forcibly included Exp Units of different casings (ie BaconPancakes and BaconPANCAKES), downloading for a particular environment(s) rather than "All Environments" resulted in the download failing due to a null pointer exception because in BrAPITrialService.java:exportObservations, the hash "entry" would get an additional value with a null key for the alternate casing version of the Exp Unit. Since this logic is dependent upon the Exp Unit value stored in additionalInfo, it was determined that the fix should be covered in BI-2778, which will deprecate use of additionalInfo for level, and that case tested there.

# Dependencies
bi-web: [feature/BI-2744](https://github.com/Breeding-Insight/bi-web/pull/458)

# Testing
- Create experiment file with multiple exp unit values
-- Attempt to upload file
-- Error message should appear and file upload should be prevented

- Create experiment file with new exp unit value (not Plot)
-- Upload file
-- Ensure Experiment Preview displays the exp unit value as capitalized regardless of what case the value was in file
-- Confirm Import and ensure file imports successfully
-- Ensure Experiment Details displays the exp unit value as capitalized regardless of what case the value was in file
-- Check that the GET /observationlevels call for that program returns the new exp unit value

- Create experiment file with same exp unit value as the first upload
-- Upload file
-- Confirm Import and ensure file imports successfully

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
