### PR TITLE
Apply BrAPI-server side Filtering/Sorting/Pagination to BI Experiments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <guava.version>31.0.1-jre</guava.version>
         <okhttp.version>4.9.3</okhttp.version>
         <mockito.version>4.3.1</mockito.version>
-        <brapi-java-client.version>2.2-SNAPSHOT</brapi-java-client.version>
+        <brapi-java-client.version>2.2.1-SNAPSHOT</brapi-java-client.version>
         <commons-io.version>2.11.0</commons-io.version>
         <tika-app.version>2.2.1</tika-app.version>
         <!-- Version of apache-poi depends on version of tika. Tika uses these. -->

--- a/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/ExperimentController.java
@@ -46,7 +46,6 @@ import java.util.stream.Collectors;
 @Secured(SecurityRule.IS_AUTHENTICATED)
 public class ExperimentController {
     private final BrAPITrialService experimentService;
-    private final ExperimentQueryMapper experimentQueryMapper;
     private final ProgramService programService;
     private final ExperimentalCollaboratorService experimentalCollaboratorService;
     private final SecurityService securityService;
@@ -54,9 +53,8 @@ public class ExperimentController {
     private final RoleService roleService;
 
     @Inject
-    public ExperimentController(BrAPITrialService experimentService, ExperimentQueryMapper experimentQueryMapper, ProgramService programService, ExperimentalCollaboratorService experimentalCollaboratorService, SecurityService securityService, ProgramUserService programUserService, RoleService roleService) {
+    public ExperimentController(BrAPITrialService experimentService, ProgramService programService, ExperimentalCollaboratorService experimentalCollaboratorService, SecurityService securityService, ProgramUserService programUserService, RoleService roleService) {
         this.experimentService = experimentService;
-        this.experimentQueryMapper = experimentQueryMapper;
         this.programService = programService;
         this.experimentalCollaboratorService = experimentalCollaboratorService;
         this.securityService = securityService;

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIStudiesController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIStudiesController.java
@@ -114,7 +114,7 @@ public class BrAPIStudiesController {
                 return ResponseUtils.getBrapiQueryResponse(authorizedStudies, studyQueryMapper, queryParams, searchRequest);
             }
 
-            // TODO: Instead of getting all studies for a program and filtering, doing the filtering on brapi side
+            // TODO: Instead of getting all studies for a program and filtering, doing the filtering on brapi side [BI-2922]
             List<BrAPIStudy> studies = studyService.getStudies(programId)
                         .stream()
                         .peek(this::setDbIds)

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
@@ -62,8 +62,6 @@ public class BrAPITrialsController {
 
     private final String referenceSource;
     private final BrAPITrialService experimentService;
-    // TODO: See if it's feasible to remove this mapper entirely
-    private final ExperimentQueryMapper experimentQueryMapper;
     private final SecurityService securityService;
     private final ProgramUserService programUserService;
     private final ExperimentalCollaboratorService experimentalCollaboratorService;
@@ -71,14 +69,12 @@ public class BrAPITrialsController {
 
     @Inject
     public BrAPITrialsController(BrAPITrialService experimentService,
-                                 ExperimentQueryMapper experimentQueryMapper,
                                  @Property(name = "brapi.server.reference-source") String referenceSource,
                                  SecurityService securityService,
                                  ProgramUserService programUserService,
                                  ExperimentalCollaboratorService experimentalCollaboratorService,
                                  ProgramService programService) {
         this.experimentService = experimentService;
-        this.experimentQueryMapper = experimentQueryMapper;
         this.referenceSource = referenceSource;
         this.securityService = securityService;
         this.programUserService = programUserService;
@@ -103,7 +99,6 @@ public class BrAPITrialsController {
             // If the program user is an experimental collaborator, filter results for only authorized experiments.
             Optional<ProgramUser> experimentalCollaborator = programUserService.getIfExperimentalCollaborator(programId, securityService.getUser().getId());
             if (experimentalCollaborator.isPresent()) {
-                // TODO: Modify this code to use brapi side filter, pagination and sort
                 List<UUID> authorizedExperimentIds = experimentalCollaboratorService.getAuthorizedExperimentIds(experimentalCollaborator.get().getId());
 
                 BrAPITrialListResponse brapiResponse = experimentService.searchTrials(program.get(), authorizedExperimentIds, queryParams);

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
@@ -161,7 +161,7 @@ public class BrAPITrialsController {
         return HttpResponse.notFound();
     }
 
-    // TODO: Remove for trialDbId once cache is removed for that entity
+    // TODO: Verify that the programDbId does not need to be reset and that the BrAPI programDbId can be used instead [BI-2931]
     private void setDbIds(BrAPITrial trial) {
         trial.programDbId(Utilities.getExternalReference(trial.getExternalReferences(), Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.PROGRAMS))
                                  .orElseThrow(() -> new IllegalStateException("No BI external reference found"))

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
@@ -104,9 +104,14 @@ public class BrAPITrialsController {
             Optional<ProgramUser> experimentalCollaborator = programUserService.getIfExperimentalCollaborator(programId, securityService.getUser().getId());
             if (experimentalCollaborator.isPresent()) {
                 // TODO: Modify this code to use brapi side filter, pagination and sort
-                List<UUID> experimentIds = experimentalCollaboratorService.getAuthorizedExperimentIds(experimentalCollaborator.get().getId());
-                List<BrAPITrial> authorizedExperiments = experimentService.getTrialsByExperimentIds(program.get(), experimentIds).stream().peek(this::setDbIds).collect(Collectors.toList());
-                return ResponseUtils.getBrapiQueryResponse(authorizedExperiments, experimentQueryMapper, queryParams, searchRequest);
+                List<UUID> authorizedExperimentIds = experimentalCollaboratorService.getAuthorizedExperimentIds(experimentalCollaborator.get().getId());
+
+                BrAPITrialListResponse brapiResponse = experimentService.searchTrials(program.get(), authorizedExperimentIds, queryParams);
+
+                List<BrAPITrial> foundTrials = brapiResponse.getResult().getData();
+                foundTrials.forEach(this::setDbIds);
+
+                return ResponseUtils.getBrapiQueryResponse(foundTrials, brapiResponse, queryParams);
             }
 
             BrAPITrialListResponse brapiResponse = experimentService.searchTrials(program.get(), queryParams);

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
@@ -26,8 +26,8 @@ import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import lombok.extern.slf4j.Slf4j;
 import org.brapi.client.v2.model.exceptions.ApiException;
-import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPITrial;
+import org.brapi.v2.model.core.response.BrAPITrialListResponse;
 import org.brapi.v2.model.core.response.BrAPITrialSingleResponse;
 import org.breedinginsight.api.auth.*;
 import org.breedinginsight.api.model.v1.request.query.SearchRequest;
@@ -43,8 +43,6 @@ import org.breedinginsight.model.ProgramUser;
 import org.breedinginsight.services.ExperimentalCollaboratorService;
 import org.breedinginsight.services.ProgramService;
 import org.breedinginsight.services.ProgramUserService;
-import org.breedinginsight.model.ProgramUser;
-import org.breedinginsight.model.Role;
 import org.breedinginsight.services.exceptions.DoesNotExistException;
 import org.breedinginsight.utilities.Utilities;
 import org.breedinginsight.utilities.response.ResponseUtils;
@@ -52,7 +50,6 @@ import org.breedinginsight.utilities.response.mappers.ExperimentQueryMapper;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -65,6 +62,7 @@ public class BrAPITrialsController {
 
     private final String referenceSource;
     private final BrAPITrialService experimentService;
+    // TODO: See if it's feasible to remove this mapper entirely
     private final ExperimentQueryMapper experimentQueryMapper;
     private final SecurityService securityService;
     private final ProgramUserService programUserService;
@@ -92,7 +90,7 @@ public class BrAPITrialsController {
     @Produces(MediaType.APPLICATION_JSON)
     @ProgramSecured(roles = {ProgramSecuredRole.SYSTEM_ADMIN, ProgramSecuredRole.READ_ONLY, ProgramSecuredRole.PROGRAM_ADMIN
             ,ProgramSecuredRole.EXPERIMENTAL_COLLABORATOR })
-    public HttpResponse<Response<DataResponse<List<BrAPITrial>>>> getExperiments(
+    public HttpResponse<Response<DataResponse<BrAPITrial>>> getExperiments(
             @PathVariable("programId") UUID programId,
             @QueryValue @QueryValid(using = ExperimentQueryMapper.class) @Valid ExperimentQuery queryParams) {
         try {
@@ -105,13 +103,17 @@ public class BrAPITrialsController {
             // If the program user is an experimental collaborator, filter results for only authorized experiments.
             Optional<ProgramUser> experimentalCollaborator = programUserService.getIfExperimentalCollaborator(programId, securityService.getUser().getId());
             if (experimentalCollaborator.isPresent()) {
+                // TODO: Modify this code to use brapi side filter, pagination and sort
                 List<UUID> experimentIds = experimentalCollaboratorService.getAuthorizedExperimentIds(experimentalCollaborator.get().getId());
                 List<BrAPITrial> authorizedExperiments = experimentService.getTrialsByExperimentIds(program.get(), experimentIds).stream().peek(this::setDbIds).collect(Collectors.toList());
                 return ResponseUtils.getBrapiQueryResponse(authorizedExperiments, experimentQueryMapper, queryParams, searchRequest);
             }
 
-            List<BrAPITrial> experiments = experimentService.getExperiments(programId).stream().peek(this::setDbIds).collect(Collectors.toList());
-            return ResponseUtils.getBrapiQueryResponse(experiments, experimentQueryMapper, queryParams, searchRequest);
+            BrAPITrialListResponse brapiResponse = experimentService.searchTrials(program.get(), queryParams);
+
+            List<BrAPITrial> foundTrials = brapiResponse.getResult().getData();
+            foundTrials.forEach(this::setDbIds);
+            return ResponseUtils.getBrapiQueryResponse(foundTrials, brapiResponse, queryParams);
         } catch (ApiException e) {
             log.info(e.getMessage(), e);
             return HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, "Error retrieving experiments");

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIStudyDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIStudyDAO.java
@@ -136,11 +136,11 @@ public class BrAPIStudyDAO extends BrAPICachedDAO<BrAPIStudy> {
         );
     }
 
-    public List<BrAPIStudy> getStudiesByExperimentID(@NotNull UUID experimentId, Program program) throws ApiException {
-        // TODO: This should look up on trialDbId, and the trialDbId should be passed thru
+    public List<BrAPIStudy> getStudiesByBrAPITrialExRefId(@NotNull UUID brapiTrialExRefId, Program program) throws ApiException {
+        // TODO: If external references are removed for trial for studies, this method should look up on trialDbId, and the trialDbId should be passed through.
         BrAPIStudySearchRequest studySearch = new BrAPIStudySearchRequest();
         studySearch.programDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
-        studySearch.addExternalReferenceIdsItem(experimentId.toString());
+        studySearch.addExternalReferenceIdsItem(brapiTrialExRefId.toString());
         studySearch.addExternalReferenceSourcesItem(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.TRIALS));
         StudiesApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), StudiesApi.class);
         return brAPIDAOUtil.search(

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIStudyDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIStudyDAO.java
@@ -137,7 +137,7 @@ public class BrAPIStudyDAO extends BrAPICachedDAO<BrAPIStudy> {
     }
 
     public List<BrAPIStudy> getStudiesByBrAPITrialExRefId(@NotNull UUID brapiTrialExRefId, Program program) throws ApiException {
-        // TODO: If external references are removed for trial for studies, this method should look up on trialDbId, and the trialDbId should be passed through.
+        // TODO: If external references are removed for trial for studies, this method should look up on trialDbId, and the trialDbId should be passed through. [BI-2933]
         BrAPIStudySearchRequest studySearch = new BrAPIStudySearchRequest();
         studySearch.programDbIds(List.of(program.getBrapiProgram().getProgramDbId()));
         studySearch.addExternalReferenceIdsItem(brapiTrialExRefId.toString());

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
@@ -19,6 +19,9 @@ package org.breedinginsight.brapi.v2.dao;
 
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.core.BrAPITrial;
+import org.brapi.v2.model.core.request.BrAPITrialSearchRequest;
+import org.brapi.v2.model.core.response.BrAPITrialListResponse;
+import org.breedinginsight.brapi.v2.model.request.query.ExperimentQuery;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.model.Program;
 import org.breedinginsight.services.exceptions.DoesNotExistException;
@@ -45,4 +48,6 @@ public interface BrAPITrialDAO {
     List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException;
 
     void deleteBrAPITrial(Program program, BrAPITrial trial, boolean hard) throws ApiException;
+
+    BrAPITrialListResponse brapiTrialSearch(Program program, ExperimentQuery experimentQuery) throws ApiException;
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPITrialDAO.java
@@ -50,4 +50,7 @@ public interface BrAPITrialDAO {
     void deleteBrAPITrial(Program program, BrAPITrial trial, boolean hard) throws ApiException;
 
     BrAPITrialListResponse brapiTrialSearch(Program program, ExperimentQuery experimentQuery) throws ApiException;
+
+    BrAPITrialListResponse brapiTrialSearch(Program program, List<UUID> brapiTrialIds, ExperimentQuery experimentQuery) throws ApiException;
+
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -227,11 +227,17 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
     }
 
     @Override
+    public BrAPITrialListResponse brapiTrialSearch(Program program, ExperimentQuery experimentQuery) throws ApiException {
+        return brapiTrialSearch(program, Collections.emptyList(), experimentQuery);
+    }
+
+    @Override
     public BrAPITrialListResponse brapiTrialSearch(Program program,
-                                             ExperimentQuery experimentQuery) throws ApiException {
+                                                   List<UUID> brapiTrialIds,
+                                                   ExperimentQuery experimentQuery) throws ApiException {
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), TrialsApi.class);
 
-        BrAPITrialSearchRequest brAPITrialSearchRequest = buildSearchRequest(program, experimentQuery);
+        BrAPITrialSearchRequest brAPITrialSearchRequest = buildSearchRequest(program, brapiTrialIds, experimentQuery);
 
         BrAPITrialListResponse brAPIResponse =
                 brAPIDAOUtil.simpleSearch(
@@ -263,7 +269,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
     }
 
 
-    private BrAPITrialSearchRequest buildSearchRequest(Program program, ExperimentQuery experimentQuery) {
+    private BrAPITrialSearchRequest buildSearchRequest(Program program, List<UUID> brapiTrialIds, ExperimentQuery experimentQuery) {
         BrAPIProgram brAPIProgram = programDAO.getProgramBrAPI(program);
 
         if (brAPIProgram == null || brAPIProgram.getProgramDbId() == null) {
@@ -273,6 +279,10 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         BrAPITrialSearchRequest searchRequest = new BrAPITrialSearchRequest();
 
         searchRequest.programDbIds(List.of(brAPIProgram.getProgramDbId()));
+
+        if (brapiTrialIds != null && !brapiTrialIds.isEmpty()) {
+            searchRequest.setTrialDbIds(brapiTrialIds.stream().map(UUID::toString).collect(Collectors.toList()));
+        }
 
         // Set FilterBy
         List<BrAPIFilterBy> brAPIFilterBy = new ArrayList<>();

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -83,6 +83,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
      * This method requires a BI-API program.  If the BrAPIProgram inside this data model is not set,
      * this method will retrieve it.
      */
+    // TODO: Generalize Code for General Get By Program for BrAPI Entities [BI-2932]
     private List<BrAPITrial> getBrAPITrialsUsingBrAPIProgramId(Program program) throws ApiException {
 
         if (program == null || program.getId() == null) {
@@ -98,7 +99,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
             brapiProgramDbId = programDAO.getProgramBrAPI(program).getProgramDbId();
         }
 
-        // TODO: Configurable max amount of trials per program, or paginate.
+        // TODO: Configurable max amount of trials per program, or paginate [BI-2932]
 
         TrialQueryParams trialQueryParams =
                 TrialQueryParams.builder()
@@ -255,7 +256,6 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
 
     @Override
     public void deleteBrAPITrial(Program program, BrAPITrial trial, boolean hard) throws ApiException {
-        // TODO: Switch to using the TrialsApi from the BrAPI client library once the delete endpoints are merged into it.
         var programBrAPIBaseUrl = brAPIDAOUtil.getProgramBrAPIBaseUrl(program.getId());
         var requestUrl = HttpUrl.parse(programBrAPIBaseUrl + "/trials/" + trial.getTrialDbId()).newBuilder();
         requestUrl.addQueryParameter("hardDelete", Boolean.toString(hard));

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -305,8 +305,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
             searchRequest.setSortBy(brAPISortBy);
         }
 
-        searchRequest.setPage(experimentQuery.getPage());
-        searchRequest.setPageSize(experimentQuery.getPageSize());
+        brAPIDAOUtil.setPagination(searchRequest, experimentQuery);
 
         return searchRequest;
 

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -21,15 +21,21 @@ import io.micronaut.http.server.exceptions.InternalServerException;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
+import org.apache.commons.lang3.StringUtils;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.model.queryParams.core.TrialQueryParams;
 import org.brapi.client.v2.modules.core.TrialsApi;
+import org.brapi.v2.model.BrAPIFilterBy;
+import org.brapi.v2.model.BrAPIResponse;
+import org.brapi.v2.model.BrAPISortBy;
 import org.brapi.v2.model.core.BrAPIProgram;
 import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.core.request.BrAPITrialSearchRequest;
 import org.brapi.v2.model.core.response.BrAPITrialListResponse;
 import org.breedinginsight.brapi.v2.dao.BrAPITrialDAO;
+import org.breedinginsight.brapi.v2.model.request.query.ExperimentQuery;
+import org.breedinginsight.brapi.v2.utilities.BrAPITrialsMapper;
 import org.breedinginsight.brapps.importer.daos.ImportDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.daos.ProgramDAO;
@@ -52,16 +58,25 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
     private final ImportDAO importDAO;
     private final BrAPIDAOUtil brAPIDAOUtil;
     private final BrAPIEndpointProvider brAPIEndpointProvider;
+    private final BrAPITrialsMapper brAPITrialsMapper;
+
+
+    private static final String BI_FILTER_COLUMN_NAME = "name";
+    private static final String BI_FILTER_COLUMN_ACTIVE = "active";
+    private static final String BI_FILTER_COLUMN_CREATED_DATE = "createdDate";
+    private static final String BI_FILTER_COLUMN_CREATED_BY = "createdBy";
 
     @Inject
     public BrAPITrialDAOImpl(ProgramDAO programDAO,
                              ImportDAO importDAO,
                              BrAPIDAOUtil brAPIDAOUtil,
-                             BrAPIEndpointProvider brAPIEndpointProvider) {
+                             BrAPIEndpointProvider brAPIEndpointProvider,
+                             BrAPITrialsMapper brAPITrialsMapper) {
         this.programDAO = programDAO;
         this.importDAO = importDAO;
         this.brAPIDAOUtil = brAPIDAOUtil;
         this.brAPIEndpointProvider = brAPIEndpointProvider;
+        this.brAPITrialsMapper = brAPITrialsMapper;
     }
 
     /**
@@ -212,6 +227,27 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
     }
 
     @Override
+    public BrAPITrialListResponse brapiTrialSearch(Program program,
+                                             ExperimentQuery experimentQuery) throws ApiException {
+        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), TrialsApi.class);
+
+        BrAPITrialSearchRequest brAPITrialSearchRequest = buildSearchRequest(program, experimentQuery);
+
+        BrAPITrialListResponse brAPIResponse =
+                brAPIDAOUtil.simpleSearch(
+                        api::searchTrialsPost,
+                        brAPITrialSearchRequest
+                );
+
+        List<BrAPITrial> processedTrials =
+                processExperimentsForDisplay(brAPIDAOUtil.getListResult(brAPIResponse), program.getKey());
+
+        brAPIResponse.getResult().setData(processedTrials);
+
+        return brAPIResponse;
+    }
+
+    @Override
     public void deleteBrAPITrial(Program program, BrAPITrial trial, boolean hard) throws ApiException {
         // TODO: Switch to using the TrialsApi from the BrAPI client library once the delete endpoints are merged into it.
         var programBrAPIBaseUrl = brAPIDAOUtil.getProgramBrAPIBaseUrl(program.getId());
@@ -224,5 +260,55 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
                 .build();
 
         brAPIDAOUtil.makeCall(brapiRequest);
+    }
+
+
+    private BrAPITrialSearchRequest buildSearchRequest(Program program, ExperimentQuery experimentQuery) {
+        BrAPIProgram brAPIProgram = programDAO.getProgramBrAPI(program);
+
+        if (brAPIProgram == null || brAPIProgram.getProgramDbId() == null) {
+            throw new InternalServerException(String.format("BI program with id [%s] not found in BrAPI db", program.getId()));
+        }
+
+        BrAPITrialSearchRequest searchRequest = new BrAPITrialSearchRequest();
+
+        searchRequest.programDbIds(List.of(brAPIProgram.getProgramDbId()));
+
+        // Set FilterBy
+        List<BrAPIFilterBy> brAPIFilterBy = new ArrayList<>();
+
+        if (StringUtils.isNotBlank(experimentQuery.getName())) {
+            brAPIFilterBy.add(brAPIDAOUtil.constructFilterBy(brAPITrialsMapper.getBrAPIName(BI_FILTER_COLUMN_NAME), experimentQuery.getName()));
+        }
+        if (StringUtils.isNotBlank(experimentQuery.getActive())) {
+            brAPIFilterBy.add(brAPIDAOUtil.constructFilterBy(brAPITrialsMapper.getBrAPIName(BI_FILTER_COLUMN_ACTIVE), experimentQuery.getActive()));
+        }
+        if (StringUtils.isNotBlank(experimentQuery.getCreatedBy())) {
+            brAPIFilterBy.add(brAPIDAOUtil.constructFilterBy(brAPITrialsMapper.getBrAPIName(BI_FILTER_COLUMN_CREATED_BY), experimentQuery.getCreatedBy()));
+        }
+        if (StringUtils.isNotBlank(experimentQuery.getCreatedDate())) {
+            brAPIFilterBy.add(brAPIDAOUtil.constructFilterBy(brAPITrialsMapper.getBrAPIName(BI_FILTER_COLUMN_CREATED_DATE), experimentQuery.getCreatedDate()));
+        }
+
+        if (!brAPIFilterBy.isEmpty()) {
+            searchRequest.setFilterBy(brAPIFilterBy);
+        }
+
+        // Set SortBy
+        List<BrAPISortBy> brAPISortBy = new ArrayList<>();
+
+        if (StringUtils.isNotBlank(experimentQuery.getSortField()) && brAPITrialsMapper.exists(experimentQuery.getSortField())) {
+            brAPISortBy.add(brAPIDAOUtil.constructSortBy(brAPITrialsMapper.getBrAPIName(experimentQuery.getSortField()), experimentQuery.getSortOrder().toString()));
+        }
+
+        if (!brAPISortBy.isEmpty()) {
+            searchRequest.setSortBy(brAPISortBy);
+        }
+
+        searchRequest.setPage(experimentQuery.getPage());
+        searchRequest.setPageSize(experimentQuery.getPageSize());
+
+        return searchRequest;
+
     }
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -17,7 +17,6 @@
 package org.breedinginsight.brapi.v2.dao.impl;
 
 import io.micronaut.context.annotation.Context;
-import io.micronaut.context.annotation.Property;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.HttpUrl;
@@ -33,10 +32,8 @@ import org.brapi.v2.model.core.response.BrAPITrialListResponse;
 import org.breedinginsight.brapi.v2.dao.BrAPITrialDAO;
 import org.breedinginsight.brapps.importer.daos.ImportDAO;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
-import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.daos.ProgramDAO;
 import org.breedinginsight.model.Program;
-import org.breedinginsight.services.ProgramService;
 import org.breedinginsight.services.brapi.BrAPIEndpointProvider;
 import org.breedinginsight.services.exceptions.DoesNotExistException;
 import org.breedinginsight.utilities.BrAPIDAOUtil;
@@ -54,33 +51,24 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
     private final ProgramDAO programDAO;
     private final ImportDAO importDAO;
     private final BrAPIDAOUtil brAPIDAOUtil;
-    private final ProgramService programService;
     private final BrAPIEndpointProvider brAPIEndpointProvider;
-    private final String referenceSource;
-    private final boolean runScheduledTasks;
 
     @Inject
     public BrAPITrialDAOImpl(ProgramDAO programDAO,
                              ImportDAO importDAO,
                              BrAPIDAOUtil brAPIDAOUtil,
-                             ProgramService programService,
-                             @Property(name = "brapi.server.reference-source") String referenceSource,
-                             BrAPIEndpointProvider brAPIEndpointProvider,
-                             @Property(name = "micronaut.bi.api.run-scheduled-tasks") boolean runScheduledTasks) {
+                             BrAPIEndpointProvider brAPIEndpointProvider) {
         this.programDAO = programDAO;
         this.importDAO = importDAO;
         this.brAPIDAOUtil = brAPIDAOUtil;
-        this.programService = programService;
-        this.referenceSource = referenceSource;
         this.brAPIEndpointProvider = brAPIEndpointProvider;
-        this.runScheduledTasks = runScheduledTasks;
     }
 
     /**
      * This method requires a BI-API program.  If the BrAPIProgram inside this data model is not set,
      * this method will retrieve it.
      */
-    private List<BrAPITrial> getBrAPITrialsUsingBrAPIProgram(Program program) throws ApiException {
+    private List<BrAPITrial> getBrAPITrialsUsingBrAPIProgramId(Program program) throws ApiException {
 
         if (program == null || program.getId() == null) {
             throw new InternalServerException("BI-API Program or Program ID is null");
@@ -128,17 +116,9 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         return processExperimentsForDisplay(trialsFromResponse, program.getKey());
     }
 
-    private Map<String, BrAPITrial> experimentById(List<BrAPITrial> trials) {
-        Map<String, BrAPITrial> experimentById = new HashMap<>();
-        for (BrAPITrial experiment: trials) {
-            experimentById.put(experiment.getTrialDbId(), experiment);
-        }
-        return experimentById;
-    }
-
     @Override
     public List<BrAPITrial> getTrialsByName(List<String> trialNames, Program program) throws ApiException {
-        List<BrAPITrial> allTrialsForProgram = getBrAPITrialsUsingBrAPIProgram(program);
+        List<BrAPITrial> allTrialsForProgram = getBrAPITrialsUsingBrAPIProgramId(program);
 
         List<BrAPITrial> trials = new ArrayList<>();
         if (allTrialsForProgram != null) {
@@ -151,7 +131,6 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         return trials;
     }
 
-    // TODO: Fix by using only code of inner callback and returning result
     @Override
     public List<BrAPITrial> createBrAPITrials(List<BrAPITrial> brAPITrialList, UUID programId, ImportUpload upload) {
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
@@ -177,7 +156,7 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         Program program = programDAO.get(programId).get(0);
         program.setBrapiProgram(programDAO.getProgramBrAPI(program));
 
-        return getBrAPITrialsUsingBrAPIProgram(program);
+        return getBrAPITrialsUsingBrAPIProgramId(program);
     }
 
     //Removes program key from trial name
@@ -213,7 +192,6 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         return getTrialsByExperimentIds(trialDbUUIDs, program);
     }
 
-    // TODO: ExperimentIds will = trialDbIds once cache is updated.  Update this method to get trials on dbId directly from brapi.
     @Override
     public List<BrAPITrial> getTrialsByExperimentIds(Collection<UUID> experimentIds, Program program) throws ApiException {
         if(experimentIds.isEmpty()) {

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -127,6 +127,12 @@ public class BrAPITrialService {
         return trialDAO.brapiTrialSearch(program, experimentQuery);
     }
 
+    public BrAPITrialListResponse searchTrials(Program program,
+                                               List<UUID> brapiTrialIds,
+                                               ExperimentQuery experimentQuery) throws ApiException, DoesNotExistException {
+        return trialDAO.brapiTrialSearch(program, brapiTrialIds, experimentQuery);
+    }
+
     public List<BrAPITrial> getTrialsByProgramId(UUID programId) throws ApiException {
         return trialDAO.getTrials(programId);
     }

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -823,7 +823,7 @@ public class BrAPITrialService {
             // Make request to delete experiment.
             trialDAO.deleteBrAPITrial(program, trial, hard);
             // Get all lists for the trial.
-            // TODO: Get lists by trialDbId if trials get decoupled from datasets.
+            // TODO: Get lists by trialDbId if trials get decoupled from datasets. [BI-2993]
             List<BrAPIListSummary> lists = listDAO
                     .getListsByTypeAndExternalRef(BrAPIListTypes.OBSERVATIONVARIABLES,
                             program.getId(),

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -196,7 +196,7 @@ public class BrAPITrialService {
 
         // get requested environments for the experiment
         log.debug(logHash + ": fetching environments for export");
-        List<BrAPIStudy> expStudies = studyDAO.getStudiesByExperimentID(UUID.fromString(expExRefId), program);
+        List<BrAPIStudy> expStudies = studyDAO.getStudiesByBrAPITrialExRefId(UUID.fromString(expExRefId), program);
         if (!requestedEnvIds.isEmpty()) {
             expStudies = expStudies
                     .stream()

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPITrialService.java
@@ -15,6 +15,7 @@ import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.*;
 import org.brapi.v2.model.core.response.BrAPIListsSingleResponse;
+import org.brapi.v2.model.core.response.BrAPITrialListResponse;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 
 import org.brapi.v2.model.pheno.*;
@@ -22,6 +23,7 @@ import org.breedinginsight.api.model.v1.request.SubEntityDatasetRequest;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapi.v2.dao.*;
 import org.breedinginsight.brapi.v2.model.request.query.ExperimentExportQuery;
+import org.breedinginsight.brapi.v2.model.request.query.ExperimentQuery;
 import org.breedinginsight.brapps.importer.model.exports.FileType;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation.Columns;
@@ -120,8 +122,12 @@ public class BrAPITrialService {
         this.observationLevelService = observationLevelService;
     }
 
-    public List<BrAPITrial> getExperiments(UUID programId) throws ApiException, DoesNotExistException {
-        // TODO: Edit this to filter/paginate trials
+    public BrAPITrialListResponse searchTrials(Program program,
+                                               ExperimentQuery experimentQuery) throws ApiException, DoesNotExistException {
+        return trialDAO.brapiTrialSearch(program, experimentQuery);
+    }
+
+    public List<BrAPITrial> getTrialsByProgramId(UUID programId) throws ApiException {
         return trialDAO.getTrials(programId);
     }
 

--- a/src/main/java/org/breedinginsight/brapi/v2/utilities/BrAPISortFilterMapper.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/utilities/BrAPISortFilterMapper.java
@@ -1,0 +1,28 @@
+package org.breedinginsight.brapi.v2.utilities;
+
+import java.util.Map;
+
+public abstract class BrAPISortFilterMapper {
+
+    private final  Map<String, String> fields;
+
+    protected BrAPISortFilterMapper(Map<String, String> fields) {
+        this.fields = Map.copyOf(fields);
+    }
+
+    public boolean exists(String fieldName) {
+        return fields.containsKey(fieldName);
+    }
+
+    public String getBrAPIName(String biFieldName) throws NullPointerException {
+        String value = fields.get(biFieldName);
+
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    "No BrAPI mapping exists for field: " + biFieldName
+            );
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/org/breedinginsight/brapi/v2/utilities/BrAPITrialsMapper.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/utilities/BrAPITrialsMapper.java
@@ -1,0 +1,16 @@
+package org.breedinginsight.brapi.v2.utilities;
+
+import javax.inject.Singleton;
+import java.util.Map;
+
+@Singleton
+public class BrAPITrialsMapper extends BrAPISortFilterMapper {
+    public BrAPITrialsMapper() {
+        super(Map.of(
+                "name", "trialName",
+                "active", "active",
+                "createdBy", "createdBy",
+                "createdDate", "createdDate"
+        ));
+    }
+}

--- a/src/main/java/org/breedinginsight/brapps/importer/model/response/PendingImportObject.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/response/PendingImportObject.java
@@ -33,7 +33,7 @@ public class PendingImportObject<T> {
     public PendingImportObject(ImportObjectState state, T brAPIObject, UUID id) {
         this.state = state;
         this.brAPIObject = brAPIObject;
-        // TODO: With 1.5 work, this id is the BI-API generated ID that is set for external references in BrAPI.  It is different than the BrAPI DB ID of an entity. We may want to consider changing this at some point
+        // TODO: With 1.5 work, this id is the BI-API generated ID that is set for external references in BrAPI.  It is different than the BrAPI DB ID of an entity. We may want to consider changing this at some point [BI-2933]
         this.id = id;
     }
     public PendingImportObject(ImportObjectState state, T brAPIObject) {

--- a/src/main/java/org/breedinginsight/brapps/importer/model/response/PendingImportObject.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/response/PendingImportObject.java
@@ -33,6 +33,7 @@ public class PendingImportObject<T> {
     public PendingImportObject(ImportObjectState state, T brAPIObject, UUID id) {
         this.state = state;
         this.brAPIObject = brAPIObject;
+        // TODO: With 1.5 work, this id is the BI-API generated ID that is set for external references in BrAPI.  It is different than the BrAPI DB ID of an entity. We may want to consider changing this at some point
         this.id = id;
     }
     public PendingImportObject(ImportObjectState state, T brAPIObject) {

--- a/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/PopulateExistingPendingImportObjectsStep.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/services/processors/experiment/create/workflow/steps/PopulateExistingPendingImportObjectsStep.java
@@ -213,7 +213,7 @@ public class PopulateExistingPendingImportObjectsStep {
         try {
             // the 'trial' variable will never be "null".
             UUID experimentId = UUID.fromString(expExRefId);
-            existingStudies = brAPIStudyDAO.getStudiesByExperimentID(experimentId, program);
+            existingStudies = brAPIStudyDAO.getStudiesByBrAPITrialExRefId(experimentId, program);
             for (BrAPIStudy existingStudy : existingStudies) {
                 experimentStudyService.processAndCacheStudy(existingStudy, program, BrAPIStudy::getStudyName, studyByName);
             }

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -44,10 +44,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static org.brapi.v2.model.BrAPIWSMIMEDataTypes.APPLICATION_JSON;
@@ -76,6 +73,53 @@ public class BrAPIDAOUtil {
         this.postGroupSize = postGroupSize;
         this.brapiFetchPageSize = brapiFetchPageSize;
         this.programService = programService;
+    }
+
+    // Performs a POST brapi search on an entity without looping paging logic, utilizing filters and pagination provided in the searchBody.
+    // Also verifies response paging matches requested paging
+    public <T extends BrAPIResponse, U extends BrAPISearchRequestParametersPaging, V> T simpleSearch(Function<U, ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>>> searchMethod,
+                                                                                     U searchBody) throws ApiException {
+        List<V> result = new ArrayList<>();
+
+
+        T brapiResponseResult = null;
+
+        try {
+            // Traverse response with an optional to allow for free null checking with .map()
+            brapiResponseResult = Optional.ofNullable(searchMethod.apply(searchBody))
+                    .map(ApiResponse::getBody)
+                    .map(Pair::getLeft)
+                    // Deal with wrapped Optionals
+                    .flatMap(optional -> optional)
+                    .orElseThrow();
+        } catch (ApiException e) {
+            log.warn(Utilities.generateApiExceptionLogMessage(e));
+            throw e;
+        } catch (NoSuchElementException e) {
+            log.debug("Unable to retrieve BrAPIResponse from POST search request", e);
+            throw new InternalServerException(e.toString(), e);
+        } catch (Exception e) {
+            log.debug("error", e);
+            throw new InternalServerException(e.toString(), e);
+        }
+
+        BrAPIPagination responsePagination = Optional.of(brapiResponseResult)
+                .map(BrAPIResponse::getMetadata)
+                .map(BrAPIMetadata::getPagination)
+                .orElse(null);
+
+        if (responsePagination == null) {
+            throw new InternalServerException("Expected pagination metadata in BrAPI search response not present");
+        }
+
+        var requestPageNumber = searchBody.getPage();
+        var requestPageSize = searchBody.getPageSize();
+
+        if (!responsePagination.getCurrentPage().equals(requestPageNumber) || !responsePagination.getPageSize().equals(requestPageSize)) {
+            throw new InternalServerException("Page number and/or page size do not match between BrAPI search request and response");
+        }
+
+        return brapiResponseResult;
     }
 
     public <T, U extends BrAPISearchRequestParametersPaging, V> List<V> search(Function<U, ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>>> searchMethod,
@@ -302,6 +346,14 @@ public class BrAPIDAOUtil {
                 new ArrayList<>();
     }
 
+    public <T extends BrAPIResponse, V> List<V> getListResult(T response) {
+        return Optional.ofNullable(response)
+                .map(BrAPIResponse::getResult)
+                .map(result -> (BrAPIResponseResult<V>) result)
+                .map(BrAPIResponseResult::getData)
+                .orElseThrow();
+    }
+
     // TODO: write generic put code
     public <T> List<T> put(List<T> brapiObjects,
                            ImportUpload upload,
@@ -454,5 +506,28 @@ public class BrAPIDAOUtil {
         var programBrAPIBaseUrl = programBrAPIEndpoints.getCoreUrl().get();
         programBrAPIBaseUrl = programBrAPIBaseUrl.endsWith("/") ? programBrAPIBaseUrl.substring(0, programBrAPIBaseUrl.length() - 1) : programBrAPIBaseUrl;
         return programBrAPIBaseUrl.endsWith(BrapiVersion.BRAPI_V2) ? programBrAPIBaseUrl : programBrAPIBaseUrl + BrapiVersion.BRAPI_V2;
+    }
+
+    public BrAPIFilterBy constructFilterBy(String filterOn, String value) {
+        var filterBy = new BrAPIFilterBy();
+
+        filterBy.setFilterOn(filterOn);
+        filterBy.setValue(value);
+        return filterBy;
+    }
+
+    public BrAPISortBy constructSortBy(String sortOn, String sortOrder) {
+        var sortBy = new BrAPISortBy();
+        sortBy.setSortedOn(sortOn);
+
+        BrAPISortOrder sortOrderEnum = BrAPISortOrder.valueOf(sortOrder.toUpperCase());
+
+        if (sortOrderEnum == null) {
+            sortOrderEnum = BrAPISortOrder.ASC;
+        }
+
+        sortBy.setSortOrder(sortOrderEnum);
+
+        return sortBy;
     }
 }

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -35,6 +35,7 @@ import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.*;
 import org.breedinginsight.api.model.v1.response.DataResponse;
 import org.breedinginsight.brapi.v1.controller.BrapiVersion;
+import org.breedinginsight.brapi.v1.model.request.query.BrapiQuery;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.model.ProgramBrAPIEndpoints;
 import org.breedinginsight.services.ProgramService;
@@ -79,10 +80,7 @@ public class BrAPIDAOUtil {
     // Also verifies response paging matches requested paging
     public <T extends BrAPIResponse, U extends BrAPISearchRequestParametersPaging, V> T simpleSearch(Function<U, ApiResponse<Pair<Optional<T>, Optional<BrAPIAcceptedSearchResponse>>>> searchMethod,
                                                                                      U searchBody) throws ApiException {
-        List<V> result = new ArrayList<>();
-
-
-        T brapiResponseResult = null;
+        T brapiResponseResult;
 
         try {
             // Traverse response with an optional to allow for free null checking with .map()
@@ -529,5 +527,19 @@ public class BrAPIDAOUtil {
         sortBy.setSortOrder(sortOrderEnum);
 
         return sortBy;
+    }
+
+    public <T extends BrAPISearchRequestParametersPaging, U extends BrapiQuery> void setPagination(T brapiSearchRequest, U biSearchQuery) {
+        if (biSearchQuery.getPage() == null) {
+            brapiSearchRequest.setPage(biSearchQuery.getDefaultPage());
+        } else {
+            brapiSearchRequest.setPage(biSearchQuery.getPage());
+        }
+
+        if (biSearchQuery.getPageSize() == null) {
+            brapiSearchRequest.setPageSize(biSearchQuery.getDefaultPageSize());
+        } else  {
+            brapiSearchRequest.setPageSize(biSearchQuery.getPageSize());
+        }
     }
 }

--- a/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
+++ b/src/main/java/org/breedinginsight/utilities/response/ResponseUtils.java
@@ -24,6 +24,8 @@ import io.micronaut.http.MediaType;
 import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.http.server.types.files.StreamedFile;
 import org.apache.commons.lang3.tuple.Pair;
+import org.brapi.client.v2.model.queryParams.core.BrAPIQueryParams;
+import org.brapi.v2.model.BrAPIResponse;
 import org.breedinginsight.api.model.v1.request.query.PaginationParams;
 import org.breedinginsight.api.model.v1.request.query.QueryParams;
 import org.breedinginsight.api.model.v1.request.query.SearchRequest;
@@ -127,6 +129,19 @@ public class ResponseUtils {
         Pair<List, Pagination> paginationResult = paginateData(data, queryParams);
         metadata = constructMetadata(metadata, paginationResult.getRight());
         return HttpResponse.ok(new Response(metadata, new DataResponse(paginationResult.getLeft())));
+    }
+
+    public static <T> HttpResponse<Response<DataResponse<T>>> getBrapiQueryResponse(List<T> data,
+                                                                                    BrAPIResponse brAPIResponse,
+                                                                                    BrapiQuery queryParams) {
+        Pagination pagination = new Pagination();
+        pagination.setTotalCount(brAPIResponse.getMetadata().getPagination().getTotalCount());
+        pagination.setCurrentPage(queryParams.getPage());
+        pagination.setPageSize(queryParams.getPageSize());
+
+        Metadata metadata = constructMetadata(new Metadata(), pagination);
+
+        return HttpResponse.ok(new Response<>(metadata, new DataResponse<>(data)));
     }
 
     private static <T> HttpResponse<Response<ProgramUpload>> processUploadSearchResponse(

--- a/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/ExperimentControllerIntegrationTest.java
@@ -24,6 +24,7 @@ import org.breedinginsight.api.auth.AuthenticatedUser;
 import org.breedinginsight.api.model.v1.request.ProgramRequest;
 import org.breedinginsight.api.model.v1.request.SpeciesRequest;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
+import org.breedinginsight.brapi.v2.model.request.query.ExperimentQuery;
 import org.breedinginsight.brapi.v2.services.BrAPITrialService;
 import org.breedinginsight.brapps.importer.ImportTestUtils;
 import org.breedinginsight.brapps.importer.model.exports.FileType;
@@ -204,7 +205,7 @@ public class ExperimentControllerIntegrationTest extends BrAPITest {
                 mappingId,
                 newExperimentWorkflowId);
 
-        BrAPITrial trial = brAPITrialService.getExperiments(program.getId()).get(0);
+        BrAPITrial trial = brAPITrialService.getTrialsByProgramId(program.getId()).get(0);
 
         experimentId = trial.getTrialDbId();
 
@@ -244,7 +245,7 @@ public class ExperimentControllerIntegrationTest extends BrAPITest {
                 mappingId,
                 newExperimentWorkflowId);
 
-        BrAPITrial trial = brAPITrialService.getExperiments(targetProgram.getId())
+        BrAPITrial trial = brAPITrialService.getTrialsByProgramId(targetProgram.getId())
                 .stream()
                 .filter(t -> t.getTrialName().equals(title))
                 .findFirst()
@@ -939,7 +940,7 @@ public class ExperimentControllerIntegrationTest extends BrAPITest {
                 mappingId,
                 newExperimentWorkflowId);
 
-        BrAPITrial trial = brAPITrialService.getExperiments(targetProgram.getId())
+        BrAPITrial trial = brAPITrialService.getTrialsByProgramId(targetProgram.getId())
                 .stream()
                 .filter(t -> t.getTrialName().equals(title))
                 .findFirst()

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPITestUtils.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPITestUtils.java
@@ -38,6 +38,7 @@ import org.breedinginsight.api.model.v1.request.ProgramRequest;
 import org.breedinginsight.api.model.v1.request.SpeciesRequest;
 import org.breedinginsight.api.v1.controller.TestTokenValidator;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
+import org.breedinginsight.brapi.v2.model.request.query.ExperimentQuery;
 import org.breedinginsight.brapi.v2.services.BrAPITrialService;
 import org.breedinginsight.brapps.importer.ImportTestUtils;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
@@ -200,7 +201,7 @@ public class BrAPITestUtils {
                 mappingId,
                 newExperimentWorkflowId);
 
-        List<BrAPITrial> trials = brAPITrialService.getExperiments(program.getId())
+        List<BrAPITrial> trials = brAPITrialService.getTrialsByProgramId(program.getId())
                 .stream()
                 // Ensure trial with title xyz is always second
                 .sorted(Comparator.comparing(BrAPITrial::getTrialName))

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ObservationVariableControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPIV2ObservationVariableControllerIntegrationTest.java
@@ -41,6 +41,7 @@ import org.breedinginsight.api.model.v1.request.ProgramRequest;
 import org.breedinginsight.api.model.v1.request.SpeciesRequest;
 import org.breedinginsight.api.v1.controller.TestTokenValidator;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
+import org.breedinginsight.brapi.v2.model.request.query.ExperimentQuery;
 import org.breedinginsight.brapi.v2.services.BrAPITrialService;
 import org.breedinginsight.brapps.importer.ImportTestUtils;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
@@ -200,7 +201,7 @@ public class BrAPIV2ObservationVariableControllerIntegrationTest extends BrAPITe
                 mappingId,
                 newExperimentWorkflowId);
 
-        BrAPITrial trial = brAPITrialService.getExperiments(program.getId())
+        BrAPITrial trial = brAPITrialService.getTrialsByProgramId(program.getId())
                 .stream()
                 .findFirst()
                 .orElseThrow();

--- a/src/test/java/org/breedinginsight/brapi/v2/SubEntityDatasetLockIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/SubEntityDatasetLockIntegrationTest.java
@@ -1,7 +1,6 @@
 package org.breedinginsight.brapi.v2;
 
 import com.google.gson.*;
-import io.micronaut.context.annotation.Property;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -12,6 +11,7 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import org.brapi.v2.model.core.BrAPITrial;
 import org.breedinginsight.BrAPITest;
+import org.breedinginsight.brapi.v2.model.request.query.ExperimentQuery;
 import org.breedinginsight.brapi.v2.services.BrAPITrialService;
 import org.breedinginsight.model.Program;
 import org.junit.jupiter.api.*;
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.*;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -51,7 +50,7 @@ public class SubEntityDatasetLockIntegrationTest extends BrAPITest {
     void setup() throws Exception {
         var setup = brAPITestUtils.setupTestProgram(super.getBrapiDsl(), gson);
         program = setup.getV1();
-        experimentId = brAPIITrialService.getExperiments(program.getId()).stream()
+        experimentId = brAPIITrialService.getTrialsByProgramId(program.getId()).stream()
                 .map(BrAPITrial::getTrialDbId)
                 .findFirst()
                 .orElseThrow();

--- a/src/test/java/org/breedinginsight/brapi/v2/services/BrAPITrialServiceUnitTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/services/BrAPITrialServiceUnitTest.java
@@ -171,7 +171,7 @@ class BrAPITrialServiceUnitTest {
 
         when(trialDAO.getTrialsByExperimentIds(eq(List.of(UUID.fromString("11111111-1111-1111-1111-111111111111"))), eq(program)))
                 .thenReturn(List.of(experiment));
-        when(studyDAO.getStudiesByExperimentID(eq(UUID.fromString("11111111-1111-1111-1111-111111111111")), eq(program)))
+        when(studyDAO.getStudiesByBrAPITrialExRefId(eq(UUID.fromString("11111111-1111-1111-1111-111111111111")), eq(program)))
                 .thenReturn(List.of(study, secondStudy));
         when(seasonDAO.getSeasonById("season-1", program.getId())).thenReturn(season);
         when(seasonDAO.getSeasonById("season-2", program.getId())).thenReturn(secondSeason);

--- a/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/ExperimentFileImportTest.java
@@ -926,7 +926,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByBrAPITrialExRefId(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
 
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
@@ -992,7 +992,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByBrAPITrialExRefId(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
 
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
@@ -1046,7 +1046,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByBrAPITrialExRefId(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
 
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
@@ -1123,7 +1123,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByBrAPITrialExRefId(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
         assertTrue(ouIdXref.isPresent());
@@ -1192,7 +1192,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByBrAPITrialExRefId(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
 
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
@@ -1260,7 +1260,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByBrAPITrialExRefId(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
 
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
@@ -1389,7 +1389,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByBrAPITrialExRefId(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
 
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
@@ -1466,7 +1466,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByBrAPITrialExRefId(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
 
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
@@ -1542,7 +1542,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         BrAPITrial brAPITrial = brAPITrialDAO.getTrialsByName(List.of((String)newExp.get(Columns.EXP_TITLE)), program).get(0);
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(brAPITrial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
-        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
+        BrAPIStudy brAPIStudy = brAPIStudyDAO.getStudiesByBrAPITrialExRefId(UUID.fromString(trialIdXref.get().getReferenceId()), program).get(0);
 
         BrAPIObservationUnit ou = ouDAO.getObservationUnitsForStudyDbId(brAPIStudy.getStudyDbId(), program).get(0);
         Optional<BrAPIExternalReference> ouIdXref = Utilities.getExternalReference(ou.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.OBSERVATION_UNITS.getName()));
@@ -1639,7 +1639,7 @@ public class ExperimentFileImportTest extends BrAPITest {
         Optional<BrAPIExternalReference> trialIdXref = Utilities.getExternalReference(trial.getExternalReferences(), String.format("%s/%s", BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.TRIALS.getName()));
         assertTrue(trialIdXref.isPresent());
 
-        List<BrAPIStudy> studies = brAPIStudyDAO.getStudiesByExperimentID(UUID.fromString(trialIdXref.get().getReferenceId()), program);
+        List<BrAPIStudy> studies = brAPIStudyDAO.getStudiesByBrAPITrialExRefId(UUID.fromString(trialIdXref.get().getReferenceId()), program);
         assertFalse(studies.isEmpty());
         BrAPIStudy study = null;
         for(BrAPIStudy s : studies) {

--- a/src/test/java/org/breedinginsight/brapps/importer/SampleSubmissionFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/SampleSubmissionFileImportTest.java
@@ -45,8 +45,8 @@ import org.breedinginsight.api.model.v1.request.ProgramRequest;
 import org.breedinginsight.api.model.v1.request.SpeciesRequest;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
 import org.breedinginsight.brapi.v2.dao.*;
+import org.breedinginsight.brapi.v2.model.request.query.ExperimentQuery;
 import org.breedinginsight.brapi.v2.services.BrAPITrialService;
-import org.breedinginsight.brapps.importer.daos.*;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
 import org.breedinginsight.brapps.importer.model.imports.sample.SampleSubmissionImport.Columns;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
@@ -585,7 +585,7 @@ public class SampleSubmissionFileImportTest extends BrAPITest {
 
         try {
             // Assumes only one trial/experiment exists
-            BrAPITrial trial = brAPITrialService.getExperiments(program.getId())
+            BrAPITrial trial = brAPITrialService.getTrialsByProgramId(program.getId())
                     .stream()
                     .findFirst()
                     .orElseThrow();


### PR DESCRIPTION
# Description
**Story:** [BI-2861](https://breedinginsight.atlassian.net/browse/BI-2861)

To support the removal of the cache for TrialEntities, a generalized implementation of filtering and sorting was created for the prod server. 

This body of changes modifies bi-api to utilize these new changes via search requests with the newly implemented SortBy and FilterBy request models that are now accessible via an updated brapi-java-client/model.

The changes to bi-api only affect Experiments/Trials, and should namely only really affect the data table seen in a Program's Experiments tab.

Included updates:

- Upgrade to new brapi-java-client version
- Pass ExperimentQuery parameters further into bi-api business logic so they can be handled by the brapi server
- ExperimentQuery parameters now used to build BrAPISearchRequest which is used to call BrAPI Trials Search POST from java client.
- Created generalized code for usage in other search requests in BrAPIDAOUtil
- Created BrAPISortFilterMapper abstract class to be implemented by entities that need to be mapped.  These implementations will define the mapping between the bi-web request names to the brapi-prod-server request names for the columns that need to be searched on
- Updated unit tests to utilize the program search for experiments instead of the existing implementation which is used by the fe to filter.  This will separate these concerns

# Dependencies
- [brapi-java-client and model](https://github.com/Breeding-Insight/brapi/pull/229)
- [java-prod-server](https://github.com/Breeding-Insight/brapi-Java-ProdServer/pull/17)
# Testing
- Test filtering and sorting of Trials by messing around with the different functionalities of the data table in the `Experiments` tab of a Program.  Mess with filtering, testing case insensitivity, and different data types.  For sorting, test the order of different columns and ASC vs DESC order.  Mess with paging, try selecting different pages, and different number of records per page


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2861]: https://breedinginsight.atlassian.net/browse/BI-2861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ