### PR TITLE
[BI-2757] Fix observations not saving on sub entity dataset append

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIListDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIListDAO.java
@@ -43,6 +43,7 @@ import org.breedinginsight.utilities.BrAPIDAOUtil;
 import org.breedinginsight.utilities.Utilities;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,6 +51,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Slf4j
+@Singleton
 public class BrAPIListDAO {
 
     private ProgramDAO programDAO;

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -16,8 +16,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.*;
-import org.brapi.v2.model.core.request.BrAPIListNewRequest;
-import org.brapi.v2.model.core.response.BrAPIListDetails;
 import org.brapi.v2.model.core.response.BrAPIListsSingleResponse;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 
@@ -29,10 +27,9 @@ import org.breedinginsight.brapi.v2.model.request.query.ExperimentExportQuery;
 import org.breedinginsight.brapps.importer.model.exports.FileType;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation.Columns;
-import org.breedinginsight.brapps.importer.model.response.ImportObjectState;
-import org.breedinginsight.brapps.importer.model.response.PendingImportObject;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.brapps.importer.services.FileMappingUtil;
+import org.breedinginsight.brapps.importer.services.processors.experiment.service.DatasetService;
 import org.breedinginsight.dao.db.enums.DataType;
 import org.breedinginsight.model.BrAPIConstants;
 import org.breedinginsight.model.Column;
@@ -83,6 +80,7 @@ public class BrAPITrialService {
     private final FileMappingUtil fileMappingUtil;
     private final DistributedLockService lockService;
     private static final String SHEET_NAME = "Data";
+    private final DatasetService datasetService;
 
     @Inject
     public BrAPITrialService(@Property(name = "brapi.server.reference-source") String referenceSource,
@@ -97,7 +95,8 @@ public class BrAPITrialService {
                              BrAPIObservationLevelDAO observationLevelDAO,
                              BrAPIGermplasmDAO germplasmDAO,
                              FileMappingUtil fileMappingUtil,
-                             DistributedLockService lockService) {
+                             DistributedLockService lockService,
+                             DatasetService datasetService) {
 
         this.referenceSource = referenceSource;
         this.trialDAO = trialDAO;
@@ -112,6 +111,7 @@ public class BrAPITrialService {
         this.germplasmDAO = germplasmDAO;
         this.fileMappingUtil = fileMappingUtil;
         this.lockService = lockService;
+        this.datasetService = datasetService;
     }
 
     public List<BrAPITrial> getExperiments(UUID programId) throws ApiException, DoesNotExistException {
@@ -465,8 +465,8 @@ public class BrAPITrialService {
                     throw new AlreadyExistsException("Dataset name already exists in this experiment");
                 }
 
-                String programDbId = program.getBrapiProgram() != null ? program.getBrapiProgram().getProgramDbId() : null;
-                HttpResponse<String> levelResponse = observationLevelDAO.createObservationLevelName(program, datasetName, DatasetLevel.SUB_OBS_UNIT, programDbId);
+                String programBrapiDbId = program.getBrapiProgram() != null ? program.getBrapiProgram().getProgramDbId() : null;
+                HttpResponse<String> levelResponse = observationLevelDAO.createObservationLevelName(program, datasetName, DatasetLevel.SUB_OBS_UNIT, programBrapiDbId);
 
                 // 409 and 200 are expected response codes, anything else error out
                 // 409 means level already exists so we just use the name in OUs
@@ -515,16 +515,7 @@ public class BrAPITrialService {
                 latestExperiment.getAdditionalInfo().add(BrAPIAdditionalInfoFields.DATASETS, DatasetUtil.jsonArrayFromDatasets(datasets));
                 trialDAO.updateBrAPITrial(latestExperiment.getTrialDbId(), latestExperiment, program.getId());
 
-                BrAPIListDetails subEntityObsVarsList = createSubEntityObsVarList(programDbId, latestExperiment, subEntityDatasetMetadata);
-
-                BrAPIListNewRequest listRq = new BrAPIListNewRequest();
-                listRq.setListName(subEntityObsVarsList.getListName());
-                listRq.setListType(subEntityObsVarsList.getListType());
-                listRq.setExternalReferences(subEntityObsVarsList.getExternalReferences());
-                listRq.setAdditionalInfo(subEntityObsVarsList.getAdditionalInfo());
-                listRq.data(subEntityObsVarsList.getData());
-
-                var newList = listDAO.createBrAPILists(List.of(listRq), program.getId(), null);
+                datasetService.createBrAPIObsVarListForDataset(program, latestExperiment, subEntityDatasetMetadata);
 
                 return getDatasetData(program, experimentId, subEntityDatasetId, false);
             });
@@ -535,45 +526,6 @@ public class BrAPITrialService {
         } catch (Exception e) {
             throw new RuntimeException("Unexpected error creating sub-entity dataset", e);
         }
-    }
-
-    public BrAPIListDetails createSubEntityObsVarList(String programDbId,
-                                                      BrAPITrial trial,
-                                                      DatasetMetadata subEntityDatasetMetadata)  {
-
-        // TODO: this is common to both workflows
-        String name = String.format("Observation Dataset [%s-%s-%s]",
-                programDbId,
-                trial.getAdditionalInfo()
-                        .get(BrAPIAdditionalInfoFields.EXPERIMENT_NUMBER)
-                        .getAsString(),
-                subEntityDatasetMetadata.getName());
-
-        return constructDatasetDetails(
-                name,
-                subEntityDatasetMetadata.getId(),
-                referenceSource,
-                programDbId,
-                trial.getTrialDbId());
-
-    }
-
-    public BrAPIListDetails constructDatasetDetails(
-            String name,
-            UUID datasetId,
-            String referenceSourceBase,
-            String programDbId, String trialId) {
-        BrAPIListDetails dataSetDetails = new BrAPIListDetails();
-        dataSetDetails.setListName(name);
-        dataSetDetails.setListType(BrAPIListTypes.OBSERVATIONVARIABLES);
-        dataSetDetails.setData(new ArrayList<>());
-        dataSetDetails.putAdditionalInfoItem("datasetType", "observationDataset");
-        List<BrAPIExternalReference> refs = new ArrayList<>();
-        Utilities.addReference(refs, UUID.fromString(programDbId), referenceSourceBase, ExternalReferenceSource.PROGRAMS);
-        Utilities.addReference(refs, UUID.fromString(trialId), referenceSourceBase, ExternalReferenceSource.TRIALS);
-        Utilities.addReference(refs, datasetId, referenceSourceBase, ExternalReferenceSource.DATASET);
-        dataSetDetails.setExternalReferences(refs);
-        return dataSetDetails;
     }
 
     public BrAPIObservationUnit createSubObservationUnit(

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -16,6 +16,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.*;
+import org.brapi.v2.model.core.request.BrAPIListNewRequest;
+import org.brapi.v2.model.core.response.BrAPIListDetails;
 import org.brapi.v2.model.core.response.BrAPIListsSingleResponse;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 
@@ -27,6 +29,8 @@ import org.breedinginsight.brapi.v2.model.request.query.ExperimentExportQuery;
 import org.breedinginsight.brapps.importer.model.exports.FileType;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation.Columns;
+import org.breedinginsight.brapps.importer.model.response.ImportObjectState;
+import org.breedinginsight.brapps.importer.model.response.PendingImportObject;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.brapps.importer.services.FileMappingUtil;
 import org.breedinginsight.dao.db.enums.DataType;
@@ -511,6 +515,17 @@ public class BrAPITrialService {
                 latestExperiment.getAdditionalInfo().add(BrAPIAdditionalInfoFields.DATASETS, DatasetUtil.jsonArrayFromDatasets(datasets));
                 trialDAO.updateBrAPITrial(latestExperiment.getTrialDbId(), latestExperiment, program.getId());
 
+                BrAPIListDetails subEntityObsVarsList = createSubEntityObsVarList(programDbId, latestExperiment, subEntityDatasetMetadata);
+
+                BrAPIListNewRequest listRq = new BrAPIListNewRequest();
+                listRq.setListName(subEntityObsVarsList.getListName());
+                listRq.setListType(subEntityObsVarsList.getListType());
+                listRq.setExternalReferences(subEntityObsVarsList.getExternalReferences());
+                listRq.setAdditionalInfo(subEntityObsVarsList.getAdditionalInfo());
+                listRq.data(subEntityObsVarsList.getData());
+
+                var newList = listDAO.createBrAPILists(List.of(listRq), program.getId(), null);
+
                 return getDatasetData(program, experimentId, subEntityDatasetId, false);
             });
         } catch (TimeoutException e) {
@@ -520,6 +535,45 @@ public class BrAPITrialService {
         } catch (Exception e) {
             throw new RuntimeException("Unexpected error creating sub-entity dataset", e);
         }
+    }
+
+    public BrAPIListDetails createSubEntityObsVarList(String programDbId,
+                                                      BrAPITrial trial,
+                                                      DatasetMetadata subEntityDatasetMetadata)  {
+
+        // TODO: this is common to both workflows
+        String name = String.format("Observation Dataset [%s-%s-%s]",
+                programDbId,
+                trial.getAdditionalInfo()
+                        .get(BrAPIAdditionalInfoFields.EXPERIMENT_NUMBER)
+                        .getAsString(),
+                subEntityDatasetMetadata.getName());
+
+        return constructDatasetDetails(
+                name,
+                subEntityDatasetMetadata.getId(),
+                referenceSource,
+                programDbId,
+                trial.getTrialDbId());
+
+    }
+
+    public BrAPIListDetails constructDatasetDetails(
+            String name,
+            UUID datasetId,
+            String referenceSourceBase,
+            String programDbId, String trialId) {
+        BrAPIListDetails dataSetDetails = new BrAPIListDetails();
+        dataSetDetails.setListName(name);
+        dataSetDetails.setListType(BrAPIListTypes.OBSERVATIONVARIABLES);
+        dataSetDetails.setData(new ArrayList<>());
+        dataSetDetails.putAdditionalInfoItem("datasetType", "observationDataset");
+        List<BrAPIExternalReference> refs = new ArrayList<>();
+        Utilities.addReference(refs, UUID.fromString(programDbId), referenceSourceBase, ExternalReferenceSource.PROGRAMS);
+        Utilities.addReference(refs, UUID.fromString(trialId), referenceSourceBase, ExternalReferenceSource.TRIALS);
+        Utilities.addReference(refs, datasetId, referenceSourceBase, ExternalReferenceSource.DATASET);
+        dataSetDetails.setExternalReferences(refs);
+        return dataSetDetails;
     }
 
     public BrAPIObservationUnit createSubObservationUnit(

--- a/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/imports/experimentObservation/ExperimentObservation.java
@@ -228,23 +228,6 @@ public class ExperimentObservation implements BrAPIImport {
         return study;
     }
 
-    public BrAPIListDetails constructDatasetDetails(
-            String name,
-            UUID datasetId,
-            String referenceSourceBase,
-            Program program, String trialId) {
-        BrAPIListDetails dataSetDetails = new BrAPIListDetails();
-        dataSetDetails.setListName(name);
-        dataSetDetails.setListType(BrAPIListTypes.OBSERVATIONVARIABLES);
-        dataSetDetails.setData(new ArrayList<>());
-        dataSetDetails.putAdditionalInfoItem("datasetType", "observationDataset");
-        List<BrAPIExternalReference> refs = new ArrayList<>();
-        Utilities.addReference(refs, program.getId(), referenceSourceBase, ExternalReferenceSource.PROGRAMS);
-        Utilities.addReference(refs, UUID.fromString(trialId), referenceSourceBase, ExternalReferenceSource.TRIALS);
-        Utilities.addReference(refs, datasetId, referenceSourceBase, ExternalReferenceSource.DATASET);
-        dataSetDetails.setExternalReferences(refs);
-        return dataSetDetails;
-    }
     public BrAPIObservationUnit constructBrAPIObservationUnit(
             Program program,
             String seqVal,

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/middleware/process/ImportTableProcess.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/appendoverwrite/middleware/process/ImportTableProcess.java
@@ -22,27 +22,23 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Prototype;
-import io.micronaut.http.HttpStatus;
-import io.micronaut.http.exceptions.HttpStatusException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPIStudy;
 import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.core.response.BrAPIListDetails;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
-import org.breedinginsight.api.model.v1.response.ValidationError;
 import org.breedinginsight.api.model.v1.response.ValidationErrors;
-import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapi.v2.dao.BrAPIObservationDAO;
-import org.breedinginsight.brapps.importer.model.ImportUpload;
-import org.breedinginsight.brapps.importer.model.imports.BrAPIImport;
 import org.breedinginsight.brapps.importer.model.imports.PendingImport;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
 import org.breedinginsight.brapps.importer.model.response.ImportObjectState;
 import org.breedinginsight.brapps.importer.model.response.PendingImportObject;
+import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.brapps.importer.services.processors.experiment.ExperimentUtilities;
 import org.breedinginsight.brapps.importer.services.processors.experiment.appendoverwrite.factory.data.ProcessedDataFactory;
 import org.breedinginsight.brapps.importer.services.processors.experiment.appendoverwrite.factory.data.VisitedObservationData;
@@ -60,15 +56,12 @@ import org.breedinginsight.services.exceptions.DoesNotExistException;
 import org.breedinginsight.services.exceptions.UnprocessableEntityException;
 import org.breedinginsight.services.exceptions.ValidatorException;
 import org.breedinginsight.utilities.Utilities;
-import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 
 import javax.inject.Inject;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.breedinginsight.brapps.importer.services.processors.experiment.model.ExpImportProcessConstants.*;
-import static org.breedinginsight.brapps.importer.services.processors.experiment.model.ExpImportProcessConstants.ErrMessage.DATASET_NOT_FOUND;
 import static org.breedinginsight.brapps.importer.services.processors.experiment.model.ExpImportProcessConstants.ErrMessage.MULTIPLE_EXP_TITLES;
 
 @Slf4j
@@ -161,12 +154,19 @@ public class ImportTableProcess extends AppendOverwriteMiddleware {
 
             // Read any observation data stored for these traits
             log.debug("fetching observation data stored for traits");
-            Set<String> ouDbIds = context.getAppendOverwriteWorkflowContext().getPendingObsUnitByOUId().values().stream().map(u -> u.getBrAPIObject().getObservationUnitDbId()).collect(Collectors.toSet());
-            Set<String> varDbIds = sortedTraits.stream().map(t->t.getObservationVariableDbId()).collect(Collectors.toSet());
-            List<BrAPIObservation> observations = brAPIObservationDAO.getObservationsByObservationUnitsAndVariables(ouDbIds, varDbIds, program);
+            Set<String> ouBrapiDbIds = context.getAppendOverwriteWorkflowContext().getPendingObsUnitByOUId().values().stream().map(u -> u.getBrAPIObject().getObservationUnitDbId()).collect(Collectors.toSet());
+            Set<String> varBrapiDbIds = sortedTraits.stream().map(t->t.getObservationVariableDbId()).collect(Collectors.toSet());
+            List<BrAPIObservation> observations = brAPIObservationDAO.getObservationsByObservationUnitsAndVariables(ouBrapiDbIds, varBrapiDbIds, program);
+
+            // OU Exref Ids are what are displayed to users in the Obs Unit Id columns in experiments in DeltaBreed.
+            Map<String, String> OuExRefIdByObsBrAPIDbId = new HashMap<>();
+
+            for (BrAPIObservation observation : observations) {
+                Optional<BrAPIExternalReference> ouExref = Utilities.getExternalReference(observation.getExternalReferences(), brapiReferenceSource, ExternalReferenceSource.OBSERVATION_UNITS);
+                ouExref.ifPresent(exRef -> OuExRefIdByObsBrAPIDbId.put(observation.getObservationDbId(), exRef.getReferenceId().toString()));
+            }
 
             // Construct helper lookup tables to use for hashing stored observation data
-            Map<String, String> unitNameByDbId = context.getAppendOverwriteWorkflowContext().getPendingObsUnitByOUId().values().stream().map(PendingImportObject::getBrAPIObject).collect(Collectors.toMap(BrAPIObservationUnit::getObservationUnitDbId, BrAPIObservationUnit::getObservationUnitName));
             Map<String, String> variableNameByDbId = sortedTraits.stream().collect(Collectors.toMap(Trait::getObservationVariableDbId, Trait::getObservationVariableName));
             Map<String, String> studyNameByDbId = context.getAppendOverwriteWorkflowContext().getStudyByNameNoScope().values().stream()
                     .filter(pio -> StringUtils.isNotBlank(pio.getBrAPIObject().getStudyDbId()))
@@ -175,7 +175,7 @@ public class ImportTableProcess extends AppendOverwriteMiddleware {
 
             // Hash stored observation data using a signature of unit, variable, and study names
             Map<String, BrAPIObservation> observationByObsHash = observations.stream().collect(Collectors.toMap(o->{
-                return observationService.getObservationHash(unitNameByDbId.get(o.getObservationUnitDbId()),
+                return observationService.getObservationHash(OuExRefIdByObsBrAPIDbId.get(o.getObservationDbId()),
                         variableNameByDbId.get(o.getObservationVariableDbId()),
                         studyNameByDbId.get(o.getStudyDbId()));
             }, o->o));
@@ -226,9 +226,8 @@ public class ImportTableProcess extends AppendOverwriteMiddleware {
                     String cellData = column.getString(rowNum);
 
                     // Generate hash for looking up prior observation data
-                    String unitName = context.getAppendOverwriteWorkflowContext().getPendingObsUnitByOUId().get(unitId).getBrAPIObject().getObservationUnitName();
                     String phenoColumnName = column.name();
-                    String observationHash = observationService.getObservationHash(unitName, phenoColumnName, studyName);
+                    String observationHash = observationService.getObservationHash(unitId, phenoColumnName, studyName);
 
                     // Get timestamp if associated column
                     var cell = new Object() {   // mutable reference object to make timestamp accessible in anonymous methods

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/PopulateNewPendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/PopulateNewPendingImportObjectsStep.java
@@ -43,6 +43,7 @@ import org.breedinginsight.brapps.importer.services.processors.experiment.create
 import org.breedinginsight.brapps.importer.services.processors.experiment.create.model.PendingImportObjectData;
 import org.breedinginsight.brapps.importer.services.processors.experiment.create.model.ProcessContext;
 import org.breedinginsight.brapps.importer.services.processors.experiment.create.model.ProcessedPhenotypeData;
+import org.breedinginsight.brapps.importer.services.processors.experiment.service.DatasetService;
 import org.breedinginsight.brapps.importer.services.processors.experiment.services.ExperimentSeasonService;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.ProgramLocation;
@@ -76,6 +77,7 @@ public class PopulateNewPendingImportObjectsStep {
     private final BrAPIObservationUnitDAO brAPIObservationUnitDAO;
     private final DSLContext dsl;
     private final Gson gson;
+    private final DatasetService datasetService;
 
     @Property(name = "brapi.server.reference-source")
     private String BRAPI_REFERENCE_SOURCE;
@@ -83,11 +85,12 @@ public class PopulateNewPendingImportObjectsStep {
     @Inject
     public PopulateNewPendingImportObjectsStep(ExperimentSeasonService experimentSeasonService,
                                                BrAPIObservationUnitDAO brAPIObservationUnitDAO,
-                                               DSLContext dsl) {
+                                               DSLContext dsl, DatasetService datasetService) {
         this.experimentSeasonService = experimentSeasonService;
         this.brAPIObservationUnitDAO = brAPIObservationUnitDAO;
         this.dsl = dsl;
         this.gson = new JSON().getGson();
+        this.datasetService = datasetService;
     }
 
     /**
@@ -370,7 +373,7 @@ public class PopulateNewPendingImportObjectsStep {
             pio = obsVarDatasetByName.get(name);
         } else {
             UUID id = UUID.randomUUID();
-            BrAPIListDetails newDataset = importRow.constructDatasetDetails(
+            BrAPIListDetails newDataset = datasetService.constructDatasetDetails(
                     name,
                     id,
                     BRAPI_REFERENCE_SOURCE,

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/DatasetService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/DatasetService.java
@@ -18,16 +18,19 @@
 package org.breedinginsight.brapps.importer.services.processors.experiment.service;
 
 import io.micronaut.context.annotation.Property;
-import io.micronaut.http.server.exceptions.InternalServerException;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPIListSummary;
 import org.brapi.v2.model.core.BrAPIListTypes;
+import org.brapi.v2.model.core.BrAPITrial;
+import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.core.response.BrAPIListDetails;
+import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapi.v2.dao.BrAPIListDAO;
 import org.breedinginsight.brapps.importer.model.response.ImportObjectState;
 import org.breedinginsight.brapps.importer.model.response.PendingImportObject;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.model.DatasetMetadata;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.utilities.Utilities;
 
@@ -113,5 +116,50 @@ public class DatasetService {
 
         // Create a PendingImportObject for the dataset with the existing list and reference ID
         return new PendingImportObject<BrAPIListDetails>(ImportObjectState.EXISTING, dataset, UUID.fromString(xref.getReferenceId()));
+    }
+
+    public void createBrAPIObsVarListForDataset(Program program,
+                                                BrAPITrial trial,
+                                                DatasetMetadata subEntityDatasetMetadata) throws ApiException {
+
+        String name = String.format("Observation Dataset [%s-%s-%s]",
+                program.getKey(),
+                trial.getAdditionalInfo()
+                        .get(BrAPIAdditionalInfoFields.EXPERIMENT_NUMBER)
+                        .getAsString(),
+                subEntityDatasetMetadata.getName());
+
+        BrAPIListDetails subEntityObsVarsList = constructDatasetDetails(name,
+                subEntityDatasetMetadata.getId(),
+                BRAPI_REFERENCE_SOURCE,
+                program,
+                trial.getTrialDbId());
+
+        BrAPIListNewRequest listRq = new BrAPIListNewRequest();
+        listRq.setListName(subEntityObsVarsList.getListName());
+        listRq.setListType(subEntityObsVarsList.getListType());
+        listRq.setExternalReferences(subEntityObsVarsList.getExternalReferences());
+        listRq.setAdditionalInfo(subEntityObsVarsList.getAdditionalInfo());
+        listRq.data(subEntityObsVarsList.getData());
+
+        brAPIListDAO.createBrAPILists(List.of(listRq), program.getId(), null);
+    }
+
+    public BrAPIListDetails constructDatasetDetails(
+            String name,
+            UUID datasetId,
+            String referenceSourceBase,
+            Program program, String trialId) {
+        BrAPIListDetails dataSetDetails = new BrAPIListDetails();
+        dataSetDetails.setListName(name);
+        dataSetDetails.setListType(BrAPIListTypes.OBSERVATIONVARIABLES);
+        dataSetDetails.setData(new ArrayList<>());
+        dataSetDetails.putAdditionalInfoItem("datasetType", "observationDataset");
+        List<BrAPIExternalReference> refs = new ArrayList<>();
+        Utilities.addReference(refs, program.getId(), referenceSourceBase, ExternalReferenceSource.PROGRAMS);
+        Utilities.addReference(refs, UUID.fromString(trialId), referenceSourceBase, ExternalReferenceSource.TRIALS);
+        Utilities.addReference(refs, datasetId, referenceSourceBase, ExternalReferenceSource.DATASET);
+        dataSetDetails.setExternalReferences(refs);
+        return dataSetDetails;
     }
 }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/ObservationService.java
@@ -99,8 +99,8 @@ public class ObservationService {
         }
         return true;
     }
-    public String getObservationHash(String observationUnitName, String variableName, String studyName) {
-        String concat = DigestUtils.sha256Hex(observationUnitName) +
+    public String getObservationHash(String observationUnitId, String variableName, String studyName) {
+        String concat = DigestUtils.sha256Hex(observationUnitId) +
                 DigestUtils.sha256Hex(variableName) +
                 DigestUtils.sha256Hex(StringUtils.defaultString(studyName));
         return DigestUtils.sha256Hex(concat);


### PR DESCRIPTION
# Description
**Story:** [BI-2757](https://breedinginsight.atlassian.net/browse/BI-2757)

It was found through spike [BI-2795](https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/3116597259/BI-2795) that observations were failing to be saved when appending to a sub entity dataset.

This ended up happening for two reasons:

1. BrAPI Lists were never being created for observation variables for sub entity datasets
2. A generated hash used to key incoming import data to data found in the database was incompatible with sub entity datasets.  Prior the hash relied on the exp unit id, which works great for top level datasets, but for sub entity datasets, the IDs repeat and are not unique.  The solution here is to change the hash from using experiment id to the observation unit id, which is unique in all cases, not just for top level.

Additional changes were made to move some reused code to `DatasetService`


# Dependencies

# Testing
1. Create a new program, uploading germplasm data and ontology data
2. Create a new top level experiment
3. Create a new sub entity dataset on this experiment
4. Download the sub entity dataset data
5. Add ontology/obs var columns to the downloaded data, and add values in the rows of these columns to create observations for the sub entity dataset
6. Go to import experiment, select "Append experimental dataset" from the dropdown, and choose the file you just edited.  Click "Upload and Validate" button.
7. You will be met with a preview, that doesn't actually load.  Some things will also be off, like the number of observation variables in the stats.  Ignore this, it is supposed to be resolved in a different ticket: [BI-2803](https://breedinginsight.atlassian.net/browse/BI-2803).  Click "Confirm"
8. Once the data is uploaded, verify the newly added observations show up in the sub entity dataset tab in the experiment you created, and that if the sub entity dataset is exported again, the new observations show up.

Suggested regression checks:
* Try reimporting same data
* Try importing new data/observations
* Appending data to top level dataset
* Verify two datasets cannot have the same observation variable/ontology term associated with its observations

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2757]: https://breedinginsight.atlassian.net/browse/BI-2757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2795]: https://breedinginsight.atlassian.net/browse/BI-2795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2803]: https://breedinginsight.atlassian.net/browse/BI-2803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ