### PR TITLE
BI-2860: Made changes to the end point to limit the access.

### DIFF
--- a/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
@@ -122,7 +122,7 @@ public class ExperimentController {
      * @return An HttpResponse with a Response object containing the newly created Dataset.
      */
     @Post("/${micronaut.bi.api.version}/programs/{programId}/experiments/{experimentId}/dataset")
-    @ProgramSecured(roleGroups = {ProgramSecuredRoleGroup.PROGRAM_SCOPED_ROLES})
+    @ProgramSecured(roles = {ProgramSecuredRole.PROGRAM_ADMIN})
     @Produces(MediaType.APPLICATION_JSON)
     public HttpResponse<Response<Dataset>> createSubEntityDataset(
             @PathVariable("programId") UUID programId,

--- a/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
@@ -10,7 +10,7 @@ import io.micronaut.http.client.RxHttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.http.netty.cookies.NettyCookie;
-import io.micronaut.test.annotation.MicronautTest;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
@@ -462,6 +462,54 @@ public class ExperimentControllerIntegrationTest extends BrAPITest {
 
         HttpResponse<String> response = call.blockingFirst();
         assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    public void createSubEntityDatasetForbiddenForExperimentalCollaborator() throws Exception {
+        // add otherTestUser to the program as an Experimental Collaborator
+        FannyPack securityFp = FannyPack.fill("src/test/resources/sql/ProgramSecuredAnnotationRuleIntegrationTest.sql");
+        dsl.execute(securityFp.get("InsertProgramRolesExperimentalCollaborator"), otherTestUser.getId().toString(), program.getId());
+
+        // add that user to this experiment as a collaborator
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("userId", otherTestUser.getId().toString());
+
+        Flowable<HttpResponse<String>> collaboratorCall = client.exchange(
+                POST(String.format("/programs/%s/experiments/%s/collaborators", program.getId().toString(), experimentId), requestBody.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")),
+                String.class
+        );
+        HttpResponse<String> collaboratorResponse = collaboratorCall.blockingFirst();
+        assertEquals(HttpStatus.OK, collaboratorResponse.getStatus());
+
+        JsonObject collaboratorResult = JsonParser.parseString(collaboratorResponse.body()).getAsJsonObject().getAsJsonObject("result");
+        String collaboratorId = collaboratorResult.get("id").getAsString();
+
+        // collaborator should be blocked from creating sub-entity datasets directly
+        Flowable<HttpResponse<String>> call = client.exchange(
+                POST(String.format("/programs/%s/experiments/%s/dataset", program.getId(), experimentId),
+                        "{\"name\":\"Plant\",\"repeatedMeasures\":2}")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "other-registered-user")),
+                String.class
+        );
+
+        HttpClientResponseException e = assertThrows(HttpClientResponseException.class, call::blockingFirst);
+        assertEquals(HttpStatus.FORBIDDEN, e.getStatus());
+
+        // cleanup collaborator record
+        Flowable<HttpResponse<String>> deleteCall = client.exchange(
+                DELETE(String.format("/programs/%s/experiments/%s/collaborators/%s", program.getId().toString(), experimentId, collaboratorId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new NettyCookie("phylo-token", "test-registered-user")),
+                String.class
+        );
+        HttpResponse<String> deleteResponse = deleteCall.blockingFirst();
+        assertEquals(HttpStatus.OK, deleteResponse.getStatus());
+
+        // cleanup program user role
+        dsl.execute(securityFp.get("DeleteProgramUser"), otherTestUser.getId().toString());
     }
 
     @Test


### PR DESCRIPTION
# Description
JIRA story card link: [BI-2860](https://breedinginsight.atlassian.net/browse/BI-2860?atlOrigin=eyJpIjoiMjU2ZjAzYTVkZjRmNGFlMDkzNDMxY2ZmMTMwMjc3MzkiLCJwIjoiaiJ9)

This PR updates the experiment dataset creation permission so that `POST /programs/{programId}/experiments/{experimentId}/dataset` is restricted to `Program Administrator`.

Previously, an `Experimental Collaborator` could reach a flow in the UI that suggested sub-entity dataset creation was available. This change enforces the backend permission rule so collaborator users cannot create sub-entity datasets directly through the API.

This PR also adds test coverage for the forbidden collaborator case.

And it depends on the bug/BI-2860-v1.3 for the frontend. 

# Dependencies
bi-web: bug/BI-2860-v1.3
bi-api: bug/BI-2860-v1.3

# Testing
1. Run the existing API test suite for the updated controller test
2. Verify Program Admin can still create a sub-entity dataset
3. Verify Experimental Collaborator receives `403 Forbidden` on:
   `POST /programs/{programId}/experiments/{experimentId}/dataset`

Manual validation:
1. Use the related `bi-web` PR
2. Confirm collaborator user sees the option disabled in the UI
3. Confirm backend blocks direct API access for collaborator users


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2860]: https://breedinginsight.atlassian.net/browse/BI-2860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ