### PR TITLE
BI-2836 - Unable to retrieve program dataset names error message

### DIFF
--- a/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
@@ -178,7 +178,7 @@ public class ExperimentController {
     @Get("/${micronaut.bi.api.version}/programs/{programId}/experiments/{experimentId}/recommended-sub-entity-dataset-names")
     @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.PROGRAM_SCOPED_ROLES})
     @Produces(MediaType.APPLICATION_JSON)
-    public HttpResponse<Response<List<String>>> getRecommendedSubEntityDatasetNames(
+    public HttpResponse<Response<DataResponse<String>>> getRecommendedSubEntityDatasetNames(
             @PathVariable("programId") UUID programId,
             @PathVariable("experimentId") UUID experimentId) {
         try {
@@ -187,7 +187,15 @@ public class ExperimentController {
                 return HttpResponse.status(HttpStatus.NOT_FOUND, "Program does not exist");
             }
 
-            Response<List<String>> response = new Response<>(experimentService.getRecommendedSubEntityDatasetNames(programOptional.get(), experimentId));
+            List<String> recommendedNames = experimentService.getRecommendedSubEntityDatasetNames(programOptional.get(), experimentId);
+
+            List<Status> metadataStatus = new ArrayList<>();
+            metadataStatus.add(new Status(StatusCode.INFO, "Successful Query"));
+            //TODO: paging if needed, unlikely to get very large
+            Pagination pagination = new Pagination(recommendedNames.size(), recommendedNames.size(), 1, 0);
+            Metadata metadata = new Metadata(pagination, metadataStatus);
+
+            Response<DataResponse<String>> response = new Response<>(metadata, new DataResponse<>(recommendedNames));
             return HttpResponse.ok(response);
         } catch (DoesNotExistException e) {
             log.info(e.getMessage());

--- a/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
@@ -1006,7 +1006,8 @@ public class ExperimentControllerIntegrationTest extends BrAPITest {
 
         JsonArray result = JsonParser.parseString(Objects.requireNonNull(response.body()))
                 .getAsJsonObject()
-                .getAsJsonArray("result");
+                .getAsJsonObject("result")
+                .getAsJsonArray("data");
 
         List<String> recommendedNames = new ArrayList<>();
         result.forEach(name -> recommendedNames.add(name.getAsString()));


### PR DESCRIPTION
# Description
**Story:** [BI-2836](https://breedinginsight.atlassian.net/browse/BI-2836?atlOrigin=eyJpIjoiNWNjOTExM2FlZGVkNGFkZjlhNjJiNjlmNDJiMGVhYjAiLCJwIjoiaiJ9)

- Changed response body to bi-api data response format
- Updated tests for new response format

# Dependencies
- bi-web bug/BI-2836

# Testing
- See acceptance criteria in JIRA card

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2836]: https://breedinginsight.atlassian.net/browse/BI-2836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ