### PR TITLE
[BI-2791] Exp File Name Improvement

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -292,8 +292,7 @@ public class BrAPITrialService {
                 List<Map<String, Object>> rows = entry.getValue();
                 sortDefaultForExportRows(rows);
                 StreamedFile streamedFile = FileUtil.writeToStreamedFile(columns, rows, fileType, SHEET_NAME);
-                // TODO: [BI-2183] remove hardcoded datasetName, use observation level.
-                String name = makeFileName(experiment, program, studyByDbId.get(entry.getKey()).getStudyName(), "Observation Dataset") + fileType.getExtension();
+                String name = makeFileName(experiment, program, studyByDbId.get(entry.getKey()).getStudyName(), StringUtils.capitalize(observationLvl.toLowerCase())) + fileType.getExtension();
                 // Add to file list.
                 files.add(new DownloadFile(name, streamedFile));
             }
@@ -313,9 +312,8 @@ public class BrAPITrialService {
             // write export data to requested file format
             StreamedFile streamedFile = FileUtil.writeToStreamedFile(columns, exportRows, fileType, SHEET_NAME);
             // Set filename.
-            String envFilenameFragment = params.getEnvironments() == null ? "All Environments" : params.getEnvironments();
-            // TODO: [BI-2183] remove hardcoded datasetName, use observation level.
-            String fileName = makeFileName(experiment, program, envFilenameFragment, "Observation Dataset") + fileType.getExtension();
+            String envFilenameFragment = params.getEnvironments() == null ? "All Env" : params.getEnvironments();
+            String fileName = makeFileName(experiment, program, envFilenameFragment, StringUtils.capitalize(observationLvl.toLowerCase())) + fileType.getExtension();
             downloadFile = new DownloadFile(fileName, streamedFile);
         }
 

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -304,7 +304,7 @@ public class BrAPITrialService {
                 log.debug(logHash + ": zipping files for export");
                 // Zip, as there are multiple files.
                 StreamedFile zipFile = zipFiles(files);
-                downloadFile = new DownloadFile(makeZipFileName(experiment, program), zipFile);
+                downloadFile = new DownloadFile(makeZipFileName(experiment, program, StringUtils.capitalize(observationLvl.toLowerCase())), zipFile);
             }
         } else {
             List<Map<String, Object>> exportRows = new ArrayList<>(rowByOUId.values());
@@ -964,12 +964,13 @@ public class BrAPITrialService {
         return Utilities.makePortableFilename(unsafeName);
     }
 
-    private String makeZipFileName(BrAPITrial experiment, Program program) {
+    private String makeZipFileName(BrAPITrial experiment, Program program, String datasetName) {
         // <exp-title_<export-timestamp>.zip
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_hh-mm-ssZ");
         String timestamp = formatter.format(OffsetDateTime.now());
-        String unsafeName = String.format("%s_%s.zip",
+        String unsafeName = String.format("%s_%s_%s.zip",
                 Utilities.removeProgramKey(experiment.getTrialName(), program.getKey()),
+                datasetName,
                 timestamp);
         // Make file name safe for all platforms.
         return Utilities.makePortableFilename(unsafeName);


### PR DESCRIPTION
# Description
**Story:** [BI-2791 - Exp File Name Improvement](https://breedinginsight.atlassian.net/browse/BI-2791)

Improvements to file name of downloaded experiments:
- Abbreviating “All_Environments” to “All_Env
- Naming the file with the associated level name instead of “Observation_Dataset”

# Dependencies
bi-web: develop

# Testing
Download:
Top level dataset, all environments
Top level dataset, specific environment
Sub entity dataset, all environments
Sub entity dataset, specific environment

File names for individual files with all environments should be in the format Experiment Name_Dataset Name_All_Env_Timestamp
File names for individual files for a specific environment should be in the format Experiment Name_Dataset Name_Environment Name_Timestamp
File names for zip files should be in format Experiment Name_Dataset Name_Timestamp

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
