### PR TITLE
[BI-2806] Remove trials cache

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIStudiesController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIStudiesController.java
@@ -114,6 +114,7 @@ public class BrAPIStudiesController {
                 return ResponseUtils.getBrapiQueryResponse(authorizedStudies, studyQueryMapper, queryParams, searchRequest);
             }
 
+            // TODO: Instead of getting all studies for a program and filtering, doing the filtering on brapi side
             List<BrAPIStudy> studies = studyService.getStudies(programId)
                         .stream()
                         .peek(this::setDbIds)
@@ -169,10 +170,6 @@ public class BrAPIStudiesController {
 
     private void setDbIds(BrAPIStudy study) {
         study.studyDbId(Utilities.getExternalReference(study.getExternalReferences(), Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.STUDIES))
-                                 .orElseThrow(() -> new IllegalStateException("No BI external reference found"))
-                                 .getReferenceID());
-
-        study.trialDbId(Utilities.getExternalReference(study.getExternalReferences(), Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.TRIALS))
                                  .orElseThrow(() -> new IllegalStateException("No BI external reference found"))
                                  .getReferenceID());
 

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
@@ -26,6 +26,7 @@ import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import lombok.extern.slf4j.Slf4j;
 import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.core.response.BrAPITrialSingleResponse;
 import org.breedinginsight.api.auth.*;
@@ -158,6 +159,7 @@ public class BrAPITrialsController {
         return HttpResponse.notFound();
     }
 
+    // TODO: Remove for trialDbId once cache is removed for that entity
     private void setDbIds(BrAPITrial trial) {
         trial.trialDbId(Utilities.getExternalReference(trial.getExternalReferences(), Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.TRIALS))
                                  .orElseThrow(() -> new IllegalStateException("No BI external reference found"))

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
@@ -161,9 +161,6 @@ public class BrAPITrialsController {
 
     // TODO: Remove for trialDbId once cache is removed for that entity
     private void setDbIds(BrAPITrial trial) {
-        trial.trialDbId(Utilities.getExternalReference(trial.getExternalReferences(), Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.TRIALS))
-                                 .orElseThrow(() -> new IllegalStateException("No BI external reference found"))
-                                 .getReferenceID());
         trial.programDbId(Utilities.getExternalReference(trial.getExternalReferences(), Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS))
                                  .orElseThrow(() -> new IllegalStateException("No BI external reference found"))
                                  .getReferenceID());

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIStudyDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIStudyDAO.java
@@ -168,11 +168,7 @@ public class BrAPIStudyDAO extends BrAPICachedDAO<BrAPIStudy> {
     public List<BrAPIStudy> getStudiesByExperimentIds(@NotNull Collection<UUID> experimentIds, Program program) throws ApiException {
         BrAPIStudySearchRequest studySearch = new BrAPIStudySearchRequest();
         studySearch.programDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
-        // Add all experimentIds as xref ID search terms.
-        for (UUID experimentId : experimentIds) {
-            studySearch.addExternalReferenceIdsItem(experimentId.toString());
-        }
-        studySearch.addExternalReferenceSourcesItem(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.TRIALS));
+        studySearch.trialDbIds(experimentIds.stream().map(UUID::toString).collect(Collectors.toList()));
         StudiesApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), StudiesApi.class);
         return new ArrayList<>(processStudyForDisplay(brAPIDAOUtil.search(
                 api::searchStudiesPost,

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIStudyDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIStudyDAO.java
@@ -137,6 +137,7 @@ public class BrAPIStudyDAO extends BrAPICachedDAO<BrAPIStudy> {
     }
 
     public List<BrAPIStudy> getStudiesByExperimentID(@NotNull UUID experimentId, Program program) throws ApiException {
+        // TODO: This should look up on trialDbId, and the trialDbId should be passed thru
         BrAPIStudySearchRequest studySearch = new BrAPIStudySearchRequest();
         studySearch.programDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
         studySearch.addExternalReferenceIdsItem(experimentId.toString());

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
@@ -40,8 +40,6 @@ public interface BrAPITrialDAO {
 
     Optional<BrAPITrial> getTrialById(UUID programId, UUID trialId) throws ApiException, DoesNotExistException;
 
-    Optional<BrAPITrial> getTrialByDbId(String trialDbId, Program program) throws ApiException;
-
     List<BrAPITrial> getTrialsByDbIds(Collection<String> trialDbIds, Program program) throws ApiException;
 
     List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException;

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
@@ -45,6 +45,4 @@ public interface BrAPITrialDAO {
     List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException;
 
     void deleteBrAPITrial(Program program, BrAPITrial trial, boolean hard) throws ApiException;
-
-    void repopulateCache(UUID programId);
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -19,15 +19,17 @@ package org.breedinginsight.brapi.v2.dao.impl;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.http.server.exceptions.InternalServerException;
-import io.micronaut.scheduling.annotation.Scheduled;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
+import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.client.v2.model.queryParams.core.TrialQueryParams;
 import org.brapi.client.v2.modules.core.TrialsApi;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.core.request.BrAPITrialSearchRequest;
+import org.brapi.v2.model.core.response.BrAPITrialListResponse;
 import org.breedinginsight.brapi.v2.dao.BrAPITrialDAO;
 import org.breedinginsight.brapps.importer.daos.ImportDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
@@ -106,6 +108,37 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         return experimentById(processExperimentsForDisplay(programExperiments, program.getKey()));
     }
 
+    private List<BrAPITrial> getBrAPITrialsByBrAPIProgramId(Program program) throws ApiException {
+        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), TrialsApi.class);
+
+        ApiResponse<BrAPITrialListResponse> response;
+
+        // TODO: Configurable max amount of trials per program, or paginate.
+        int pageSize = 1000;
+
+        try {
+            TrialQueryParams trialQueryParams =
+                    TrialQueryParams.builder()
+                            .programDbId(program.getBrapiProgram().getProgramDbId())
+                            .pageSize(pageSize)
+                            .page(0)
+                            .build();
+
+            response = api.trialsGet(trialQueryParams);
+        } catch (ApiException e) {
+            log.warn(Utilities.generateApiExceptionLogMessage(e));
+            throw new InternalServerException("Error making BrAPI call", e);
+        }
+
+        if (response.getBody().getMetadata().getPagination().getTotalCount() > pageSize) {
+            throw new InternalServerException(String.format("More trials exist than requested [%s]", pageSize));
+        }
+
+        List<BrAPITrial> trialsFromResponse = response.getBody().getResult().getData();
+
+        return processExperimentsForDisplay(trialsFromResponse, program.getKey());
+    }
+
     private Map<String, BrAPITrial> experimentById(List<BrAPITrial> trials) {
         Map<String, BrAPITrial> experimentById = new HashMap<>();
         for (BrAPITrial experiment: trials) {
@@ -119,16 +152,13 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         return experimentById;
     }
 
-    // TODO: Fix by calling BrAPI trials get on brapiProgramDbId, then filter on names
     @Override
     public List<BrAPITrial> getTrialsByName(List<String> trialNames, Program program) throws ApiException {
-        Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
-        List<BrAPITrial> trials = new ArrayList<>();
-        if (cache != null) {
+        List<BrAPITrial> allTrialsForProgram = getBrAPITrialsByBrAPIProgramId(program);
 
-            // TODO: replace with more performant cache search, e.g. RediSearch
-            trials.addAll(cache
-                    .values()
+        List<BrAPITrial> trials = new ArrayList<>();
+        if (allTrialsForProgram != null) {
+            trials.addAll(allTrialsForProgram
                     .stream()
                     .filter(t -> trialNames.contains(t.getTrialName()))
                     .collect(Collectors.toList()));

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -80,21 +80,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         this.runScheduledTasks = runScheduledTasks;
     }
 
-
-    @Scheduled(initialDelay = "${startup.delay.trial}")
-    public void setup() {
-        if(!runScheduledTasks) {
-            return;
-        }
-
-        // Populate the experiment cache for all programs on startup
-        log.debug("populating experiment cache");
-        List<Program> programs = programDAO.getActive();
-        if (programs != null) {
-            programExperimentCache.populate(programs.stream().map(Program::getId).collect(Collectors.toList()));
-        }
-    }
-
+    // TODO: Can be removed once cache instance is gone
     private Map<String, BrAPITrial> fetchProgramExperiments(UUID programId) throws ApiException {
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
 
@@ -133,6 +119,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         return experimentById;
     }
 
+    // TODO: Fix by calling BrAPI trials get on brapiProgramDbId, then filter on names
     @Override
     public List<BrAPITrial> getTrialsByName(List<String> trialNames, Program program) throws ApiException {
         Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
@@ -150,31 +137,9 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         return trials;
     }
 
-    private List<BrAPITrial> getTrialsByExRef(String referenceSource, String referenceId, Program program) throws ApiException {
-        Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
-        List<BrAPITrial> trials = new ArrayList<>();
-        if (cache != null) {
-            trials.addAll(cache
-                    .values()
-                    .stream()
-                    .filter(t -> {
-                        BrAPIExternalReference xref = t
-                                .getExternalReferences()
-                                .stream()
-                                .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.TRIALS)
-                                        .equalsIgnoreCase(reference.getReferenceSource()))
-                                .findFirst().orElseThrow(() -> new IllegalStateException("No BI trial external reference found"));
-                        return referenceId.equals(xref.getReferenceID());
-                    })
-                    .collect(Collectors.toList()));
-        }
-
-        return trials;
-    }
-
+    // TODO: Fix by using only code of inner callback and returning result
     @Override
-    public List<BrAPITrial> createBrAPITrials(List<BrAPITrial> brAPITrialList, UUID programId, ImportUpload upload)
-            throws ApiException {
+    public List<BrAPITrial> createBrAPITrials(List<BrAPITrial> brAPITrialList, UUID programId, ImportUpload upload) {
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
         List<BrAPITrial> createdTrials = new ArrayList<>();
         try {
@@ -192,8 +157,10 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
             throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
         }
     }
+
+    // TODO: Fix by grabbing inner code of callback, removing callback and cache call, and return result from BrAPI call.
     @Override
-    public BrAPITrial updateBrAPITrial(String trialDbId, BrAPITrial trial, UUID programId) throws ApiException {
+    public BrAPITrial updateBrAPITrial(String trialDbId, BrAPITrial trial, UUID programId) {
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
         BrAPITrial updatedTrial = null;
         try {
@@ -215,6 +182,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         }
     }
 
+    // TODO: call getTrials endpoint using brapiProgramId
     @Override
     public List<BrAPITrial> getTrials(UUID programId) throws ApiException {
         return new ArrayList<>(programExperimentCache.get(programId).values());
@@ -232,6 +200,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         return displayExperiments;
     }
 
+    // TODO: Grab all trials for program, then filter on brapi trialDbID.  This will likely involve analyzing downstream usages to get brapiTrialId
     @Override
     public Optional<BrAPITrial> getTrialById(UUID programId, UUID trialId) throws ApiException, DoesNotExistException {
         Map<String, BrAPITrial> cache = programExperimentCache.get(programId);
@@ -243,12 +212,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         return Optional.ofNullable(trial);
     }
 
-    @Override
-    public Optional<BrAPITrial> getTrialByDbId(String trialDbId, Program program) throws ApiException {
-        List<BrAPITrial> trials = getTrialsByDbIds(List.of(trialDbId), program);
-        return Utilities.getSingleOptional(trials);
-    }
-
+    // TODO: Grab all trials for program, then filter on brapi trialDbID.  This will likely involve analyzing downstream usages to get brapiTrialId
     @Override
     public List<BrAPITrial> getTrialsByDbIds(Collection<String> trialDbIds, Program program) throws ApiException {
         Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
@@ -263,6 +227,8 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
 
         return trials;
     }
+
+    // TODO: Investigate what constitutes an experiment ID, and if it's the cache trialDbId, analyze downstream usages to get brapiTrialDbIds instead and submit them into this method
     @Override
     public List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException {
         if(experimentIds.isEmpty()) {
@@ -295,6 +261,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         brAPIDAOUtil.makeCall(brapiRequest);
     }
 
+    // TODO: Remove when trial cache is removed.
     @Override
     public void repopulateCache(UUID programId) {
         this.programExperimentCache.invalidate(programId);

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -265,18 +265,9 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
 
     @Override
     public List<BrAPITrial> getTrialsByDbIds(Collection<String> trialDbIds, Program program) throws ApiException {
-        // Lookup on trialDbIds directly in BrAPI
-        Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
-        List<BrAPITrial> trials = new ArrayList<>();
-        if (cache != null) {
-            trials.addAll(cache
-                    .values()
-                    .stream()
-                    .filter(t -> trialDbIds.contains(t.getTrialDbId()))
-                    .collect(Collectors.toList()));
-        }
+        Collection<UUID> trialDbUUIDs = trialDbIds.stream().map(UUID::fromString).collect(Collectors.toList());
 
-        return trials;
+        return getTrialsByExperimentIds(trialDbUUIDs, program);
     }
 
     // TODO: ExperimentIds will = trialDbIds once cache is updated.  Update this method to get trials on dbId directly from brapi.

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -27,6 +27,7 @@ import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.model.queryParams.core.TrialQueryParams;
 import org.brapi.client.v2.modules.core.TrialsApi;
 import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.core.BrAPIProgram;
 import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.core.request.BrAPITrialSearchRequest;
 import org.brapi.v2.model.core.response.BrAPITrialListResponse;
@@ -108,7 +109,25 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         return experimentById(processExperimentsForDisplay(programExperiments, program.getKey()));
     }
 
-    private List<BrAPITrial> getBrAPITrialsByBrAPIProgramId(Program program) throws ApiException {
+    /**
+     * This method requires a BI-API program.  If the BrAPIProgram inside this data model is not set,
+     * this method will retrieve it.
+     */
+    private List<BrAPITrial> getBrAPITrialsUsingBrAPIProgram(Program program) throws ApiException {
+
+        if (program == null || program.getId() == null) {
+            throw new InternalServerException("BI-API Program or Program ID is null");
+        }
+
+        String brapiProgramDbId = Optional.of(program)
+                .map(Program::getBrapiProgram)
+                .map(BrAPIProgram::getProgramDbId)
+                .orElse(null);
+
+        if (brapiProgramDbId == null) {
+            brapiProgramDbId = programDAO.getProgramBrAPI(program).getProgramDbId();
+        }
+
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), TrialsApi.class);
 
         ApiResponse<BrAPITrialListResponse> response;
@@ -119,7 +138,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         try {
             TrialQueryParams trialQueryParams =
                     TrialQueryParams.builder()
-                            .programDbId(program.getBrapiProgram().getProgramDbId())
+                            .programDbId(brapiProgramDbId)
                             .pageSize(pageSize)
                             .page(0)
                             .build();
@@ -154,7 +173,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
 
     @Override
     public List<BrAPITrial> getTrialsByName(List<String> trialNames, Program program) throws ApiException {
-        List<BrAPITrial> allTrialsForProgram = getBrAPITrialsByBrAPIProgramId(program);
+        List<BrAPITrial> allTrialsForProgram = getBrAPITrialsUsingBrAPIProgram(program);
 
         List<BrAPITrial> trials = new ArrayList<>();
         if (allTrialsForProgram != null) {
@@ -212,10 +231,12 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         }
     }
 
-    // TODO: call getTrials endpoint using brapiProgramId
     @Override
     public List<BrAPITrial> getTrials(UUID programId) throws ApiException {
-        return new ArrayList<>(programExperimentCache.get(programId).values());
+        Program program = programDAO.get(programId).get(0);
+        program.setBrapiProgram(programDAO.getProgramBrAPI(program));
+
+        return getBrAPITrialsUsingBrAPIProgram(program);
     }
 
     //Removes program key from trial name

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -26,7 +26,6 @@ import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.model.queryParams.core.TrialQueryParams;
 import org.brapi.client.v2.modules.core.TrialsApi;
-import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPIProgram;
 import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.core.request.BrAPITrialSearchRequest;
@@ -36,8 +35,6 @@ import org.breedinginsight.brapps.importer.daos.ImportDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.daos.ProgramDAO;
-import org.breedinginsight.daos.cache.ProgramCache;
-import org.breedinginsight.daos.cache.ProgramCacheProvider;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.services.ProgramService;
 import org.breedinginsight.services.brapi.BrAPIEndpointProvider;
@@ -48,14 +45,12 @@ import org.breedinginsight.utilities.Utilities;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.*;
-import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 @Slf4j
 @Context
 @Singleton
 public class BrAPITrialDAOImpl implements BrAPITrialDAO {
-    private final ProgramCache<BrAPITrial> programExperimentCache;
     private final ProgramDAO programDAO;
     private final ImportDAO importDAO;
     private final BrAPIDAOUtil brAPIDAOUtil;
@@ -65,15 +60,13 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
     private final boolean runScheduledTasks;
 
     @Inject
-    public BrAPITrialDAOImpl(ProgramCacheProvider programCacheProvider,
-                             ProgramDAO programDAO,
+    public BrAPITrialDAOImpl(ProgramDAO programDAO,
                              ImportDAO importDAO,
                              BrAPIDAOUtil brAPIDAOUtil,
                              ProgramService programService,
                              @Property(name = "brapi.server.reference-source") String referenceSource,
                              BrAPIEndpointProvider brAPIEndpointProvider,
                              @Property(name = "micronaut.bi.api.run-scheduled-tasks") boolean runScheduledTasks) {
-        this.programExperimentCache = programCacheProvider.getProgramCache(this::fetchProgramExperiments, BrAPITrial.class);
         this.programDAO = programDAO;
         this.importDAO = importDAO;
         this.brAPIDAOUtil = brAPIDAOUtil;
@@ -81,32 +74,6 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         this.referenceSource = referenceSource;
         this.brAPIEndpointProvider = brAPIEndpointProvider;
         this.runScheduledTasks = runScheduledTasks;
-    }
-
-    // TODO: Can be removed once cache instance is gone
-    private Map<String, BrAPITrial> fetchProgramExperiments(UUID programId) throws ApiException {
-        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
-
-        // Get the program
-        List<Program> programs = programDAO.get(programId);
-        if (programs.size() != 1) {
-            throw new InternalServerException("Program was not found for given key");
-        }
-        Program program = programs.get(0);
-
-        // Get the program experiments
-        BrAPITrialSearchRequest trialSearch = new BrAPITrialSearchRequest();
-        trialSearch.externalReferenceIDs(List.of(programId.toString()));
-        trialSearch.externalReferenceSources(
-                List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS))
-        );
-        List<BrAPITrial> programExperiments = brAPIDAOUtil.search(
-                api::searchTrialsPost,
-                api::searchTrialsSearchResultsDbIdGet,
-                trialSearch
-        );
-
-        return experimentById(processExperimentsForDisplay(programExperiments, program.getKey()));
     }
 
     /**
@@ -188,18 +155,8 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
     @Override
     public List<BrAPITrial> createBrAPITrials(List<BrAPITrial> brAPITrialList, UUID programId, ImportUpload upload) {
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
-        List<BrAPITrial> createdTrials = new ArrayList<>();
         try {
-            if (!brAPITrialList.isEmpty()) {
-                Callable<Map<String, BrAPITrial>> postCallback = () -> {
-                    List<BrAPITrial> postedTrials = brAPIDAOUtil
-                            .post(brAPITrialList, upload, api::trialsPost, importDAO::update);
-                    return experimentById(postedTrials);
-                };
-                createdTrials.addAll(programExperimentCache.post(programId, postCallback));
-            }
-
-            return createdTrials;
+            return brAPIDAOUtil.post(brAPITrialList, upload, api::trialsPost, importDAO::update);
         } catch (Exception e) {
             throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
         }
@@ -289,12 +246,5 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
                 .build();
 
         brAPIDAOUtil.makeCall(brapiRequest);
-    }
-
-    // TODO: Remove when trial cache is removed.
-    @Override
-    public void repopulateCache(UUID programId) {
-        this.programExperimentCache.invalidate(programId);
-        this.programExperimentCache.populate(programId);
     }
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -205,25 +205,11 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         }
     }
 
-    // TODO: Fix by grabbing inner code of callback, removing callback and cache call, and return result from BrAPI call.
     @Override
     public BrAPITrial updateBrAPITrial(String trialDbId, BrAPITrial trial, UUID programId) {
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
-        BrAPITrial updatedTrial = null;
         try {
-            if (trial != null && !trialDbId.isBlank()) {
-                Callable<Map<String, BrAPITrial>> putCallback = () -> {
-                    BrAPITrial putTrial = brAPIDAOUtil.put(trialDbId, trial, api::trialsTrialDbIdPut);
-                    return experimentById(List.of(putTrial));
-                };
-                List<BrAPITrial> cachedUpdates = programExperimentCache.post(programId, putCallback);
-                if (cachedUpdates.isEmpty()) {
-                    throw new Exception();
-                }
-                updatedTrial = cachedUpdates.get(0);
-            }
-
-            return updatedTrial;
+            return brAPIDAOUtil.put(trialDbId, trial, api::trialsTrialDbIdPut);
         } catch (Exception e) {
             throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
         }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -128,29 +128,32 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
             brapiProgramDbId = programDAO.getProgramBrAPI(program).getProgramDbId();
         }
 
+        // TODO: Configurable max amount of trials per program, or paginate.
+
+        TrialQueryParams trialQueryParams =
+                TrialQueryParams.builder()
+                        .programDbId(brapiProgramDbId)
+                        .pageSize(1000)
+                        .page(0)
+                        .build();
+
+        return getTrialsFromBrAPI(program, trialQueryParams);
+    }
+
+    private List<BrAPITrial> getTrialsFromBrAPI(Program program, TrialQueryParams trialQueryParams) throws ApiException {
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), TrialsApi.class);
 
         ApiResponse<BrAPITrialListResponse> response;
 
-        // TODO: Configurable max amount of trials per program, or paginate.
-        int pageSize = 1000;
-
         try {
-            TrialQueryParams trialQueryParams =
-                    TrialQueryParams.builder()
-                            .programDbId(brapiProgramDbId)
-                            .pageSize(pageSize)
-                            .page(0)
-                            .build();
-
             response = api.trialsGet(trialQueryParams);
         } catch (ApiException e) {
             log.warn(Utilities.generateApiExceptionLogMessage(e));
             throw new InternalServerException("Error making BrAPI call", e);
         }
 
-        if (response.getBody().getMetadata().getPagination().getTotalCount() > pageSize) {
-            throw new InternalServerException(String.format("More trials exist than requested [%s]", pageSize));
+        if (response.getBody().getMetadata().getPagination().getTotalCount() > trialQueryParams.pageSize()) {
+            throw new InternalServerException(String.format("More trials exist than requested [%s]", trialQueryParams));
         }
 
         List<BrAPITrial> trialsFromResponse = response.getBody().getResult().getData();
@@ -161,12 +164,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
     private Map<String, BrAPITrial> experimentById(List<BrAPITrial> trials) {
         Map<String, BrAPITrial> experimentById = new HashMap<>();
         for (BrAPITrial experiment: trials) {
-            BrAPIExternalReference xref = experiment
-                    .getExternalReferences()
-                    .stream()
-                    .filter(reference -> String.format("%s/%s", referenceSource, ExternalReferenceSource.TRIALS.getName()).equals(reference.getReferenceSource()))
-                    .findFirst().orElseThrow(() -> new IllegalStateException("No BI external reference found"));
-            experimentById.put(xref.getReferenceID(), experiment);
+            experimentById.put(experiment.getTrialDbId(), experiment);
         }
         return experimentById;
     }
@@ -251,21 +249,23 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         return displayExperiments;
     }
 
-    // TODO: Grab all trials for program, then filter on brapi trialDbID.  This will likely involve analyzing downstream usages to get brapiTrialId
     @Override
     public Optional<BrAPITrial> getTrialById(UUID programId, UUID trialId) throws ApiException, DoesNotExistException {
-        Map<String, BrAPITrial> cache = programExperimentCache.get(programId);
-        BrAPITrial trial = null;
-        if (cache != null) {
-            trial = cache.get(trialId.toString());
-        }
+        Program program = programDAO.get(programId).get(0);
 
-        return Optional.ofNullable(trial);
+        TrialQueryParams params = TrialQueryParams.builder()
+                .trialDbId(trialId.toString())
+                .pageSize(1)
+                .page(0)
+                .build();
+
+
+        return getTrialsFromBrAPI(program, params).stream().findFirst();
     }
 
-    // TODO: Grab all trials for program, then filter on brapi trialDbID.  This will likely involve analyzing downstream usages to get brapiTrialId
     @Override
     public List<BrAPITrial> getTrialsByDbIds(Collection<String> trialDbIds, Program program) throws ApiException {
+        // Lookup on trialDbIds directly in BrAPI
         Map<String, BrAPITrial> cache = programExperimentCache.get(program.getId());
         List<BrAPITrial> trials = new ArrayList<>();
         if (cache != null) {
@@ -279,16 +279,18 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         return trials;
     }
 
-    // TODO: Investigate what constitutes an experiment ID, and if it's the cache trialDbId, analyze downstream usages to get brapiTrialDbIds instead and submit them into this method
+    // TODO: ExperimentIds will = trialDbIds once cache is updated.  Update this method to get trials on dbId directly from brapi.
     @Override
     public List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException {
         if(experimentIds.isEmpty()) {
             return Collections.emptyList();
         }
+
+        List<String> experimentIdsAsStrings = experimentIds.stream().map(UUID::toString).collect(Collectors.toList());
+
         BrAPITrialSearchRequest trialSearch = new BrAPITrialSearchRequest();
         trialSearch.programDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
-        trialSearch.externalReferenceSources(List.of(referenceSource + "/" + ExternalReferenceSource.TRIALS.getName()));
-        trialSearch.externalReferenceIds(experimentIds.stream().map(UUID::toString).collect(Collectors.toList()));
+        trialSearch.trialDbIds(experimentIdsAsStrings);
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), TrialsApi.class);
         return processExperimentsForDisplay(brAPIDAOUtil.search(
                 api::searchTrialsPost,

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -185,10 +185,13 @@ public class BrAPITrialService {
         // add columns for requested dataset obsvars and timestamps
         log.debug(logHash + ": fetching experiment for export");
         BrAPITrial experiment = getExperiment(program, experimentId);
+        String expExRefId = Utilities.getExternalReference(experiment.getExternalReferences(), this.referenceSource, ExternalReferenceSource.TRIALS)
+                .map(BrAPIExternalReference::getReferenceId)
+                .orElse(null);
 
         // get requested environments for the experiment
         log.debug(logHash + ": fetching environments for export");
-        List<BrAPIStudy> expStudies = studyDAO.getStudiesByExperimentID(experimentId, program);
+        List<BrAPIStudy> expStudies = studyDAO.getStudiesByExperimentID(UUID.fromString(expExRefId), program);
         if (!requestedEnvIds.isEmpty()) {
             expStudies = expStudies
                     .stream()

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -823,8 +823,6 @@ public class BrAPITrialService {
                 listDAO.deleteBrAPIList(list.getListDbId(), program.getId(), hard);
             }
             // TODO: if performance is poor, implement more precise invalidation, possibly using hierarchical cache keys.
-            // Invalidate and repopulate cache for Trial, Study, Observation, ObservationUnit.
-            trialDAO.repopulateCache(program.getId());
             studyDAO.repopulateCache(program.getId());
             observationDAO.repopulateCache(program.getId());
             observationUnitDAO.repopulateCache(program.getId());

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -121,6 +121,7 @@ public class BrAPITrialService {
     }
 
     public List<BrAPITrial> getExperiments(UUID programId) throws ApiException, DoesNotExistException {
+        // TODO: Edit this to filter/paginate trials
         return trialDAO.getTrials(programId);
     }
 

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -792,17 +792,27 @@ public class BrAPITrialService {
         }
         BrAPITrial trial = trials.get(0);
 
+        UUID exRefId = Utilities.getExternalReference(trial.getExternalReferences(), referenceSource, ExternalReferenceSource.TRIALS)
+                .map(BrAPIExternalReference::getReferenceId)
+                .map(UUID::fromString)
+                .orElse(null);
+
+        if (exRefId == null) {
+            throw new InternalServerException(String.format("Experiment with UUID [%s] does not have TRIALS exref", experimentId));
+        }
+
         List<BrAPIObservation> existingObservations = observationDAO.getObservationsByTrialDbId(List.of(trial.getTrialDbId()), program);
         // If there are no observations or a soft delete is requested, proceed.
         if (existingObservations.isEmpty() || !hard) {
             // Make request to delete experiment.
             trialDAO.deleteBrAPITrial(program, trial, hard);
             // Get all lists for the trial.
+            // TODO: Get lists by trialDbId if trials get decoupled from datasets.
             List<BrAPIListSummary> lists = listDAO
                     .getListsByTypeAndExternalRef(BrAPIListTypes.OBSERVATIONVARIABLES,
                             program.getId(),
                             Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.TRIALS),
-                            experimentId);
+                            exRefId);
             // TODO: replace with a single call to a batch delete method if that becomes available.
             // Iterate over lists, delete each by listDbId.
             for (BrAPIListSummary list : lists) {

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -190,6 +190,10 @@ public class BrAPITrialService {
                 .map(BrAPIExternalReference::getReferenceId)
                 .orElse(null);
 
+        if (expExRefId == null) {
+            throw new InternalServerException(String.format("Trials exref does not exist for experiment [%s]",  experimentId));
+        }
+
         // get requested environments for the experiment
         log.debug(logHash + ": fetching environments for export");
         List<BrAPIStudy> expStudies = studyDAO.getStudiesByExperimentID(UUID.fromString(expExRefId), program);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/CommitPendingImportObjectsStep.java
@@ -208,9 +208,14 @@ public class CommitPendingImportObjectsStep {
             // set the DbId to the for each newly created trial
             for (BrAPITrial createdTrial : createdTrials) {
                 String createdTrialName = Utilities.removeProgramKey(createdTrial.getTrialName(), program.getKey());
+
+
                 trialByNameNoScope.get(createdTrialName)
                         .getBrAPIObject()
                         .setTrialDbId(createdTrial.getTrialDbId());
+                // TODO: May need to set the main ID for pending objects with the BrAPI ID for downstream usage once cache is removed.
+                trialByNameNoScope.get(createdTrialName)
+                        .setId(UUID.fromString(createdTrial.getTrialDbId()));
             }
 
             List<ProgramLocation> createdLocations = new ArrayList<>(locationService.create(actingUser, program.getId(), newLocations));

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/PopulateExistingPendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/PopulateExistingPendingImportObjectsStep.java
@@ -198,9 +198,21 @@ public class PopulateExistingPendingImportObjectsStep {
         List<BrAPIStudy> existingStudies;
         Optional<PendingImportObject<BrAPITrial>> trial = getTrialPIO(experimentImportRows, trialByNameNoScope);
 
+        String expExRefId = Utilities.getExternalReference(trial.get()
+                .getBrAPIObject()
+                .getExternalReferences(), BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS)
+                .map(BrAPIExternalReference::getReferenceId)
+                .orElse(null);
+
+        if (expExRefId == null) {
+            String logMessage = "No exref found in trial to link trial to study";
+            log.error(logMessage);
+            throw new InternalServerException(logMessage);
+        }
+
         try {
             // the 'trial' variable will never be "null".
-            UUID experimentId = trial.get().getId();
+            UUID experimentId = UUID.fromString(expExRefId);
             existingStudies = brAPIStudyDAO.getStudiesByExperimentID(experimentId, program);
             for (BrAPIStudy existingStudy : existingStudies) {
                 experimentStudyService.processAndCacheStudy(existingStudy, program, BrAPIStudy::getStudyName, studyByName);

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/TrialService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/service/TrialService.java
@@ -273,11 +273,7 @@ public class TrialService {
             Program program,
             Map<String, PendingImportObject<BrAPITrial>> trialByNameNoScope) {
 
-        //get TrialId from existingTrial
-        BrAPIExternalReference experimentIDRef = Utilities.getExternalReference(existingTrial.getExternalReferences(),
-                        String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()))
-                .orElseThrow(() -> new InternalServerException("An Experiment ID was not found in any of the external references"));
-        UUID experimentId = UUID.fromString(experimentIDRef.getReferenceId());
+        UUID experimentId = UUID.fromString(existingTrial.getTrialDbId());
 
         trialByNameNoScope.put(
                 Utilities.removeProgramKey(existingTrial.getTrialName(), program.getKey()),
@@ -288,20 +284,14 @@ public class TrialService {
      * Constructs a PendingImportObject containing a BrAPITrial object based on the input BrAPITrial.
      *
      * This function takes a BrAPITrial object as input and constructs a PendingImportObject which
-     * encapsulates the trial along with its associated experiment ID. The experiment ID is retrieved
-     * from the external references of the trial object using utility method getExternalReference.
-     * If the experiment ID is not found in the external references, an InternalServerException is thrown.
+     * encapsulates the trial along with its associated experiment ID, which is the trialDbId from the BrAPI DB.
      *
      * @param trial the BrAPITrial object for which the PendingImportObject is to be constructed
      * @return a PendingImportObject containing the BrAPITrial object and its associated experiment ID
-     * @throws InternalServerException if the experiment ID is not found in the external references of the trial
      */
-    public PendingImportObject<BrAPITrial> constructPIOFromBrapiTrial(BrAPITrial trial) throws InternalServerException {
-        PendingImportObject<BrAPITrial> pio = null;
-        BrAPIExternalReference experimentIDRef = Utilities.getExternalReference(trial.getExternalReferences(),
-                        String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()))
-                .orElseThrow(() -> new InternalServerException("An Experiment ID was not found in any of the external references"));
-        UUID experimentId = UUID.fromString(experimentIDRef.getReferenceId());
+    public PendingImportObject<BrAPITrial> constructPIOFromBrapiTrial(BrAPITrial trial) {
+        PendingImportObject<BrAPITrial> pio;
+        UUID experimentId = UUID.fromString(trial.getTrialDbId());
         pio = new PendingImportObject<>(ImportObjectState.EXISTING, trial, experimentId);
         return pio;
     }

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/services/ExperimentTrialService.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/services/ExperimentTrialService.java
@@ -149,11 +149,7 @@ public class ExperimentTrialService {
             Program program,
             Map<String, PendingImportObject<BrAPITrial>> trialByNameNoScope) {
 
-        //get TrialId from existingTrial
-        BrAPIExternalReference experimentIDRef = Utilities.getExternalReference(existingTrial.getExternalReferences(),
-                        String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()))
-                .orElseThrow(() -> new InternalServerException("An Experiment ID was not found in any of the external references"));
-        UUID experimentId = UUID.fromString(experimentIDRef.getReferenceId());
+        UUID experimentId = UUID.fromString(existingTrial.getTrialDbId());
 
         trialByNameNoScope.put(
                 Utilities.removeProgramKey(existingTrial.getTrialName(), program.getKey()),

--- a/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
@@ -95,6 +95,8 @@ public class ExperimentControllerIntegrationTest extends BrAPITest {
     private ProgramUserDAO programUserDAO;
     @Inject
     private RoleDao roleDao;
+    @Inject
+    private BrAPITrialService brAPITrialService;
 
     @Inject
     @Client("/${micronaut.bi.api.version}")
@@ -201,12 +203,11 @@ public class ExperimentControllerIntegrationTest extends BrAPITest {
                 program,
                 mappingId,
                 newExperimentWorkflowId);
-        experimentId = importResult
-                .get("preview").getAsJsonObject()
-                .get("rows").getAsJsonArray()
-                .get(0).getAsJsonObject()
-                .get("trial").getAsJsonObject()
-                .get("id").getAsString();
+
+        BrAPITrial trial = brAPITrialService.getExperiments(program.getId()).get(0);
+
+        experimentId = trial.getTrialDbId();
+
         // Add environmentIds.
         envIds.add(getEnvId(importResult, 0));
         envIds.add(getEnvId(importResult, 1));

--- a/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
@@ -235,7 +235,7 @@ public class ExperimentControllerIntegrationTest extends BrAPITest {
         expRows.add(row2);
 
         // Import test experiment, environments.
-        JsonObject importResult = importTestUtils.uploadAndFetchWorkflow(
+        importTestUtils.uploadAndFetchWorkflow(
                 writeDataToFile(expRows, null),
                 null,
                 true,
@@ -243,14 +243,14 @@ public class ExperimentControllerIntegrationTest extends BrAPITest {
                 targetProgram,
                 mappingId,
                 newExperimentWorkflowId);
-        String expId = importResult
-                .get("preview").getAsJsonObject()
-                .get("rows").getAsJsonArray()
-                .get(0).getAsJsonObject()
-                .get("trial").getAsJsonObject()
-                .get("id").getAsString();
 
-        return expId;
+        BrAPITrial trial = brAPITrialService.getExperiments(targetProgram.getId())
+                .stream()
+                .filter(t -> t.getTrialName().equals(title))
+                .findFirst()
+                .orElseThrow();
+
+        return trial.getTrialDbId();
     }
 
     /**
@@ -930,7 +930,7 @@ public class ExperimentControllerIntegrationTest extends BrAPITest {
     private String uploadExperimentWithObs(Program targetProgram, String title, List<Map<String, Object>> expRows) throws Exception {
         ImportTestUtils importTestUtils = new ImportTestUtils();
 
-        JsonObject importResult = importTestUtils.uploadAndFetchWorkflow(
+        importTestUtils.uploadAndFetchWorkflow(
                 importTestUtils.writeExperimentDataToFile(expRows, traits, false, false, null),
                 null,
                 true,
@@ -939,12 +939,13 @@ public class ExperimentControllerIntegrationTest extends BrAPITest {
                 mappingId,
                 newExperimentWorkflowId);
 
-        return importResult
-                .get("preview").getAsJsonObject()
-                .get("rows").getAsJsonArray()
-                .get(0).getAsJsonObject()
-                .get("trial").getAsJsonObject()
-                .get("id").getAsString();
+        BrAPITrial trial = brAPITrialService.getExperiments(targetProgram.getId())
+                .stream()
+                .filter(t -> t.getTrialName().equals(title))
+                .findFirst()
+                .orElseThrow();
+
+        return trial.getTrialDbId();
     }
 
     private List<Map<String, Object>> buildSubEntityRows(List<Map<String, Object>> topLevelRows, String entityName, int repeatedMeasures) {

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPITestUtils.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPITestUtils.java
@@ -30,6 +30,7 @@ import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.netty.cookies.NettyCookie;
 import io.reactivex.Flowable;
 import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.breedinginsight.TestUtils;
 import org.breedinginsight.api.auth.AuthenticatedUser;
@@ -37,6 +38,7 @@ import org.breedinginsight.api.model.v1.request.ProgramRequest;
 import org.breedinginsight.api.model.v1.request.SpeciesRequest;
 import org.breedinginsight.api.v1.controller.TestTokenValidator;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
+import org.breedinginsight.brapi.v2.services.BrAPITrialService;
 import org.breedinginsight.brapps.importer.ImportTestUtils;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
 import org.breedinginsight.dao.db.enums.DataType;
@@ -56,6 +58,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static io.micronaut.http.HttpRequest.GET;
 
@@ -75,6 +78,8 @@ public class BrAPITestUtils {
     private OntologyService ontologyService;
     @Inject
     private BrAPIGermplasmDAO germplasmDAO;
+    @Inject
+    private BrAPITrialService brAPITrialService;
 
     @Inject
     @Client("/${micronaut.bi.api.version}")
@@ -184,12 +189,6 @@ public class BrAPITestUtils {
                 program,
                 mappingId,
                 newExperimentWorkflowId);
-        String experiment1Id = importResult
-                .get("preview").getAsJsonObject()
-                .get("rows").getAsJsonArray()
-                .get(0).getAsJsonObject()
-                .get("trial").getAsJsonObject()
-                .get("id").getAsString();
 
         // Import test experiment, environments, and any observations
         importResult = importTestUtils.uploadAndFetchWorkflow(
@@ -200,12 +199,15 @@ public class BrAPITestUtils {
                 program,
                 mappingId,
                 newExperimentWorkflowId);
-        String experiment2Id = importResult
-                .get("preview").getAsJsonObject()
-                .get("rows").getAsJsonArray()
-                .get(0).getAsJsonObject()
-                .get("trial").getAsJsonObject()
-                .get("id").getAsString();
+
+        List<BrAPITrial> trials = brAPITrialService.getExperiments(program.getId())
+                .stream()
+                // Ensure trial with title xyz is always second
+                .sorted(Comparator.comparing(BrAPITrial::getTrialName))
+                .collect(Collectors.toList());
+
+        String experiment1Id = trials.get(0).getTrialDbId();
+        String experiment2Id = trials.get(1).getTrialDbId();
 
         // Refetch collaborator, since we updated program_user_roles.
         collaborator = userDAO.getUserByOAuthId(TestTokenValidator.OTHER_TEST_USER_ORCID).orElseThrow(Exception::new);

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPITrialsControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPITrialsControllerIntegrationTest.java
@@ -28,6 +28,7 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import org.brapi.v2.model.core.BrAPITrial;
 import org.breedinginsight.BrAPITest;
+import org.breedinginsight.brapi.v2.services.BrAPITrialService;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.model.*;
 import org.breedinginsight.utilities.Utilities;
@@ -58,6 +59,9 @@ public class BrAPITrialsControllerIntegrationTest extends BrAPITest {
 
     @Inject
     private BrAPITestUtils brAPITestUtils;
+
+    @Inject
+    private BrAPITrialService brAPIITrialService;
 
     private final Gson gson = new GsonBuilder().registerTypeAdapter(OffsetDateTime.class, (JsonDeserializer<OffsetDateTime>)
                     (json, type, context) -> OffsetDateTime.parse(json.getAsString()))
@@ -98,16 +102,17 @@ public class BrAPITrialsControllerIntegrationTest extends BrAPITest {
 
         // Check names and experimentIds (the BI-assigned UUID stored as an xref).
         List<String> expNames = new ArrayList<>();
-        List<String> expIds = new ArrayList<>();
+        List<String> trialExRefIds = new ArrayList<>();
         for (BrAPITrial trial : trials) {
             String experimentId = Utilities.getExternalReference(trial.getExternalReferences(), source).get().getReferenceId();
-            expIds.add(experimentId);
+            trialExRefIds.add(experimentId);
             expNames.add(trial.getTrialName());
         }
         assert(expNames.contains("xyz"));
         assert(expNames.contains("Test Exp"));
-        assert(expIds.contains(experiment1Id));
-        assert(expIds.contains(experiment2Id));
+        // Verify two different bi-api ex ref ids were generated for each trial
+        assertEquals(2 , trialExRefIds.size());
+        assertNotEquals(trialExRefIds.get(0), trialExRefIds.get(1));
     }
 
     /**
@@ -129,9 +134,7 @@ public class BrAPITrialsControllerIntegrationTest extends BrAPITest {
         assertEquals(1, trials.size());
         BrAPITrial trial = gson.fromJson(trials.get(0).getAsJsonObject(), BrAPITrial.class);
         assertEquals("xyz", trial.getTrialName());
-        String source = Utilities.generateReferenceSource(BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS);
-        String experimentId = Utilities.getExternalReference(trial.getExternalReferences(), source).get().getReferenceId();
-        assertEquals(this.experiment2Id, experimentId);
+        assertEquals(this.experiment2Id, trial.getTrialDbId());
     }
 
 }

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ObservationVariableControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ObservationVariableControllerIntegrationTest.java
@@ -31,6 +31,7 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import lombok.SneakyThrows;
 import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.pheno.BrAPIObservationVariable;
 import org.breedinginsight.BrAPITest;
@@ -40,6 +41,7 @@ import org.breedinginsight.api.model.v1.request.ProgramRequest;
 import org.breedinginsight.api.model.v1.request.SpeciesRequest;
 import org.breedinginsight.api.v1.controller.TestTokenValidator;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
+import org.breedinginsight.brapi.v2.services.BrAPITrialService;
 import org.breedinginsight.brapps.importer.ImportTestUtils;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
 import org.breedinginsight.dao.db.enums.DataType;
@@ -88,6 +90,8 @@ public class BrAPIV2ObservationVariableControllerIntegrationTest extends BrAPITe
     private OntologyService ontologyService;
     @Inject
     private BrAPIGermplasmDAO germplasmDAO;
+    @Inject
+    BrAPITrialService brAPITrialService;
 
     @Inject
     @Client("/${micronaut.bi.api.version}")
@@ -195,12 +199,15 @@ public class BrAPIV2ObservationVariableControllerIntegrationTest extends BrAPITe
                 program,
                 mappingId,
                 newExperimentWorkflowId);
-        experimentId = importResult
-                .get("preview").getAsJsonObject()
-                .get("rows").getAsJsonArray()
-                .get(0).getAsJsonObject()
-                .get("trial").getAsJsonObject()
-                .get("id").getAsString();
+
+        BrAPITrial trial = brAPITrialService.getExperiments(program.getId())
+                .stream()
+                .findFirst()
+                .orElseThrow();
+
+        experimentId = trial.getTrialDbId();
+
+
         // Add environmentIds.
         envIds.add(getEnvId(importResult, 0));
         envIds.add(getEnvId(importResult, 1));

--- a/src/test/java/org/breedinginsight/brapi/v2/SubEntityDatasetLockIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/SubEntityDatasetLockIntegrationTest.java
@@ -10,7 +10,9 @@ import io.micronaut.http.client.RxHttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
+import org.brapi.v2.model.core.BrAPITrial;
 import org.breedinginsight.BrAPITest;
+import org.breedinginsight.brapi.v2.services.BrAPITrialService;
 import org.breedinginsight.model.Program;
 import org.junit.jupiter.api.*;
 
@@ -35,6 +37,9 @@ public class SubEntityDatasetLockIntegrationTest extends BrAPITest {
     private BrAPITestUtils brAPITestUtils;
 
     @Inject
+    BrAPITrialService brAPIITrialService;
+
+    @Inject
     @Client("/${micronaut.bi.api.version}")
     private RxHttpClient client;
 
@@ -46,7 +51,10 @@ public class SubEntityDatasetLockIntegrationTest extends BrAPITest {
     void setup() throws Exception {
         var setup = brAPITestUtils.setupTestProgram(super.getBrapiDsl(), gson);
         program = setup.getV1();
-        experimentId = setup.getV2().get(0);
+        experimentId = brAPIITrialService.getExperiments(program.getId()).stream()
+                .map(BrAPITrial::getTrialDbId)
+                .findFirst()
+                .orElseThrow();
     }
 
     @Test

--- a/src/test/java/org/breedinginsight/brapi/v2/services/BrAPITrialServiceUnitTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/services/BrAPITrialServiceUnitTest.java
@@ -35,6 +35,7 @@ import org.breedinginsight.services.exceptions.DoesNotExistException;
 import org.breedinginsight.services.TraitService;
 import org.breedinginsight.services.lock.DistributedLockService;
 import org.breedinginsight.utilities.FileUtil;
+import org.breedinginsight.utilities.Utilities;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.api.Table;
@@ -120,6 +121,12 @@ class BrAPITrialServiceUnitTest {
         JsonObject experimentInfo = new JsonObject();
         experimentInfo.addProperty(BrAPIAdditionalInfoFields.EXPERIMENT_TYPE, "Phenotyping");
         experiment.setAdditionalInfo(experimentInfo);
+
+        BrAPIExternalReference externalReference = new BrAPIExternalReference();
+        externalReference.setReferenceSource(Utilities.generateReferenceSource(REFERENCE_SOURCE, ExternalReferenceSource.TRIALS));
+        externalReference.setReferenceId("11111111-1111-1111-1111-111111111111");
+
+        experiment.setExternalReferences(List.of(externalReference));
 
         study = new BrAPIStudy();
         study.setStudyDbId("study-1");

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -327,12 +327,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         newExp.put(Columns.COLUMN, "1");
 
         JsonObject importResponse = importTestUtils.uploadAndFetchWorkflow(importTestUtils.writeExperimentDataToFile(List.of(newExp), null, false, false, null), null, true, client, program, mappingId, newExperimentWorkflowId);
-        String expId = importResponse
-                .get("preview").getAsJsonObject()
-                .get("rows").getAsJsonArray()
-                .get(0).getAsJsonObject()
-                .get("trial").getAsJsonObject()
-                .get("id").getAsString();
+        String expId = brAPITrialDAO.getTrialsByName(List.of(newExp.get(Columns.EXP_TITLE).toString()), program).get(0).getTrialDbId();
 
         // Create two sub-entity datasets that have two different sub entity units
         Flowable<HttpResponse<String>> sub1PostCall = client.exchange(

--- a/src/test/java/org/breedinginsight/brapps/importer/SampleSubmissionFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/SampleSubmissionFileImportTest.java
@@ -45,6 +45,7 @@ import org.breedinginsight.api.model.v1.request.ProgramRequest;
 import org.breedinginsight.api.model.v1.request.SpeciesRequest;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapi.v2.dao.*;
+import org.breedinginsight.brapi.v2.services.BrAPITrialService;
 import org.breedinginsight.brapps.importer.daos.*;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
 import org.breedinginsight.brapps.importer.model.imports.sample.SampleSubmissionImport.Columns;
@@ -142,6 +143,9 @@ public class SampleSubmissionFileImportTest extends BrAPITest {
 
     @Inject
     private SampleSubmissionService sampleSubmissionService;
+
+    @Inject
+    BrAPITrialService brAPITrialService;
 
     private Gson gson = new GsonBuilder().registerTypeAdapter(OffsetDateTime.class, (JsonDeserializer<OffsetDateTime>)
                                                  (json, type, context) -> OffsetDateTime.parse(json.getAsString()))
@@ -567,7 +571,7 @@ public class SampleSubmissionFileImportTest extends BrAPITest {
                 .getAsJsonArray("data")
                 .get(0).getAsJsonObject().get("id").getAsString();
 
-        JsonObject importResult = importTestUtils.uploadAndFetchWorkflow(
+        importTestUtils.uploadAndFetchWorkflow(
                 importTestUtils.writeExperimentDataToFile(List.of(makeExpImportRow("Env1")), null, false, false, null),
                 null,
                 true,
@@ -575,12 +579,23 @@ public class SampleSubmissionFileImportTest extends BrAPITest {
                 program,
                 expMappingId,
                 newExperimentWorkflowId);
-        return importResult
-                .get("preview").getAsJsonObject()
-                .get("rows").getAsJsonArray()
-                .get(0).getAsJsonObject()
-                .get("trial").getAsJsonObject()
-                .get("id").getAsString();
+
+
+        String result;
+
+        try {
+            // Assumes only one trial/experiment exists
+            BrAPITrial trial = brAPITrialService.getExperiments(program.getId())
+                    .stream()
+                    .findFirst()
+                    .orElseThrow();
+
+            result = trial.getTrialDbId();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return result;
     }
 
     private Map<String, Object> makeExpImportRow(String environment) {


### PR DESCRIPTION
# Description
**Story:** [BI-2806](https://breedinginsight.atlassian.net/browse/BI-2806)

The body of changes in this MR effectively removes the cache implementation for BrAPITrials in bi-api.

There's quite a lot in here, so I'll try to sum up the important areas:

BrAPITrialDAOImpl was edited to
- Retrieve trials by ID via brapi trialDbId
- getTrialMethods updated utilize above method
- createTrials uses brapi post with no update to the cache
- updateTrial uses brapi put with no update to the cache
- deleteTrial uses brapi delete with no update to the cache
- repopulateCache method and usages deleted
- fetch method deleted which grabbed all trials for a program from brapi whenever post, put, delete was made
- Trial cache removed.

Various entities in need of relation to a trial were updated to use the bi-api generated trial ex ref id from the trial itself like Study, List.  These can be changed after the cache is removed

Fixed some instances where certain controllers automatically updated the BrAPITrialDbId in the entity to the bi generated id, which was breaking compatability.

Unit tests were updated to support the changes.  Many of these unit tests depended on the bi-api generated uuid from the workflow response to pass through to methods which validated everything.  This doesn't really work with the cache gone for trials because now it needs to validate on the trialDbId for the created record.  Tests have been updated to grab these IDs from the brapiDb once the workflows complete.

# Dependencies
[bi-web](https://github.com/Breeding-Insight/bi-web/pull/466)

# Testing
Regression on just about anything Experiment related, including:

- Experiment creation
- Experiment deletion
- Experiment updates
- Experiment Collaborator checks
- Experiment viewing
- Dataset viewing
- Dataset creation
- Dataset appending

Verify there are no log messages related to caching trials for a program by looking at logs once above tests have been completed.
# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2806]: https://breedinginsight.atlassian.net/browse/BI-2806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ