### PR TITLE
[BI-2813] Set levelNameDbIds in OUs in experiment creation use case

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIObservationLevelService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIObservationLevelService.java
@@ -1,49 +1,28 @@
 package org.breedinginsight.brapi.v2.services;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
-import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.model.exceptions.ApiException;
-import org.brapi.client.v2.modules.phenotype.ObservationUnitsApi;
 import org.brapi.v2.model.pheno.BrAPIObservationUnitHierarchyLevel;
-import org.brapi.v2.model.pheno.BrAPIObservationUnitLevelRelationship;
-import org.brapi.v2.model.pheno.response.BrAPIObservationLevelListResponse;
 import org.breedinginsight.brapi.v2.dao.BrAPIObservationLevelDAO;
 import org.breedinginsight.model.DatasetLevel;
 import org.breedinginsight.model.Program;
-import org.breedinginsight.services.ProgramService;
-import org.breedinginsight.services.exceptions.DoesNotExistException;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Singleton
 public class BrAPIObservationLevelService {
     private final BrAPIObservationLevelDAO brAPIObservationLevelDAO;
-    private final ProgramService programService;
-
 
     @Inject
-    public BrAPIObservationLevelService(BrAPIObservationLevelDAO brAPIObservationLevelDAO,
-                                        ProgramService programService) {
+    public BrAPIObservationLevelService(BrAPIObservationLevelDAO brAPIObservationLevelDAO) {
         this.brAPIObservationLevelDAO = brAPIObservationLevelDAO;
-        this.programService = programService;
     }
 
-    /**
-     * @return Pair[GlobalLevelNames, ProgrammaticLevelNames]
-     */
-    public Pair<List<BrAPIObservationUnitHierarchyLevel>, List<BrAPIObservationUnitHierarchyLevel>> getGlobalAndProgrammaticLevelNames(Program program, String brapiProgramDbId) {
-        List<BrAPIObservationUnitHierarchyLevel> globalLevels = brAPIObservationLevelDAO.getGlobalObservationLevelNames(program);
-        List<BrAPIObservationUnitHierarchyLevel> programmaticLevels = brAPIObservationLevelDAO.getObservationLevelNamesByProgramId(program, brapiProgramDbId);
-
-
-        return new ImmutablePair<>(globalLevels, programmaticLevels);
+    public List<BrAPIObservationUnitHierarchyLevel> getGlobalLevelNames(Program program) {
+        return brAPIObservationLevelDAO.getGlobalObservationLevelNames(program);
     }
 
     public List<BrAPIObservationUnitHierarchyLevel> getProgrammaticLevelNames(Program program, String brapiProgramDbId) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
@@ -23,6 +23,7 @@ import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.core.BrAPIListSummary;
+import org.brapi.v2.model.core.BrAPIProgram;
 import org.brapi.v2.model.core.BrAPIStudy;
 import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
@@ -43,6 +44,7 @@ import org.breedinginsight.brapps.importer.services.processors.ProcessorData;
 import org.breedinginsight.brapps.importer.services.processors.experiment.ExperimentUtilities;
 import org.breedinginsight.brapps.importer.services.processors.experiment.create.model.PendingData;
 import org.breedinginsight.brapps.importer.services.processors.experiment.create.model.ProcessContext;
+import org.breedinginsight.brapps.importer.services.processors.experiment.service.DatasetService;
 import org.breedinginsight.model.DatasetLevel;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.model.ProgramLocation;
@@ -55,10 +57,7 @@ import org.breedinginsight.utilities.Utilities;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.breedinginsight.brapps.importer.services.processors.experiment.ExperimentUtilities.PREEXISTING_EXPERIMENT_TITLE;
@@ -74,7 +73,7 @@ public class CommitPendingImportObjectsStep {
     private final BrAPIObservationUnitDAO brAPIObservationUnitDAO;
     private final ProgramLocationService locationService;
     private final OntologyService ontologyService;
-    private final BrAPIObservationLevelDAO brAPIObservationLevelDAO;
+    private final DatasetService datasetService;
 
     @Inject
     public CommitPendingImportObjectsStep(BrAPIListDAO brAPIListDAO,
@@ -84,7 +83,7 @@ public class CommitPendingImportObjectsStep {
                                           BrAPIObservationUnitDAO brAPIObservationUnitDAO,
                                           ProgramLocationService locationService,
                                           OntologyService ontologyService,
-                                          BrAPIObservationLevelDAO brAPIObservationLevelDAO) {
+                                          DatasetService datasetService) {
         this.brAPIListDAO = brAPIListDAO;
         this.brapiTrialDAO = brapiTrialDAO;
         this.brAPIStudyDAO = brAPIStudyDAO;
@@ -92,11 +91,13 @@ public class CommitPendingImportObjectsStep {
         this.brAPIObservationUnitDAO = brAPIObservationUnitDAO;
         this.locationService = locationService;
         this.ontologyService = ontologyService;
-        this.brAPIObservationLevelDAO = brAPIObservationLevelDAO;
+        this.datasetService = datasetService;
     }
 
     // TODO: some common code between workflows here that could be broken out, removed append/update specific code
-    public void process(ProcessContext processContext, ProcessedData processedData) throws UnprocessableEntityException {
+    // TODO: For instance, multiple trials don't really exist in the use case which this code is used for: creating an experiment.
+    // TODO: This means having a Map of trials doesn't really make sense anymore, and should be replaced with a singular PendingImportObject<Trial>
+    public void process(ProcessContext processContext, ProcessedData processedData) throws UnprocessableEntityException, ApiException {
 
         PendingData pendingData = processContext.getPendingData();
         ImportContext importContext = processContext.getImportContext();
@@ -112,6 +113,32 @@ public class CommitPendingImportObjectsStep {
         Map<String, PendingImportObject<BrAPIObservationUnit>> observationUnitByNameNoScope = pendingData.getObservationUnitByNameNoScope();
         Map<String, PendingImportObject<BrAPIObservation>> observationByHash = pendingData.getObservationByHash();
         Map<String, String> expUnitbyTrialName = pendingData.getExpUnitByTrialName();
+
+        // Assume that there's only one expUnit per trial in this workflow.
+        // This should be a safe assumption to make considering this workflow is for the creation of a single experiment.
+        // If that changes in the future, this code will break and need to be dealt with.
+
+        if (expUnitbyTrialName.size() > 1) {
+            throw new InternalServerException("Multiple Experiment names exist during commit stage");
+        }
+
+        String expUnitName = expUnitbyTrialName.values()
+                .stream()
+                .findFirst()
+                .orElse(null);
+
+        if (expUnitName == null) {
+            throw new InternalServerException("Experiment unit name not found during commit stage");
+        }
+
+        String brapiProgramId = Optional.of(program)
+                .map(Program::getBrapiProgram)
+                .map(BrAPIProgram::getProgramDbId)
+                .orElse(null);
+
+        if (brapiProgramId == null) {
+            throw new InternalServerException("BrAPI program not found during commit stage");
+        }
 
         List<BrAPITrial> newTrials = ProcessorData.getNewObjects(pendingData.getTrialByNameNoScope());
 
@@ -138,6 +165,14 @@ public class CommitPendingImportObjectsStep {
                 .getMutationsByObjectId(pendingData.getObsVarDatasetByName(), BrAPIListSummary::getListDbId);
 
         List<BrAPIObservationUnit> newObservationUnits = ProcessorData.getNewObjects(pendingData.getObservationUnitByNameNoScope());
+
+        // Inject level names here
+        datasetService.updateObservationUnitsWithLevelNameDbIds(newObservationUnits,
+                program,
+                brapiProgramId,
+                expUnitName,
+                DatasetLevel.EXP_UNIT
+                );
 
         // filter out observations with no 'value' so they will not be saved
         List<BrAPIObservation> newObservations = ProcessorData.getNewObjects(observationByHash)
@@ -176,8 +211,6 @@ public class CommitPendingImportObjectsStep {
                 trialByNameNoScope.get(createdTrialName)
                         .getBrAPIObject()
                         .setTrialDbId(createdTrial.getTrialDbId());
-
-                createObservationLevel(createdTrialName, expUnitbyTrialName, program);
             }
 
             List<ProgramLocation> createdLocations = new ArrayList<>(locationService.create(actingUser, program.getId(), newLocations));
@@ -249,22 +282,6 @@ public class CommitPendingImportObjectsStep {
 
         // NOTE: removed mutated observations code
 
-    }
-
-    //Check if the experimental unit associated with the trial does not exist in the system and if so create a new observation level
-    private void createObservationLevel(String trialName, Map<String, String> expUnitByTrialName, Program program) throws ApiException, InternalServerException {
-        String expUnit = expUnitByTrialName.get(trialName).toLowerCase();
-        String programDbId = program.getBrapiProgram() != null ? program.getBrapiProgram().getProgramDbId() : null;
-        HttpResponse<String> levelResponse = brAPIObservationLevelDAO.createObservationLevelName(program, expUnit, DatasetLevel.EXP_UNIT, programDbId);
-
-        if (levelResponse.getStatus().getCode() == 409) {
-            log.info(String.format("Level with name=%s, order=%s, programDbId=%s already exists in database", expUnit, DatasetLevel.EXP_UNIT, programDbId));
-        } else if (levelResponse.getStatus().getCode() == 200) {
-            log.info(String.format("Level with name=%s, order=%s, programDbId=%s created in database", expUnit, DatasetLevel.EXP_UNIT, programDbId));
-        } else {
-            log.error("Error saving experiment import: " + levelResponse.getStatus().getReason());
-            throw new InternalServerException("Unable to create observation level: " + levelResponse.getStatus().getReason());
-        }
     }
 
     private void updateStudyDependencyValues(PendingData pendingData, Map<Integer, PendingImport> mappedBrAPIImport, String programKey) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/DatasetService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/DatasetService.java
@@ -18,6 +18,7 @@
 package org.breedinginsight.brapps.importer.services.processors.experiment.service;
 
 import io.micronaut.context.annotation.Property;
+import io.micronaut.http.server.exceptions.InternalServerException;
 import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.BrAPIExternalReference;
@@ -26,14 +27,16 @@ import org.brapi.v2.model.core.BrAPIListTypes;
 import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.core.request.BrAPIListNewRequest;
 import org.brapi.v2.model.core.response.BrAPIListDetails;
+import org.brapi.v2.model.pheno.BrAPIObservationUnit;
 import org.brapi.v2.model.pheno.BrAPIObservationUnitHierarchyLevel;
+import org.brapi.v2.model.pheno.BrAPIObservationUnitLevelRelationship;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapi.v2.dao.BrAPIListDAO;
-import org.breedinginsight.brapi.v2.dao.BrAPIObservationLevelDAO;
 import org.breedinginsight.brapi.v2.services.BrAPIObservationLevelService;
 import org.breedinginsight.brapps.importer.model.response.ImportObjectState;
 import org.breedinginsight.brapps.importer.model.response.PendingImportObject;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.model.BrAPIConstants;
 import org.breedinginsight.model.DatasetLevel;
 import org.breedinginsight.model.DatasetMetadata;
 import org.breedinginsight.model.Program;
@@ -215,5 +218,43 @@ public class DatasetService {
         }
 
         return levelNameStreamResult.get(0).getLevelNameDbId();
+    }
+
+    public void updateObservationUnitsWithLevelNameDbIds(List<BrAPIObservationUnit> observationUnits,
+                                                         Program program,
+                                                         String brapiProgramDbId,
+                                                         String expUnitName,
+                                                         DatasetLevel levelOrder) throws ApiException {
+        Map<String, String> levelNameDbIdByName = new HashMap<>();
+
+        String expLevelName = expUnitName.toLowerCase();
+
+        String existingLevelNameDbId = getOrCreateLevelNameForDataset(program, brapiProgramDbId, expLevelName, levelOrder);
+        levelNameDbIdByName.put(expLevelName, existingLevelNameDbId);
+
+        List<BrAPIObservationUnitHierarchyLevel> globalLevelNames = observationLevelService.getGlobalLevelNames(program);
+
+        globalLevelNames.forEach(ouln -> levelNameDbIdByName.put(ouln.getLevelName(), ouln.getLevelNameDbId()));
+
+        for (BrAPIObservationUnit observationUnit : observationUnits) {
+
+            String positionLevelName = observationUnit.getObservationUnitPosition().getObservationLevel().getLevelName().toLowerCase();
+
+            observationUnit.getObservationUnitPosition().getObservationLevel().setLevelNameDbId(levelNameDbIdByName.get(positionLevelName));
+
+            for (BrAPIObservationUnitLevelRelationship lvlRelationship : observationUnit.getObservationUnitPosition().getObservationLevelRelationships()) {
+                if (lvlRelationship.getLevelName().equals(BrAPIConstants.BLOCK.getValue())) {
+                    lvlRelationship.setLevelNameDbId(levelNameDbIdByName.get(lvlRelationship.getLevelName()));
+                } else if (lvlRelationship.getLevelName().equals(BrAPIConstants.REPLICATE.getValue())) {
+                    lvlRelationship.setLevelNameDbId(levelNameDbIdByName.get(lvlRelationship.getLevelName()));
+                } else {
+                    throw new InternalServerException(String.format("Level name [%s] detected in OU Level Relationship " +
+                            "for experiment with Exp Unit name [%s].  This is unexpected and the new level " +
+                            "name must be retrieved properly from BrAPI to insert its DbId into BrAPI request for proper creation and assignment.",
+                            lvlRelationship.getLevelName(), expUnitName));
+                }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
# Description
**Story:** [BI-2813](https://breedinginsight.atlassian.net/browse/BI-2813)

* Updated observation level creation logic in the create experiment workflow to work similarly and use similar methods as sub entity workflow
* Added some comments to CommitPendingImportObjectsStep regarding how it could be improved to reflect the actual use case it runs, and some deterministic logic which is needed to support the observation level creation logic supporting that use case.


# Dependencies
[BI-2814](https://github.com/Breeding-Insight/bi-api/pull/506) should be merged first, and then this ticket/MR should be pointed to `develop`
# Testing
Create a program then do the following: 

* Create a new experiment with any level name
* Create a sub-entity dataset with any level name (except top level name of this experiment, this will always result in an error as intended)
* Verify no errors occur on creating the datasets, and that the data can be viewed for the datasets in the experiment, and the dataset data can also be exported without issue

In a program where there already exists an experiment with both a top level dataset and a sub entity dataset: 

* Create a new experiment with top level name that has the same name as the existing sub entity dataset name created in the first experiment
* Create a sub-entity dataset that has the same name as an existing top level dataset in a different experiment in the program.
* Verify no errors occur on creating the datasets, and that the data can be viewed for the datasets in the experiment, and the dataset data can also be exported without issue

In a program where there already exists an experiment with both a top level dataset and a sub entity dataset: 
* Create a new experiment with top level name that has the same name as the existing sub entity dataset name created in the first experiment
* Create a sub-entity dataset with a name that isn’t shared by any of the other existing sub entity datasets for the experiments in this program.
* Verify no errors occur on creating the datasets, and that the data can be viewed for the datasets in the experiment, and the dataset data can also be exported without issue



# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2813]: https://breedinginsight.atlassian.net/browse/BI-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2814]: https://breedinginsight.atlassian.net/browse/BI-2814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ