### PR TITLE
[BI-2823] Remove sub entity level name from level relationships in sub entity dataset creation

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -618,8 +618,6 @@ public class BrAPITrialService {
 
         // ObservationLevelRelationships.
         List<BrAPIObservationUnitLevelRelationship> levelRelationships = new ArrayList<>();
-        // TODO: Figure out if we actually need to add the sub entity level to the level relationships BI-2823
-        levelRelationships.add(level);
         // ObservationLevelRelationships for rep.
         BrAPIObservationUnitLevelRelationship expRepLevel = expUnit.getObservationUnitPosition()
                 .getObservationLevelRelationships().stream()


### PR DESCRIPTION
# Description
[BI-2823](https://breedinginsight.atlassian.net/browse/BI-2823) Remove sub entity level name from level relationships in sub entity dataset creation

CHANGES
The only change is the removal of the _sub entity_ element from the _level relationships_ element.

# Dependencies
bi-web: **develop**

# Testing
GIVEN: an experiment with a sub-entity has been created (and thus sent to the BrAPI server)
THEN: Inspect the JSON data sent to and stored in the BrAPI server.
   1.  Using an HTTP POST to `http://localhost:8083/brapi/v2/search/observationunits`
           a. NOTE: here port `8083` was used.  Use whatever port the BrAPI server is listening on.
   2. BODY
 > {
	"externalReferenceIds": [
		"2f0ae898-697c-464c-95ea-0e918cde117d"
	]
}

 a. NOTE: here the external Reference `2f0ae898-697c-464c-95ea-0e918cde117d` was used.  Use a sub-entity ObsUnitID from the experiment.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2823]: https://breedinginsight.atlassian.net/browse/BI-2823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ