### PR TITLE
BI-2887: Germplasm download error with blank source or breeding method

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -119,24 +119,29 @@ public class BrAPIGermplasmService {
             row.put("GID", Integer.valueOf(germplasmEntry.getAccessionNumber()));
             // Strip programKey and accessionNumber from germplasmName for the file output.
             row.put("Germplasm Name", Utilities.removeProgramKeyAnyAccession(germplasmEntry.getGermplasmName(), program.getKey()));
-            row.put("Breeding Method", germplasmEntry.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD).getAsString());
-            String source = germplasmEntry.getSeedSource();
-            row.put("Source", source);
+            if (germplasmEntry.getAdditionalInfo() != null &&
+                    germplasmEntry.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD)) {
+                row.put("Breeding Method", germplasmEntry.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD).getAsString());
+            }
 
             // Use the entry number in the list map if generated
-            if(listData == null) {
+            if (listData == null) {
                 // Not downloading a real list, use GID (https://breedinginsight.atlassian.net/browse/BI-2266).
                 row.put("Entry No", Integer.valueOf(germplasmEntry.getAccessionNumber()));
             } else {
                 row.put("Entry No", entryNumber);
             }
 
-            //If germplasm was imported with an external UID, it will be stored in external reference with same source as seed source
-            List<BrAPIExternalReference> externalReferences = germplasmEntry.getExternalReferences();
-            for (BrAPIExternalReference reference: externalReferences){
-                if (reference.getReferenceSource().equals(source)) {
-                    row.put("External UID", reference.getReferenceID());
-                    break;
+            String source = germplasmEntry.getSeedSource();
+            if (source != null) {
+                row.put("Source", source);
+                //If germplasm was imported with an external UID, it will be stored in external reference with same source as seed source
+                List<BrAPIExternalReference> externalReferences = germplasmEntry.getExternalReferences();
+                for (BrAPIExternalReference reference : externalReferences) {
+                    if (reference.getReferenceSource().equals(source)) {
+                        row.put("External UID", reference.getReferenceID());
+                        break;
+                    }
                 }
             }
 

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -120,7 +120,8 @@ public class BrAPIGermplasmService {
             // Strip programKey and accessionNumber from germplasmName for the file output.
             row.put("Germplasm Name", Utilities.removeProgramKeyAnyAccession(germplasmEntry.getGermplasmName(), program.getKey()));
             if (germplasmEntry.getAdditionalInfo() != null &&
-                    germplasmEntry.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD)) {
+                    germplasmEntry.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD) &&
+                    !germplasmEntry.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD).isJsonNull()) {
                 row.put("Breeding Method", germplasmEntry.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD).getAsString());
             }
 

--- a/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
@@ -185,12 +185,11 @@ public class BrAPIGermplasmServiceUnitTest extends DatabaseTest {
         testGermplasm.setAccessionNumber("1");
 
         JsonObject additionalInfo = new JsonObject();
-        additionalInfo.addProperty(GERMPLASM_BREEDING_METHOD, false);
         additionalInfo.addProperty(MALE_PARENT_UNKNOWN, false);
         additionalInfo.addProperty(FEMALE_PARENT_UNKNOWN, false);
 
         testGermplasm.setAdditionalInfo(additionalInfo);
-        testGermplasm.setExternalReferences(null);
+        testGermplasm.setExternalReferences(new ArrayList<>());
 
         germplasmService = new BrAPIGermplasmService(listDAO, programService, germplasmDAO);
 
@@ -203,7 +202,7 @@ public class BrAPIGermplasmServiceUnitTest extends DatabaseTest {
         assertEquals(1, processedData.size());
         assertEquals("Germplasm A", processedData.get(0).get("Germplasm Name"));
         assertEquals(1, processedData.get(0).get("Entry No"));
-        assertTrue(processedData.get(0).containsKey("Breeding Method"));
+        assertFalse(processedData.get(0).containsKey("Breeding Method"));
         assertFalse(processedData.get(0).containsKey("Source"));
         assertFalse(processedData.get(0).containsKey("External UID"));
     }

--- a/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
@@ -1,5 +1,6 @@
 package org.breedinginsight.services;
 
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import io.reactivex.functions.Function;
 import io.reactivex.functions.Function3;
@@ -37,7 +38,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -165,12 +166,94 @@ public class BrAPIGermplasmServiceUnitTest extends DatabaseTest {
         List<String> expectedColumnNames = GermplasmFileColumns.getOrderedColumns().stream().map(c -> c.getValue()).collect(Collectors.toList());
 
         //Check file values
-        assertEquals(listName+"_"+timestamp, downloadFile.getFileName(), "Incorrect export file name");
+        assertEquals(listName + "_" + timestamp, downloadFile.getFileName(), "Incorrect export file name");
         assertEquals(expectedColumnNames, resultTable.columnNames(), "Incorrect columns were exported");
         assertEquals(2, resultTable.rowCount(), "Wrong number of rows were exported");
         assertEquals("Germplasm A", resultTable.get(0, 1), "Incorrect data exported");
         // Check that "GID" column matches "Entry No" for both (https://breedinginsight.atlassian.net/browse/BI-2266).
-        assertEquals(resultTable.get(0,0), resultTable.get(0, 6), "Incorrect data exported");
-        assertEquals(resultTable.get(1,0), resultTable.get(1, 6), "Incorrect data exported");
+        assertEquals(resultTable.get(0, 0), resultTable.get(0, 6), "Incorrect data exported");
+        assertEquals(resultTable.get(1, 0), resultTable.get(1, 6), "Incorrect data exported");
+    }
+
+    @Test
+    public void processListDataAllowsBlankOptionalFieldsForProgramExport() { // NEW: covers full germplasm export path
+        Program testProgram = new Program();
+        testProgram.setKey("TEST");
+
+        BrAPIGermplasm testGermplasm = new BrAPIGermplasm();
+        testGermplasm.setGermplasmName("Germplasm A");
+        testGermplasm.setAccessionNumber("1");
+
+        JsonObject additionalInfo = new JsonObject();
+        additionalInfo.addProperty(GERMPLASM_BREEDING_METHOD, false);
+        additionalInfo.addProperty(MALE_PARENT_UNKNOWN, false);
+        additionalInfo.addProperty(FEMALE_PARENT_UNKNOWN, false);
+
+        testGermplasm.setAdditionalInfo(additionalInfo);
+        testGermplasm.setExternalReferences(null);
+
+        germplasmService = new BrAPIGermplasmService(listDAO, programService, germplasmDAO);
+
+        List<Map<String, Object>> processedData = germplasmService.processListData(
+                Collections.singletonList(testGermplasm),
+                null,
+                testProgram
+        );
+
+        assertEquals(1, processedData.size());
+        assertEquals("Germplasm A", processedData.get(0).get("Germplasm Name"));
+        assertEquals(1, processedData.get(0).get("Entry No"));
+        assertTrue(processedData.get(0).containsKey("Breeding Method"));
+        assertFalse(processedData.get(0).containsKey("Source"));
+        assertFalse(processedData.get(0).containsKey("External UID"));
+    }
+
+    @Test
+    public void processListDataAllowsBlankOptionalFieldsForListExport() {
+        Program testProgram = new Program();
+        testProgram.setKey("TEST");
+
+        BrAPIGermplasm blankOptionalFields = new BrAPIGermplasm();
+        blankOptionalFields.setGermplasmName("Germplasm A");
+        blankOptionalFields.setAccessionNumber("1");
+        blankOptionalFields.setSeedSource("");
+
+        JsonObject blankInfo = new JsonObject();
+        blankInfo.add(GERMPLASM_BREEDING_METHOD, JsonNull.INSTANCE);
+        blankInfo.addProperty(MALE_PARENT_UNKNOWN, false);
+        blankInfo.addProperty(FEMALE_PARENT_UNKNOWN, false);
+
+        blankOptionalFields.setAdditionalInfo(blankInfo);
+        blankOptionalFields.setExternalReferences(new ArrayList<>());
+
+        BrAPIGermplasm orderedFirst = new BrAPIGermplasm();
+        orderedFirst.setGermplasmName("Germplasm B");
+        orderedFirst.setAccessionNumber("2");
+        orderedFirst.setSeedSource("Cultivated");
+
+        JsonObject orderedFirstInfo = new JsonObject();
+        orderedFirstInfo.addProperty(GERMPLASM_BREEDING_METHOD, "Autopolyploid");
+        orderedFirstInfo.addProperty(MALE_PARENT_UNKNOWN, false);
+        orderedFirstInfo.addProperty(FEMALE_PARENT_UNKNOWN, false);
+
+        orderedFirst.setAdditionalInfo(orderedFirstInfo);
+        orderedFirst.setExternalReferences(new ArrayList<>());
+
+        germplasmService = new BrAPIGermplasmService(listDAO, programService, germplasmDAO);
+
+        List<Map<String, Object>> processedData = germplasmService.processListData(
+                Arrays.asList(blankOptionalFields, orderedFirst),
+                Arrays.asList("Germplasm B [TEST-2]", "Germplasm A [TEST-1]"),
+                testProgram
+        );
+
+        assertEquals(2, processedData.size());
+        assertEquals("Germplasm B", processedData.get(0).get("Germplasm Name"));
+        assertEquals(1, processedData.get(0).get("Entry No"));
+        assertEquals("Germplasm A", processedData.get(1).get("Germplasm Name"));
+        assertEquals(2, processedData.get(1).get("Entry No"));
+        assertEquals("", processedData.get(1).get("Source"));
+        assertFalse(processedData.get(1).containsKey("Breeding Method"));
+        assertFalse(processedData.get(1).containsKey("External UID"));
     }
 }


### PR DESCRIPTION
# Description
**Story:** [BI-2887](https://breedinginsight.atlassian.net/browse/BI-2887?atlOrigin=eyJpIjoiM2M3MjUzZGQ4YTc2NDFiYmIyNTU4NGYzYzU1ODcxNGUiLCJwIjoiaiJ9)

This PR fixes a backend-only regression in germplasm export/download behavior introduced after BI-2789 made `Source` and `Breeding Method` optional for records without parent information.

Previously, germplasm downloads could fail when a record had:
- a blank `Breeding Method`
- a blank `Source`
- both fields blank

This change makes the export processing null-safe so downloads succeed and blank optional values are exported as blank cells.

# Dependencies
bi-api: bug/BI-2887
bi-web: develop

# Testing
- Verified download succeeds in all cases
- Verified blank optional fields are exported as blank cells
- Verified export column order is unchanged
- Verified germplasm-list export preserves list order and entry numbers

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2887]: https://breedinginsight.atlassian.net/browse/BI-2887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ