### PR TITLE
BI-2860 - Experimental Collaborators able to create sub entity datasets

### DIFF
--- a/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
@@ -122,7 +122,7 @@ public class ExperimentController {
      * @return An HttpResponse with a Response object containing the newly created Dataset.
      */
     @Post("/${micronaut.bi.api.version}/programs/{programId}/experiments/{experimentId}/dataset")
-    @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.PROGRAM_SCOPED_ROLES})
+    @ProgramSecured(roles = {ProgramSecuredRole.PROGRAM_ADMIN})
     @Produces(MediaType.APPLICATION_JSON)
     public HttpResponse<Response<Dataset>> createSubEntityDataset(
             @PathVariable("programId") UUID programId,

--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -57,12 +57,10 @@ public class Germplasm implements BrAPIObject {
     private String germplasmName;
 
     @ImportFieldType(type= ImportFieldTypeEnum.TEXT)
-    @ImportMappingRequired
     @ImportFieldMetadata(id="breedingMethod", name="Breeding Method", description = "The breeding method name or code")
     private String breedingMethod;
 
     @ImportFieldType(type= ImportFieldTypeEnum.TEXT)
-    @ImportMappingRequired
     @ImportFieldMetadata(id="germplasmSource", name="Source", description = "The germplasm origin. If External UID present, assumed to be the source associated with the External UID.")
     private String germplasmSource;
 
@@ -165,7 +163,8 @@ public class Germplasm implements BrAPIObject {
      * @param updatePedigree flag indicating if pedigree should be updated
      * @return mutated indicator
      */
-    public boolean updateBrAPIGermplasm(BrAPIGermplasm germplasm, Program program, UUID listId, boolean commit, boolean updatePedigree) {
+     public boolean updateBrAPIGermplasm(BrAPIGermplasm germplasm, Program program, UUID listId, boolean commit,
+                                         boolean updatePedigree, ProgramBreedingMethodEntity breedingMethod) {
 
         boolean mutated = false;
 
@@ -184,6 +183,27 @@ public class Germplasm implements BrAPIObject {
             }
             mutated = true;
         }
+
+         // Append Source only when DB value is blank
+         if (StringUtils.isBlank(germplasm.getSeedSource()) && StringUtils.isNotBlank(getGermplasmSource())) {
+             germplasm.setSeedSource(getGermplasmSource());
+             mutated = true;
+         }
+
+         // Append Breeding Method only when DB field is blank
+         if (breedingMethod != null) {
+             boolean hasBreedingMethodId = hasDateInAdditionalInfo(germplasm, BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD_ID);
+             boolean hasBreedingMethodName = hasDateInAdditionalInfo(germplasm, BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD);
+
+             if (!hasBreedingMethodId) {
+                 germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD_ID, breedingMethod.getId().toString());
+                 mutated = true;
+             }
+             if (!hasBreedingMethodName) {
+                 germplasm.putAdditionalInfoItem(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD, breedingMethod.getName());
+                 mutated = true;
+             }
+         }
 
         // Append synonyms to germplasm that don't already exist
         // Synonym comparison is based on name and type
@@ -211,6 +231,14 @@ public class Germplasm implements BrAPIObject {
         return mutated;
     }
 
+    //Method to check whether breeding method already exists in DB additionalInfo
+    private boolean hasDateInAdditionalInfo(BrAPIGermplasm germplasm, String key) {
+        JsonObject additionalInfo = germplasm.getAdditionalInfo();
+        return additionalInfo != null
+                && additionalInfo.has(key)
+                && !additionalInfo.get(key).isJsonNull()
+                && StringUtils.isNotBlank(additionalInfo.get(key).getAsString());
+    }
 
     public void setUpdateCommitFields(BrAPIGermplasm germplasm, String programKey) {
 

--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -158,12 +158,11 @@ public class Germplasm implements BrAPIObject {
      *
      * @param germplasm germplasm object
      * @param program program
-     * @param listId list id
      * @param commit flag indicating if commit changes should be made
      * @param updatePedigree flag indicating if pedigree should be updated
      * @return mutated indicator
      */
-     public boolean updateBrAPIGermplasm(BrAPIGermplasm germplasm, Program program, UUID listId, boolean commit,
+     public boolean updateBrAPIGermplasm(BrAPIGermplasm germplasm, Program program, boolean commit,
                                          boolean updatePedigree, ProgramBreedingMethodEntity breedingMethod) {
 
         boolean mutated = false;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/SampleSubmissionProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/SampleSubmissionProcessor.java
@@ -67,7 +67,6 @@ public class SampleSubmissionProcessor implements Processor {
     private static final String UNKNOWN_GID = "Unknown germplasm GID";
     private static final String INVALID_COLUMN = "Column must be a number between 1 and 12";
     private static final String INVALID_ROW = "Row must be a letter between A and H";
-//    private static final String MULTIPLE_SAMPLES_SINGLE_WELL = "The sample in row %d is already in row: %s, column: %d";
     private static final String MULTIPLE_SAMPLES_SINGLE_WELL = "Plate position not unique, duplicate in row %d";
     private final String referenceSource;
     private final BrAPIGermplasmDAO germplasmDAO;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/SampleSubmissionProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/SampleSubmissionProcessor.java
@@ -67,7 +67,8 @@ public class SampleSubmissionProcessor implements Processor {
     private static final String UNKNOWN_GID = "Unknown germplasm GID";
     private static final String INVALID_COLUMN = "Column must be a number between 1 and 12";
     private static final String INVALID_ROW = "Row must be a letter between A and H";
-    private static final String MULTIPLE_SAMPLES_SINGLE_WELL = "The sample in row %d is already in row: %s, column: %d";
+//    private static final String MULTIPLE_SAMPLES_SINGLE_WELL = "The sample in row %d is already in row: %s, column: %d";
+    private static final String MULTIPLE_SAMPLES_SINGLE_WELL = "Plate position not unique, duplicate in row %d";
     private final String referenceSource;
     private final BrAPIGermplasmDAO germplasmDAO;
     private final BrAPIObservationUnitDAO observationUnitDAO;
@@ -230,7 +231,7 @@ public class SampleSubmissionProcessor implements Processor {
             if (plateLayout[plateRow][plateCol] > 0) {
                 validationErrors.addError(rowNum,
                                           new ValidationError(SampleSubmissionImport.Columns.ROW + "/" + SampleSubmissionImport.Columns.COLUMN,
-                                                              String.format(MULTIPLE_SAMPLES_SINGLE_WELL, plateLayout[plateRow][plateCol], Character.toString('A' + plateRow), plateCol),
+                                                              String.format(MULTIPLE_SAMPLES_SINGLE_WELL, plateLayout[plateRow][plateCol]),
                                                               HttpStatus.UNPROCESSABLE_ENTITY));
             } else {
                 plateLayout[plateRow][plateCol] = rowNum;

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/germplasm/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/germplasm/GermplasmProcessor.java
@@ -17,7 +17,6 @@
 package org.breedinginsight.brapps.importer.services.processors.germplasm;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonElement;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.http.HttpStatus;
@@ -94,6 +93,7 @@ public class GermplasmProcessor implements Processor {
     public static String missingParentalEntryNoMsg = "The following parental entry numbers were not found in the file: %s";
     public static String badBreedMethodsMsg = "Invalid breeding method";
     public static String badGermplasmNameMsg = "Germplasm name cannot contain /";
+    public static String missingBreedingMethodForParentalGIDorEntryNo = "Required field \"Breeding Method\" cannot contain empty values when parent(s) are specified";
     public static String missingEntryNumbersMsg = "Either all or none of the germplasm must have entry numbers";
     public static String duplicateEntryNoMsg = "Entry numbers must be unique. Duplicated entry numbers found: %s";
     public static String circularDependency = "Circular dependency in the pedigree tree";
@@ -315,7 +315,7 @@ public class GermplasmProcessor implements Processor {
             //TODO maybe make separate method for cleanliness
             // Have GID so updating an existing germplasm record
             if (germplasm.getAccessionNumber() != null) {
-                processExistingGermplasm(germplasm, validationErrors, importRows, program, importListId, commit, mappedImportRow, i);
+                processExistingGermplasm(germplasm, validationErrors, importRows, breedingMethods, badBreedingMethods, program, importListId, commit, mappedImportRow, i);
             } else {
                 processNewGermplasm(germplasm, validationErrors, breedingMethods, badBreedingMethods, program, importListId, commit, mappedImportRow, i, user, nextVal);
             }
@@ -351,23 +351,10 @@ public class GermplasmProcessor implements Processor {
                                      List<String> badBreedingMethods,
                                      Program program, UUID importListId, boolean commit, PendingImport mappedImportRow, int i, User user, Supplier<BigInteger> nextVal) {
         germplasm = removeBreedingMethodBlanks(germplasm);
+        //Validating if Breeding Method exists for valid parent entries
+        validateGermplasmBreedingMethod(germplasm, i + 2, validationErrors);
         // Get the breeding method database object
-        ProgramBreedingMethodEntity breedingMethod = null;
-        if (germplasm.getBreedingMethod() != null) {
-            if (breedingMethods.containsKey(germplasm.getBreedingMethod())) {
-                breedingMethod = breedingMethods.get(germplasm.getBreedingMethod());
-            } else {
-                List<ProgramBreedingMethodEntity> breedingMethodResults = breedingMethodDAO.findByNameOrAbbreviation(germplasm.getBreedingMethod(), program.getId());
-                if (breedingMethodResults.size() > 0) {
-                    breedingMethods.put(germplasm.getBreedingMethod(), breedingMethodResults.get(0));
-                    breedingMethod = breedingMethods.get(germplasm.getBreedingMethod());
-                } else {
-                    ValidationError ve = new ValidationError("Breeding Method", badBreedMethodsMsg, HttpStatus.UNPROCESSABLE_ENTITY);
-                    validationErrors.addError(i + 2, ve);  // +2 instead of +1 to account for the column header row.
-                    badBreedingMethods.add(germplasm.getBreedingMethod());
-                }
-            }
-        }
+        ProgramBreedingMethodEntity breedingMethod = resolveBreedingMethod(germplasm, validationErrors, breedingMethods, badBreedingMethods, program, i + 2);
 
         validateGermplasmName(germplasm, i+2, validationErrors);
         validatePedigree(germplasm, i + 2, validationErrors);
@@ -397,7 +384,8 @@ public class GermplasmProcessor implements Processor {
         return germplasm;
     }
 
-    private boolean processExistingGermplasm(Germplasm germplasm, ValidationErrors validationErrors, List<BrAPIImport> importRows, Program program, UUID importListId, boolean commit, PendingImport mappedImportRow, int rowIndex) {
+    private boolean processExistingGermplasm(Germplasm germplasm, ValidationErrors validationErrors, List<BrAPIImport> importRows, Map<String, ProgramBreedingMethodEntity> breedingMethods,
+                                             List<String> badBreedingMethods, Program program, UUID importListId, boolean commit, PendingImport mappedImportRow, int rowIndex) {
         BrAPIGermplasm existingGermplasm;
         String gid = germplasm.getAccessionNumber();
         boolean mutated = false;
@@ -413,6 +401,12 @@ public class GermplasmProcessor implements Processor {
             validationErrors.addError(rowIndex+2, ve );  // +2 instead of +1 to account for the column header row.
             return false;
         }
+
+        germplasm = removeBreedingMethodBlanks(germplasm);
+        //Validating if Breeding Method exists for valid parent entries
+        validateGermplasmBreedingMethod(germplasm, rowIndex + 2, validationErrors);
+        // Get the breeding method database object
+        ProgramBreedingMethodEntity breedingMethod = resolveBreedingMethod(germplasm, validationErrors, breedingMethods, badBreedingMethods, program, rowIndex + 2);
 
         // Error conditions:
         // has existing pedigree and file pedigree is different and not empty
@@ -434,7 +428,7 @@ public class GermplasmProcessor implements Processor {
             updatePedigree = true;
         }
 
-        mutated = germplasm.updateBrAPIGermplasm(existingGermplasm, program, importListId, commit, updatePedigree);
+        mutated = germplasm.updateBrAPIGermplasm(existingGermplasm, program, importListId, commit, updatePedigree, breedingMethod);
 
         if (mutated) {
             updatedGermplasmList.add(existingGermplasm);
@@ -602,6 +596,35 @@ public class GermplasmProcessor implements Processor {
             ValidationError error = new ValidationError("Germplasm Name", badGermplasmNameMsg, HttpStatus.UNPROCESSABLE_ENTITY);
             validationErrors.addError(rowNumber, error);
         }
+    }
+
+    private void validateGermplasmBreedingMethod(Germplasm germplasm, Integer rowNumber, ValidationErrors validationErrors) {
+        if (germplasm.pedigreeExists() && StringUtils.isBlank(germplasm.getBreedingMethod())) {
+            ValidationError error = new ValidationError("Breeding Method", missingBreedingMethodForParentalGIDorEntryNo, HttpStatus.UNPROCESSABLE_ENTITY);
+            validationErrors.addError(rowNumber, error);
+        }
+    }
+
+    //shared Breeding Method lookup for create and update processes
+    private ProgramBreedingMethodEntity resolveBreedingMethod(Germplasm germplasm, ValidationErrors validationErrors,
+                                                              Map<String, ProgramBreedingMethodEntity> breedingMethods,
+                                                              List<String> badBreedingMethods, Program program, int rowNumber) {
+        if (germplasm.getBreedingMethod() == null) {
+            return null;
+        }
+        if (breedingMethods.containsKey(germplasm.getBreedingMethod())) {
+            return breedingMethods.get(germplasm.getBreedingMethod());
+        }
+        List<ProgramBreedingMethodEntity> breedingMethodResults = breedingMethodDAO.findByNameOrAbbreviation(germplasm.getBreedingMethod(), program.getId());
+
+        if (breedingMethodResults.isEmpty()) {
+            ValidationError ve = new ValidationError("Breeding Method", badBreedMethodsMsg, HttpStatus.UNPROCESSABLE_ENTITY);
+            validationErrors.addError(rowNumber, ve);
+            badBreedingMethods.add(germplasm.getBreedingMethod());
+            return null;
+        }
+        breedingMethods.put(germplasm.getBreedingMethod(), breedingMethodResults.get(0));
+        return breedingMethods.get(germplasm.getBreedingMethod());
     }
 
     private void validatePedigree(Germplasm germplasm, Integer rowNumber, ValidationErrors validationErrors) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/germplasm/GermplasmProcessor.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/germplasm/GermplasmProcessor.java
@@ -160,17 +160,16 @@ public class GermplasmProcessor implements Processor {
         });
 
         // Get parental accession nos in file
-        for (int i = 0; i < importRows.size(); i++) {
-            BrAPIImport germplasmImport = importRows.get(i);
+        for (BrAPIImport germplasmImport : importRows) {
             Germplasm germplasm = germplasmImport.getGermplasm();
             if (germplasm != null) {
                 // Retrieve parent accession numbers to assess if already in db
-                    if (germplasm.getFemaleParentAccessionNumber() != null) {
-                        germplasmAccessionNumbers.put(germplasm.getFemaleParentAccessionNumber(), true);
-                    }
-                    if (germplasm.getMaleParentAccessionNumber() != null) {
-                        germplasmAccessionNumbers.put(germplasm.getMaleParentAccessionNumber(), true);
-                    }
+                if (germplasm.getFemaleParentAccessionNumber() != null) {
+                    germplasmAccessionNumbers.put(germplasm.getFemaleParentAccessionNumber(), true);
+                }
+                if (germplasm.getMaleParentAccessionNumber() != null) {
+                    germplasmAccessionNumbers.put(germplasm.getMaleParentAccessionNumber(), true);
+                }
             }
         }
 
@@ -269,7 +268,7 @@ public class GermplasmProcessor implements Processor {
         // Method for generating accession number
         String germplasmSequenceName = program.getGermplasmSequence();
         if (germplasmSequenceName == null) {
-            log.error(String.format("Program, %s, is missing a value in the germplasm sequence column.", program.getName()));
+            log.error("Program, {}, is missing a value in the germplasm sequence column.", program.getName());
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Program is not properly configured for germplasm import");
         }
         Supplier<BigInteger> nextVal = () -> dsl.nextval(germplasmSequenceName.toLowerCase());
@@ -285,14 +284,13 @@ public class GermplasmProcessor implements Processor {
         newGermplasmList = new ArrayList<>();
         updatedGermplasmList = new ArrayList<>();
         Map<String, ProgramBreedingMethodEntity> breedingMethods = new HashMap<>();
-        Boolean nullEntryNotFound = false;
         List<String> badBreedingMethods = new ArrayList<>();
         Map<String, Integer> entryNumberCounts = new HashMap<>();
         List<String> userProvidedEntryNumbers = new ArrayList<>();
         ValidationErrors validationErrors = new ValidationErrors();
 
         for (int i = 0; i < importRows.size(); i++) {
-            log.debug("processing germplasm row: " + (i+1));
+            log.debug("processing germplasm row: {}", i + 1);
             BrAPIImport brapiImport = importRows.get(i);
             PendingImport mappedImportRow = mappedBrAPIImport.getOrDefault(i, new PendingImport());
 
@@ -315,28 +313,28 @@ public class GermplasmProcessor implements Processor {
             //TODO maybe make separate method for cleanliness
             // Have GID so updating an existing germplasm record
             if (germplasm.getAccessionNumber() != null) {
-                processExistingGermplasm(germplasm, validationErrors, importRows, breedingMethods, badBreedingMethods, program, importListId, commit, mappedImportRow, i);
+                processExistingGermplasm(germplasm, validationErrors, importRows, breedingMethods, badBreedingMethods, program, commit, mappedImportRow, i);
             } else {
                 processNewGermplasm(germplasm, validationErrors, breedingMethods, badBreedingMethods, program, importListId, commit, mappedImportRow, i, user, nextVal);
             }
             mappedBrAPIImport.put(i, mappedImportRow);
         }
-        if (validationErrors.hasErrors() ){
+        if (validationErrors.hasErrors()) {
             throw new ValidatorException(validationErrors);
         }
 
         // Check for missing entry numbers
-        if (userProvidedEntryNumbers.size() > 0 && userProvidedEntryNumbers.size() < importRows.size()) {
+        if (!userProvidedEntryNumbers.isEmpty() && userProvidedEntryNumbers.size() < importRows.size()) {
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY, missingEntryNumbersMsg);
         }
 
         // Check for duplicate entry numbers
         if (entryNumberCounts.size() < importRows.size()) {
             List<String> dups = entryNumberCounts.keySet().stream()
-                                                 .filter(key -> entryNumberCounts.get(key) > 1)
-                                                 .collect(Collectors.toList());
+                    .filter(key -> entryNumberCounts.get(key) > 1)
+                    .collect(Collectors.toList());
             throw new HttpStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
-                                          String.format(duplicateEntryNoMsg, arrayOfStringFormatter.apply(dups)));
+                    String.format(duplicateEntryNoMsg, arrayOfStringFormatter.apply(dups)));
         }
 
         // Construct pedigree
@@ -356,7 +354,7 @@ public class GermplasmProcessor implements Processor {
         // Get the breeding method database object
         ProgramBreedingMethodEntity breedingMethod = resolveBreedingMethod(germplasm, validationErrors, breedingMethods, badBreedingMethods, program, i + 2);
 
-        validateGermplasmName(germplasm, i+2, validationErrors);
+        validateGermplasmName(germplasm, i + 2, validationErrors);
         validatePedigree(germplasm, i + 2, validationErrors);
 
         if (germplasm.pedigreeExists()) {
@@ -378,17 +376,17 @@ public class GermplasmProcessor implements Processor {
 
     // Removes leading and trailing blanks from the germplasm breedingMethod
     private Germplasm removeBreedingMethodBlanks(Germplasm germplasm) {
-        if(germplasm.getBreedingMethod() != null ) {
+        if (germplasm.getBreedingMethod() != null) {
             germplasm.setBreedingMethod(germplasm.getBreedingMethod().strip());
         }
         return germplasm;
     }
 
-    private boolean processExistingGermplasm(Germplasm germplasm, ValidationErrors validationErrors, List<BrAPIImport> importRows, Map<String, ProgramBreedingMethodEntity> breedingMethods,
-                                             List<String> badBreedingMethods, Program program, UUID importListId, boolean commit, PendingImport mappedImportRow, int rowIndex) {
+    private void processExistingGermplasm(Germplasm germplasm, ValidationErrors validationErrors, List<BrAPIImport> importRows, Map<String, ProgramBreedingMethodEntity> breedingMethods,
+                                          List<String> badBreedingMethods, Program program, boolean commit, PendingImport mappedImportRow, int rowIndex) {
         BrAPIGermplasm existingGermplasm;
         String gid = germplasm.getAccessionNumber();
-        boolean mutated = false;
+        boolean mutated;
         boolean updatePedigree = false;
 
         if (germplasmByAccessionNumber.containsKey(gid)) {
@@ -398,8 +396,8 @@ public class GermplasmProcessor implements Processor {
         } else {
             //should be caught in getExistingBrapiData
             ValidationError ve = new ValidationError("GID", String.format(missingGID, gid), HttpStatus.NOT_FOUND);
-            validationErrors.addError(rowIndex+2, ve );  // +2 instead of +1 to account for the column header row.
-            return false;
+            validationErrors.addError(rowIndex + 2, ve);  // +2 instead of +1 to account for the column header row.
+            return;
         }
 
         germplasm = removeBreedingMethodBlanks(germplasm);
@@ -414,21 +412,21 @@ public class GermplasmProcessor implements Processor {
         // no existing pedigree and file different pedigree
         // existing pedigree and file pedigree same
         // existing pedigree and file pedigree empty
-        if(hasPedigree(existingGermplasm) && germplasm.pedigreeExists()) {
-            if(!arePedigreesEqual(existingGermplasm, germplasm, importRows)) {
+        if (hasPedigree(existingGermplasm) && germplasm.pedigreeExists()) {
+            if (!arePedigreesEqual(existingGermplasm, germplasm, importRows)) {
                 ValidationError ve = new ValidationError("Pedigree", pedigreeAlreadyExists, HttpStatus.UNPROCESSABLE_ENTITY);
                 validationErrors.addError(rowIndex + 2, ve);  // +2 instead of +1 to account for the column header row.
-                return false;
+                return;
             }
         }
 
         // if no existing pedigree and file has pedigree then validate and update
-        if(germplasm.pedigreeExists() && !hasPedigree(existingGermplasm)) {
+        if (germplasm.pedigreeExists() && !hasPedigree(existingGermplasm)) {
             validatePedigree(germplasm, rowIndex + 2, validationErrors);
             updatePedigree = true;
         }
 
-        mutated = germplasm.updateBrAPIGermplasm(existingGermplasm, program, importListId, commit, updatePedigree, breedingMethod);
+        mutated = germplasm.updateBrAPIGermplasm(existingGermplasm, program, commit, updatePedigree, breedingMethod);
 
         if (mutated) {
             updatedGermplasmList.add(existingGermplasm);
@@ -442,7 +440,6 @@ public class GermplasmProcessor implements Processor {
 
         // add to list regardless of mutated or not
         importList.addDataItem(existingGermplasm.getGermplasmName());
-        return true;
     }
 
     private boolean canUpdatePedigree(BrAPIGermplasm existingGermplasm, Germplasm germplasm) {
@@ -680,7 +677,7 @@ public class GermplasmProcessor implements Processor {
             }
 
             totalRecorded += createList.size();
-            if (createList.size() > 0) {
+            if (!createList.isEmpty()) {
                 created.addAll(createList.stream().map(GermplasmImportIdUtils::getImportId).collect(Collectors.toList()));
                 postOrder.add(createList);
             } else if (totalRecorded < newGermplasmList.size()) {

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-version=v1.3.0+1123
-versionInfo=https://github.com/Breeding-Insight/bi-api/commit/b742cfe4fdf5eded5041d6c79d1e7e94651feff9
+version=v1.3.0+1127
+versionInfo=https://github.com/Breeding-Insight/bi-api/commit/24bed04e26733bfc40ec5f8c7c8b8898388981aa

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-version=v1.3.0+1127
-versionInfo=https://github.com/Breeding-Insight/bi-api/commit/24bed04e26733bfc40ec5f8c7c8b8898388981aa
+version=v1.3.0+1131
+versionInfo=https://github.com/Breeding-Insight/bi-api/commit/cd343a162fae4e9b3f30e5f3d487d24cc729c461

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-version=v1.3.0+1137
-versionInfo=https://github.com/Breeding-Insight/bi-api/commit/ee7f4cd8f9d949ecbd897897883d44275490d8d8
+version=v1.3.0+1139
+versionInfo=https://github.com/Breeding-Insight/bi-api/commit/a84dc18e892625a13b5f5e473103f5b1359b147e

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-version=v1.3.0+1135
-versionInfo=https://github.com/Breeding-Insight/bi-api/commit/18fbef7a74983de92ffad0e97d7881526d414601
+version=v1.3.0+1137
+versionInfo=https://github.com/Breeding-Insight/bi-api/commit/ee7f4cd8f9d949ecbd897897883d44275490d8d8

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-version=v1.3.0+1131
-versionInfo=https://github.com/Breeding-Insight/bi-api/commit/cd343a162fae4e9b3f30e5f3d487d24cc729c461
+version=v1.3.0+1135
+versionInfo=https://github.com/Breeding-Insight/bi-api/commit/18fbef7a74983de92ffad0e97d7881526d414601

--- a/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
@@ -465,6 +465,54 @@ public class ExperimentControllerIntegrationTest extends BrAPITest {
     }
 
     @Test
+    public void createSubEntityDatasetForbiddenForExperimentalCollaborator() throws Exception {
+        // add otherTestUser to the program as an Experimental Collaborator
+        FannyPack securityFp = FannyPack.fill("src/test/resources/sql/ProgramSecuredAnnotationRuleIntegrationTest.sql");
+        dsl.execute(securityFp.get("InsertProgramRolesExperimentalCollaborator"), otherTestUser.getId().toString(), program.getId());
+
+        // add that user to this experiment as a collaborator
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("userId", otherTestUser.getId().toString());
+
+        Flowable<HttpResponse<String>> collaboratorCall = client.exchange(
+                POST(String.format("/programs/%s/experiments/%s/collaborators", program.getId().toString(), experimentId), requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")),
+                String.class
+        );
+        HttpResponse<String> collaboratorResponse = collaboratorCall.blockingFirst();
+        assertEquals(HttpStatus.OK, collaboratorResponse.getStatus());
+
+        JsonObject collaboratorResult = JsonParser.parseString(collaboratorResponse.body()).getAsJsonObject().getAsJsonObject("result");
+        String collaboratorId = collaboratorResult.get("id").getAsString();
+
+        // collaborator should be blocked from creating sub-entity datasets directly
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST(String.format("/programs/%s/experiments/%s/dataset", program.getId(), experimentId),
+                        "{\"name\":\"Plant\",\"repeatedMeasures\":2}")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "other-registered-user")),
+                String.class
+        );
+
+        HttpClientResponseException e = assertThrows(HttpClientResponseException.class, call::blockingFirst);
+        assertEquals(HttpStatus.FORBIDDEN, e.getStatus());
+
+        // cleanup collaborator record
+        Flowable<HttpResponse<String>> deleteCall = client.exchange(
+                DELETE(String.format("/programs/%s/experiments/%s/collaborators/%s", program.getId().toString(), experimentId, collaboratorId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")),
+                String.class
+        );
+        HttpResponse<String> deleteResponse = deleteCall.blockingFirst();
+        assertEquals(HttpStatus.OK, deleteResponse.getStatus());
+
+        // cleanup program user role
+        dsl.execute(securityFp.get("DeleteProgramUser"), otherTestUser.getId().toString());
+    }
+
+    @Test
     public void recommendedSubEntityDatasetNamesIncludeExpUnitNamesFromOtherExperiments() throws Exception {
         Program testProgram = createSeededProgram("Recommended Names");
         uploadExperimentWithoutObs(testProgram, "Plant Autocomplete Source", "Plant");

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
@@ -13,9 +13,12 @@ import io.micronaut.http.netty.cookies.NettyCookie;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import lombok.SneakyThrows;
+import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPIListTypes;
+import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.breedinginsight.BrAPITest;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
+import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapps.importer.model.base.Germplasm;
 import org.breedinginsight.brapps.importer.model.imports.germplasm.GermplasmImportService;
 import org.breedinginsight.brapps.importer.model.response.ImportObjectState;
@@ -70,6 +73,8 @@ public class GermplasmFileImportTest extends BrAPITest {
     private BreedingMethodDAO breedingMethodDAO;
     @Inject
     private DSLContext dsl;
+    @Inject
+    private BrAPIGermplasmDAO germplasmDAO;
 
     private ImportTestUtils importTestUtils;
 
@@ -644,7 +649,7 @@ public class GermplasmFileImportTest extends BrAPITest {
         assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatus());
 
         JsonArray rowErrors = JsonParser.parseString((String) e.getResponse().getBody().get()).getAsJsonObject().getAsJsonArray("rowErrors");
-        assertEquals(2, rowErrors.size(), "Wrong number of row errors returned");
+        assertEquals(1, rowErrors.size(), "Wrong number of row errors returned");
 
         JsonObject rowError1 = rowErrors.get(0).getAsJsonObject();
         JsonArray errors = rowError1.getAsJsonArray("errors");
@@ -653,14 +658,126 @@ public class GermplasmFileImportTest extends BrAPITest {
         assertEquals(422, error.get("httpStatusCode").getAsInt(), "Incorrect http status code");
         assertEquals("Germplasm Name", error.get("field").getAsString(), "Incorrect field name");
         assertEquals(importService.getBlankRequiredFieldMsg("Germplasm Name"), error.get("errorMessage").getAsString(), "Incorrect error message");
+    }
 
-        JsonObject rowError2 = rowErrors.get(1).getAsJsonObject();
-        JsonArray errors2 = rowError2.getAsJsonArray("errors");
-        assertEquals(1, errors2.size(), "Not enough errors were returned");
-        JsonObject error2 = errors2.get(0).getAsJsonObject();
-        assertEquals(422, error2.get("httpStatusCode").getAsInt(), "Incorrect http status code");
-        assertEquals("Source", error2.get("field").getAsString(), "Incorrect field name");
-        assertEquals(importService.getBlankRequiredFieldMsg("Source"), error2.get("errorMessage").getAsString(), "Incorrect error message");
+    @Test
+    @SneakyThrows
+    public void blankBreedingMethodAllowedWithoutParents() {
+        JsonObject result = importGermplasm(
+                "src/test/resources/files/germplasm_import/breeding_method_optional_without_parents.csv",
+                "BlankBreedingMethodNoParents",
+                "Blank breeding method without parents should succeed",
+                false
+        );
+
+        assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt());
+    }
+
+    @Test
+    @SneakyThrows
+    public void blankBreedingMethodRejectedWhenParentProvided() {
+        JsonObject result = importGermplasm(
+                "src/test/resources/files/germplasm_import/breeding_method_required_with_parent.csv",
+                "BlankBreedingMethodWithParent",
+                "Blank breeding method with parent should fail",
+                false
+        );
+
+        assertEquals(422, result.getAsJsonObject("progress").get("statuscode").getAsInt());
+
+        JsonArray rowErrors = result.getAsJsonObject("progress").getAsJsonArray("rowErrors");
+        assertEquals(1, rowErrors.size());
+
+        JsonObject error = rowErrors.get(0).getAsJsonObject()
+                .getAsJsonArray("errors").get(0).getAsJsonObject();
+
+        assertEquals("Breeding Method", error.get("field").getAsString());
+        assertEquals(GermplasmProcessor.missingBreedingMethodForParentalGIDorEntryNo, error.get("errorMessage").getAsString());
+    }
+
+    @Test
+    @SneakyThrows
+    public void blankSourceAllowedWhenParentProvided() {
+        JsonObject result = importGermplasm(
+                "src/test/resources/files/germplasm_import/source_optional_with_parent.csv",
+                "BlankSourceWithParent",
+                "Blank source with parent should succeed",
+                false
+        );
+
+        assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt());
+    }
+
+    @Test
+    @SneakyThrows
+    public void appendSourceToExistingRecordWhenBlank() {
+        seedExistingGermplasm("9001", "Existing Blank Source", null, null);
+
+        JsonObject result = importGermplasm(
+                "src/test/resources/files/germplasm_import/append_existing_blank_source.csv",
+                "AppendBlankSource",
+                "Append source to existing record",
+                false
+        );
+
+        assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt());
+        assertEquals(ImportObjectState.MUTATED.name(), getPreviewState(result, 0));
+
+        JsonObject germplasm = getPreviewGermplasm(result, 0);
+        assertEquals("Wild", germplasm.get("seedSource").getAsString());
+    }
+
+    @Test
+    @SneakyThrows
+    public void appendBreedingMethodToExistingRecordWhenBlank() {
+        seedExistingGermplasm("9002", "Existing Blank Method", "Wild", null);
+
+        JsonObject result = importGermplasm(
+                "src/test/resources/files/germplasm_import/append_existing_blank_breeding_method.csv",
+                "AppendBlankMethod",
+                "Append breeding method to existing record",
+                false
+        );
+
+        assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt());
+        assertEquals(ImportObjectState.MUTATED.name(), getPreviewState(result, 0));
+
+        ProgramBreedingMethodEntity breedingMethod = breedingMethodDAO
+                .findByNameOrAbbreviation("BCR", validProgram.getId())
+                .get(0);
+
+        JsonObject germplasm = getPreviewGermplasm(result, 0);
+        JsonObject additionalInfo = germplasm.getAsJsonObject("additionalInfo");
+
+        assertEquals(breedingMethod.getName(), additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD).getAsString());
+        assertEquals(breedingMethod.getId().toString(), additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD_ID).getAsString());
+    }
+
+    @Test
+    @SneakyThrows
+    public void doNotOverwriteExistingSourceOrBreedingMethod() {
+        seedExistingGermplasm("9003", "Germplasm1", "Existing Source", "ANE");
+
+        JsonObject result = importGermplasm(
+                "src/test/resources/files/germplasm_import/do_not_overwrite_existing_source_or_breeding_method.csv",
+                "DoNotOverwrite",
+                "Existing source and breeding method should not be overwritten",
+                false
+        );
+
+        assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt());
+        assertEquals(ImportObjectState.EXISTING.name(), getPreviewState(result, 0));
+
+        ProgramBreedingMethodEntity breedingMethod = breedingMethodDAO
+                .findByNameOrAbbreviation("ANE", validProgram.getId())
+                .get(0);
+
+        JsonObject germplasm = getPreviewGermplasm(result, 0);
+        JsonObject additionalInfo = germplasm.getAsJsonObject("additionalInfo");
+
+        assertEquals("Existing Source", germplasm.get("seedSource").getAsString());
+        assertEquals(breedingMethod.getName(), additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD).getAsString());
+        assertEquals(breedingMethod.getId().toString(), additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD_ID).getAsString());
     }
 
     @Test
@@ -1082,5 +1199,61 @@ public class GermplasmFileImportTest extends BrAPITest {
             assertEquals(germplasmNames.size(), germplasmList.size(), "Wrong number of germplasm found in the list");
             assertFalse(found.contains(false), "Some germplasm names were not found in saved list");
         }
+    }
+
+    /**
+     * Methods to help test scenarios with existing records in DB
+     */
+    private JsonObject getPreviewRow(JsonObject result, int index) {
+        return result.get("preview").getAsJsonObject().get("rows").getAsJsonArray().get(index).getAsJsonObject();
+    }
+
+    private JsonObject getPreviewGermplasm(JsonObject result, int index) {
+        return getPreviewRow(result, index).getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
+    }
+
+    private String getPreviewState(JsonObject result, int index) {
+        return getPreviewRow(result, index).getAsJsonObject("germplasm").get("state").getAsString();
+    }
+
+    private void seedExistingGermplasm(String accessionNumber, String displayName, String source, String breedingMethodCode) {
+        BrAPIGermplasm germplasm = new BrAPIGermplasm();
+        germplasm.setAccessionNumber(accessionNumber);
+        germplasm.setDefaultDisplayName(displayName);
+        germplasm.setGermplasmName(String.format("%s [%s-%s]", displayName, validProgram.getKey(), accessionNumber));
+        germplasm.setSeedSource(source);
+
+        JsonObject additionalInfo = new JsonObject();
+        additionalInfo.addProperty(BrAPIAdditionalInfoFields.GERMPLASM_IMPORT_ENTRY_NUMBER, accessionNumber);
+
+        if (isNotBlank(breedingMethodCode)) {
+            ProgramBreedingMethodEntity breedingMethod = breedingMethodDAO
+                    .findByNameOrAbbreviation(breedingMethodCode, validProgram.getId())
+                    .get(0);
+
+            additionalInfo.addProperty(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD_ID, breedingMethod.getId().toString());
+            additionalInfo.addProperty(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD, breedingMethod.getName());
+        }
+
+        germplasm.setAdditionalInfo(additionalInfo);
+
+        List<BrAPIExternalReference> externalReferences = new ArrayList<>();
+
+        BrAPIExternalReference programReference = new BrAPIExternalReference();
+        programReference.setReferenceSource(String.format("%s/programs", BRAPI_REFERENCE_SOURCE));
+        programReference.setReferenceId(validProgram.getId().toString());
+        externalReferences.add(programReference);
+
+        BrAPIExternalReference germplasmReference = new BrAPIExternalReference();
+        germplasmReference.setReferenceSource(BRAPI_REFERENCE_SOURCE);
+        germplasmReference.setReferenceId(UUID.randomUUID().toString());
+        externalReferences.add(germplasmReference);
+
+        germplasm.setExternalReferences(externalReferences);
+
+        germplasmDAO.createBrAPIGermplasm(List.of(germplasm), validProgram.getId(), null);
+
+        //Refresh cache so importer lookup sees the seeded germplasm immediately.
+        germplasmDAO.repopulateGermplasmCacheForProgram(validProgram.getId());
     }
 }

--- a/src/test/resources/files/germplasm_import/append_existing_blank_breeding_method.csv
+++ b/src/test/resources/files/germplasm_import/append_existing_blank_breeding_method.csv
@@ -1,0 +1,2 @@
+GID,Germplasm Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID,Synonyms
+9002,Existing Blank Method,BCR,,,,,,,,

--- a/src/test/resources/files/germplasm_import/append_existing_blank_source.csv
+++ b/src/test/resources/files/germplasm_import/append_existing_blank_source.csv
@@ -1,0 +1,2 @@
+GID,Germplasm Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID,Synonyms
+9001,Existing Blank Source,,Wild,,,,,,,

--- a/src/test/resources/files/germplasm_import/breeding_method_optional_without_parents.csv
+++ b/src/test/resources/files/germplasm_import/breeding_method_optional_without_parents.csv
@@ -1,0 +1,3 @@
+GID,Germplasm Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID,Synonyms
+,No Parent 1,,Wild,,,,,,,
+,No Parent 2,,,,,,,,,

--- a/src/test/resources/files/germplasm_import/breeding_method_required_with_parent.csv
+++ b/src/test/resources/files/germplasm_import/breeding_method_required_with_parent.csv
@@ -1,0 +1,2 @@
+GID,Germplasm Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID,Synonyms
+,Name1,,Wild,0,0,,,,,

--- a/src/test/resources/files/germplasm_import/do_not_overwrite_existing_source_or_breeding_method.csv
+++ b/src/test/resources/files/germplasm_import/do_not_overwrite_existing_source_or_breeding_method.csv
@@ -1,0 +1,2 @@
+GID,Germplasm Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID,Synonyms
+9003,Germplasm1,BCR,New Source,,,,,,,

--- a/src/test/resources/files/germplasm_import/source_optional_with_parent.csv
+++ b/src/test/resources/files/germplasm_import/source_optional_with_parent.csv
@@ -1,0 +1,2 @@
+GID,Germplasm Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID,Synonyms
+,Name1,BCR,,0,,,,,,


### PR DESCRIPTION
# Description
JIRA story card link: [BI-2860](https://breedinginsight.atlassian.net/browse/BI-2860?atlOrigin=eyJpIjoiMjU2ZjAzYTVkZjRmNGFlMDkzNDMxY2ZmMTMwMjc3MzkiLCJwIjoiaiJ9)

This PR updates the experiment dataset creation permission so that `POST /programs/{programId}/experiments/{experimentId}/dataset` is restricted to `Program Administrator`.

Previously, an `Experimental Collaborator` could reach a flow in the UI that suggested sub-entity dataset creation was available. This change enforces the backend permission rule so collaborator users cannot create sub-entity datasets directly through the API.

This PR also adds test coverage for the forbidden collaborator case.

And it depends on the bug/BI-2860 for the frontend. 

# Dependencies
bi-web: bug/BI-2860
bi-api: bug/BI-2860

# Testing
1. Run the existing API test suite for the updated controller test
2. Verify Program Admin can still create a sub-entity dataset
3. Verify Experimental Collaborator receives `403 Forbidden` on:
   `POST /programs/{programId}/experiments/{experimentId}/dataset`

Manual validation:
1. Use the related `bi-web` PR
2. Confirm collaborator user sees the option disabled in the UI
3. Confirm backend blocks direct API access for collaborator users


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2860]: https://breedinginsight.atlassian.net/browse/BI-2860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ