### PR TITLE
BI-2825 - Add Sunflower to list of species

### DIFF
--- a/src/main/resources/brapi/sql/R__species.sql
+++ b/src/main/resources/brapi/sql/R__species.sql
@@ -41,7 +41,7 @@ BEGIN
         ('Strawberry'), ('Honey Bee'), ('Pecan'), ('Lettuce'),
         ('Cotton'), ('Sorghum'), ('Hemp'), ('Hop'),
         ('Hydrangea'), ('Red Clover'), ('Potato'), ('Blackberry'),
-        ('Raspberry'), ('Sugar Beet'), ('Coffee')
+        ('Raspberry'), ('Sugar Beet'), ('Coffee'), ('Sunflower')
     ) AS src(crop_name)
     ON CONFLICT (id) DO
         -- want case changes or space changes to overwrite existing

--- a/src/main/resources/db/migration/V1.35.0__add_sunflower_to_species.sql
+++ b/src/main/resources/db/migration/V1.35.0__add_sunflower_to_species.sql
@@ -1,0 +1,12 @@
+DO $$
+DECLARE
+user_id UUID;
+BEGIN
+
+user_id := (SELECT id FROM bi_user WHERE name = 'system');
+
+-- just putting blank strings in for descriptions until later date, can update if needed
+INSERT INTO species (common_name, description, created_by, updated_by)
+VALUES
+    ('Sunflower', '', user_id, user_id) ON CONFLICT DO NOTHING;
+END $$;

--- a/src/test/resources/sql/brapi/species.sql
+++ b/src/test/resources/sql/brapi/species.sql
@@ -36,7 +36,7 @@ FROM (VALUES
           ('Strawberry'), ('Honey Bee'), ('Pecan'), ('Lettuce'),
           ('Cotton'), ('Sorghum'), ('Hemp'), ('Hop'),
           ('Hydrangea'), ('Red Clover'), ('Potato'), ('Blackberry'),
-          ('Raspberry'), ('Sugar Beet'), ('Coffee')
+          ('Raspberry'), ('Sugar Beet'), ('Coffee'), ('Sunflower')
      ) AS src(crop_name)
     ON CONFLICT (id) DO
 UPDATE SET crop_name = EXCLUDED.crop_name


### PR DESCRIPTION
# Description
[BI-2825](https://breedinginsight.atlassian.net/browse/BI-2825) Add Sunflower to list of species

# Changes
updated migrations


# Dependencies
bi-web: **develop**

# Testing

1. (make sure migrations have run)
2. Add a new program with species = 'Sunflower' ('Sunflower' should be an option in the pull down)
3. Press `Save`
4. You should see a 'Success!' message.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2825]: https://breedinginsight.atlassian.net/browse/BI-2825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ