### PR TITLE
BI-2783 - Logic In Germplasm Import Dependent on Name Lookup

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/germplasm/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/germplasm/GermplasmProcessor.java
@@ -151,7 +151,8 @@ public class GermplasmProcessor implements Processor {
             }
         }
 
-        // Get existing germplasm names
+        // Get existing germplasm names.  This should be used ONLY to identify duplicate germplasm names.
+        // In general you should look up germplasm by GID.
         List<BrAPIGermplasm> dbGermplasm = brAPIGermplasmService.getGermplasmByDisplayName(new ArrayList<>(fileGermplasmByName.keySet()), program.getId());
         dbGermplasm.forEach(germplasm -> {
             dbGermplasmByName.put(germplasm.getDefaultDisplayName(), germplasm);


### PR DESCRIPTION
# Description
[BI-2783](https://breedinginsight.atlassian.net/browse/BI-2783) Logic In Germplasm Import Dependent on Name Lookup

**Change**
Only modified a comment to guide the developers away from using the germplasm Name to find a germplasm.

# Dependencies
bi-web: **develop**

# Testing
No testing needed.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2783]: https://breedinginsight.atlassian.net/browse/BI-2783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ