### PR TITLE
BI-2820 Improve sample submission tabular error message

### DIFF
--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/SampleSubmissionProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/SampleSubmissionProcessor.java
@@ -67,7 +67,6 @@ public class SampleSubmissionProcessor implements Processor {
     private static final String UNKNOWN_GID = "Unknown germplasm GID";
     private static final String INVALID_COLUMN = "Column must be a number between 1 and 12";
     private static final String INVALID_ROW = "Row must be a letter between A and H";
-//    private static final String MULTIPLE_SAMPLES_SINGLE_WELL = "The sample in row %d is already in row: %s, column: %d";
     private static final String MULTIPLE_SAMPLES_SINGLE_WELL = "Plate position not unique, duplicate in row %d";
     private final String referenceSource;
     private final BrAPIGermplasmDAO germplasmDAO;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/SampleSubmissionProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/SampleSubmissionProcessor.java
@@ -67,7 +67,8 @@ public class SampleSubmissionProcessor implements Processor {
     private static final String UNKNOWN_GID = "Unknown germplasm GID";
     private static final String INVALID_COLUMN = "Column must be a number between 1 and 12";
     private static final String INVALID_ROW = "Row must be a letter between A and H";
-    private static final String MULTIPLE_SAMPLES_SINGLE_WELL = "The sample in row %d is already in row: %s, column: %d";
+//    private static final String MULTIPLE_SAMPLES_SINGLE_WELL = "The sample in row %d is already in row: %s, column: %d";
+    private static final String MULTIPLE_SAMPLES_SINGLE_WELL = "Plate position not unique, duplicate in row %d";
     private final String referenceSource;
     private final BrAPIGermplasmDAO germplasmDAO;
     private final BrAPIObservationUnitDAO observationUnitDAO;
@@ -230,7 +231,7 @@ public class SampleSubmissionProcessor implements Processor {
             if (plateLayout[plateRow][plateCol] > 0) {
                 validationErrors.addError(rowNum,
                                           new ValidationError(SampleSubmissionImport.Columns.ROW + "/" + SampleSubmissionImport.Columns.COLUMN,
-                                                              String.format(MULTIPLE_SAMPLES_SINGLE_WELL, plateLayout[plateRow][plateCol], Character.toString('A' + plateRow), plateCol),
+                                                              String.format(MULTIPLE_SAMPLES_SINGLE_WELL, plateLayout[plateRow][plateCol]),
                                                               HttpStatus.UNPROCESSABLE_ENTITY));
             } else {
                 plateLayout[plateRow][plateCol] = rowNum;


### PR DESCRIPTION
# Description
[BI-2820](https://breedinginsight.atlassian.net/browse/BI-2820) Improve sample submission tabular error message

Update Error message (and pass in only one variable).


# Dependencies
bi-web: **develop**

# Testing

1. Import this `Genotype Samples`  file [sample_submission.csv](https://github.com/user-attachments/files/27249477/sample_submission.csv) (this assumes there is a valid Germplasm with GID=`1`)
2. THEN: The tabular error `Plate position not unique, duplicate in row 3 ` should appear.  
3. AND: The import should not happen.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2820]: https://breedinginsight.atlassian.net/browse/BI-2820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ