### PR TITLE
[BI-2816] Unknown error when creating new exp with more than one exp title

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/CreateNewExperimentWorkflow.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/CreateNewExperimentWorkflow.java
@@ -43,6 +43,7 @@ import org.breedinginsight.brapps.importer.services.processors.experiment.create
 import org.breedinginsight.brapps.importer.services.processors.experiment.create.workflow.steps.PopulateNewPendingImportObjectsStep;
 import org.breedinginsight.brapps.importer.services.processors.experiment.create.workflow.steps.ValidatePendingImportObjectsStep;
 import org.breedinginsight.brapps.importer.services.processors.experiment.services.ExperimentPhenotypeService;
+import org.breedinginsight.services.exceptions.UnprocessableEntityException;
 import org.breedinginsight.services.exceptions.ValidatorException;
 
 import javax.inject.Inject;
@@ -57,6 +58,7 @@ import org.breedinginsight.brapps.importer.services.processors.experiment.Experi
 
 import javax.inject.Singleton;
 
+import static org.breedinginsight.brapps.importer.services.processors.experiment.model.ExpImportProcessConstants.ErrMessage.MULTIPLE_EXP_TITLES;
 import static org.breedinginsight.brapps.importer.services.processors.experiment.model.ExpImportProcessConstants.OBSERVATION_UNIT_ID_SUFFIX;
 
 @Slf4j
@@ -97,6 +99,12 @@ public class CreateNewExperimentWorkflow implements ExperimentWorkflow {
         // Make sure the file does not contain obs unit ids before proceeding
         if (containsObsUnitIDs(context)) {
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "ObsUnitIDs are detected");
+        }
+
+        //Make sure file only contains one exp title, check early cause avoids issues with titles corresponding to existing and new trials
+        List<ExperimentObservation> experimentImportRows = ExperimentUtilities.importRowsToExperimentObservations(importRows);
+        if (experimentImportRows.stream().map(ExperimentObservation::getExpTitle).distinct().count() > 1) {
+            throw new UnprocessableEntityException(MULTIPLE_EXP_TITLES.getValue());
         }
 
         statusService.updateMessage(upload, "Checking existing experiment objects in brapi service and mapping data");


### PR DESCRIPTION
# Description
**Story:** [BI-2816 - Unknown error when creating new experiment with file with more than one experiment title and at least one title is that of an existing experiment](https://breedinginsight.atlassian.net/browse/BI-2816)

Fix to move checking for multiple experiment titles on experiment creation earlier, to avoid problems when at least one of the multiple experiment titles was existing and one was new, where PopulateExistingPendingImportObjectsStep.java ended up attempting to populate information for rows without the existing title which was resulting in an Unknown Error.

# Dependencies
bi-web: develop

# Testing
Import experiment file for new experiment:
- with multiple exp title, all new: should get error saying multiple experiment titles
- with multiple exp title, at least one existing: should get error saying multiple experiment titles
- with one exp title, already existing: should get error saying exp title already exists
- with one exp title, new: should be able to import without issue

Also repeat above tests with adding new environment to existing experiment via the create experiment workflow

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
