### PR TITLE
BI-2841 - Retrieve Germplasm Genotype Data Through DeltaBreed Samples

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIGermplasmController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIGermplasmController.java
@@ -439,7 +439,8 @@ public class BrAPIGermplasmController {
 
         try {
             BrAPIGermplasm germplasm = germplasmDAO.getGermplasmByUUID(germplasmId, programId);
-            GermplasmGenotype germplasmGenotype = genoService.retrieveGenotypeData(programId, germplasm);
+
+            GermplasmGenotype germplasmGenotype = genoService.retrieveGenotypeData(programId, UUID.fromString(germplasmId));
 
             Response<GermplasmGenotype> response = new Response(germplasmGenotype);
             return HttpResponse.ok(response);

--- a/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPISampleDAO.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/daos/BrAPISampleDAO.java
@@ -40,7 +40,6 @@ import org.breedinginsight.utilities.Utilities;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -77,11 +76,23 @@ public class BrAPISampleDAO {
 
     public List<BrAPISample> readSamplesByIds(Program program, List<String> sampleExternalIds) throws ApiException {
         if(sampleExternalIds.isEmpty()) {
-            return Collections.emptyList();
+            return  Collections.emptyList();
         }
 
         BrAPISampleSearchRequest searchRequest = new BrAPISampleSearchRequest().externalReferenceIDs(sampleExternalIds)
                                                                                .externalReferenceSources(List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.SAMPLES)));
+
+        SamplesApi samplesApi = brAPIEndpointProvider.get(programDAO.getSampleClient(program.getId()), SamplesApi.class);
+        return brAPIDAOUtil.search(samplesApi::searchSamplesPost, samplesApi::searchSamplesSearchResultsDbIdGet, searchRequest);
+    }
+
+    public List<BrAPISample> readSamplesByGermplasmIds(Program program, List<String> germplasmExternalIds) throws ApiException {
+        if(germplasmExternalIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        BrAPISampleSearchRequest searchRequest = new BrAPISampleSearchRequest().externalReferenceIDs(germplasmExternalIds)
+                .externalReferenceSources(List.of(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.GERMPLASM)));
 
         SamplesApi samplesApi = brAPIEndpointProvider.get(programDAO.getSampleClient(program.getId()), SamplesApi.class);
         return brAPIDAOUtil.search(samplesApi::searchSamplesPost, samplesApi::searchSamplesSearchResultsDbIdGet, searchRequest);

--- a/src/main/java/org/breedinginsight/services/geno/GenotypeService.java
+++ b/src/main/java/org/breedinginsight/services/geno/GenotypeService.java
@@ -13,5 +13,5 @@ import java.util.UUID;
 public interface GenotypeService {
     ImportResponse submitGenotypeData(UUID userId, UUID programId, UUID submissionId, CompletedFileUpload uploadedFile) throws DoesNotExistException, AuthorizationException, ApiException;
 
-    GermplasmGenotype retrieveGenotypeData(UUID programId, BrAPIGermplasm germplasm) throws DoesNotExistException, AuthorizationException, ApiException;
+    GermplasmGenotype retrieveGenotypeData(UUID programId, UUID germplasmId) throws DoesNotExistException, AuthorizationException, ApiException;
 }

--- a/src/main/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImpl.java
+++ b/src/main/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImpl.java
@@ -283,31 +283,26 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
         BrAPIClient brapiPhenoClient = programDAO.getPhenoClient(programId);
 
         if(verifyProgramExists(brAPIClient, program)) {
-            //loose this
-//            List<BrAPIObservationUnit> germplasmOUs = fetchObservationUnits(brapiPhenoClient, germplasm);
+
             List<BrAPISample> samples = fetchSamples(program, germplasmId);
             List<String> sampleNames = samples.stream().map(BrAPISample::getSampleName).collect(Collectors.toList());
-// TEMP REMOVE FOR Debug
 
-//            REMOVE THE BELOW Call
-            List<BrAPISample> germplasmSamples = fetchGigwaSamples(brAPIClient, program, sampleNames);
-            List<BrAPICallSet> callSets = fetchCallsets(brAPIClient, samples);
-//
-//            List<BrAPICall> calls = fetchCalls(brAPIClient, callSets);
-//
-//            List<BrAPIVariant> variants = fetchVariants(brAPIClient, calls);
-//
-//            return GermplasmGenotype.builder()
-//                                    .germplasm(germplasm)
-//                                    .calls(calls.stream().collect(Collectors.groupingBy(BrAPICall::getCallSetDbId)))
-//                                    .callSets(callSets.stream().collect(Collectors.toMap(BrAPICallSet::getCallSetDbId, callset -> callset)))
-//                                    .variants(variants.stream().collect(Collectors.toMap(BrAPIVariant::getVariantDbId, variant -> variant)))
-//                                    .build();
-//        } else {
+            List<BrAPISample> gigwaSamples = fetchGigwaSamples(brAPIClient, program, sampleNames);
+            List<BrAPICallSet> callSets = fetchCallsets(brAPIClient, gigwaSamples);
+
+            List<BrAPICall> calls = fetchCalls(brAPIClient, callSets);
+
+            List<BrAPIVariant> variants = fetchVariants(brAPIClient, calls);
+
+            return GermplasmGenotype.builder()
+                                    .germplasm(germplasm)
+                                    .calls(calls.stream().collect(Collectors.groupingBy(BrAPICall::getCallSetDbId)))
+                                    .callSets(callSets.stream().collect(Collectors.toMap(BrAPICallSet::getCallSetDbId, callset -> callset)))
+                                    .variants(variants.stream().collect(Collectors.toMap(BrAPIVariant::getVariantDbId, variant -> variant)))
+                                    .build();
+        } else {
             return new GermplasmGenotype();
         }
-        // remove the next line
-        return new GermplasmGenotype();
     }
 
     private boolean validateSamples(Program program, UUID submissionId, byte[] fileContents, ImportUpload upload) throws DoesNotExistException, ApiException {
@@ -427,7 +422,7 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
     }
 
     private List<BrAPISample> fetchGigwaSamples(BrAPIClient genoBrAPIClient, Program program, List<String> sampleNames) throws ApiException {
-//        log.debug("fetching samples for OUs");
+        log.debug("fetching Gigwa Samples");
         if(sampleNames.isEmpty()) {
             log.debug("No samples were supplied, returning");
             return Collections.emptyList();
@@ -477,7 +472,6 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
 
         BrAPICallSetsSearchRequest searchRequest = new BrAPICallSetsSearchRequest();
         searchRequest.setGermplasmDbIds(germplasmSamples.stream().map(BrAPISample::getGermplasmDbId).collect(Collectors.toList()));
-        List<BrAPICallSet> callSets =  brAPIDAOUtil.search(callSetsApi::searchCallsetsPost, callSetsApi::searchCallsetsSearchResultsDbIdGet, searchRequest);
         return brAPIDAOUtil.search(callSetsApi::searchCallsetsPost, callSetsApi::searchCallsetsSearchResultsDbIdGet, searchRequest);
     }
 

--- a/src/main/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImpl.java
+++ b/src/main/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImpl.java
@@ -283,31 +283,26 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
         BrAPIClient brapiPhenoClient = programDAO.getPhenoClient(programId);
 
         if(verifyProgramExists(brAPIClient, program)) {
-            //loose this
-//            List<BrAPIObservationUnit> germplasmOUs = fetchObservationUnits(brapiPhenoClient, germplasm);
+
+            // get sample names from brapi server
             List<BrAPISample> samples = fetchSamples(program, germplasmId);
             List<String> sampleNames = samples.stream().map(BrAPISample::getSampleName).collect(Collectors.toList());
-// TEMP REMOVE FOR Debug
 
-//            REMOVE THE BELOW Call
-            List<BrAPISample> germplasmSamples = fetchGigwaSamples(brAPIClient, program, sampleNames);
-            List<BrAPICallSet> callSets = fetchCallsets(brAPIClient, samples);
-//
-//            List<BrAPICall> calls = fetchCalls(brAPIClient, callSets);
-//
-//            List<BrAPIVariant> variants = fetchVariants(brAPIClient, calls);
-//
-//            return GermplasmGenotype.builder()
-//                                    .germplasm(germplasm)
-//                                    .calls(calls.stream().collect(Collectors.groupingBy(BrAPICall::getCallSetDbId)))
-//                                    .callSets(callSets.stream().collect(Collectors.toMap(BrAPICallSet::getCallSetDbId, callset -> callset)))
-//                                    .variants(variants.stream().collect(Collectors.toMap(BrAPIVariant::getVariantDbId, variant -> variant)))
-//                                    .build();
-//        } else {
+            // get samples from gigwa given sample names
+            List<BrAPISample> gigwaSamples = fetchGigwaSamples(brAPIClient, program, sampleNames);
+            List<BrAPICallSet> callSets = fetchCallsets(brAPIClient, gigwaSamples);
+            List<BrAPICall> calls = fetchCalls(brAPIClient, callSets);
+            List<BrAPIVariant> variants = fetchVariants(brAPIClient, calls);
+
+            return GermplasmGenotype.builder()
+                                    .germplasm(germplasm)
+                                    .calls(calls.stream().collect(Collectors.groupingBy(BrAPICall::getCallSetDbId)))
+                                    .callSets(callSets.stream().collect(Collectors.toMap(BrAPICallSet::getCallSetDbId, callset -> callset)))
+                                    .variants(variants.stream().collect(Collectors.toMap(BrAPIVariant::getVariantDbId, variant -> variant)))
+                                    .build();
+        } else {
             return new GermplasmGenotype();
         }
-        // remove the next line
-        return new GermplasmGenotype();
     }
 
     private boolean validateSamples(Program program, UUID submissionId, byte[] fileContents, ImportUpload upload) throws DoesNotExistException, ApiException {
@@ -427,12 +422,12 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
     }
 
     private List<BrAPISample> fetchGigwaSamples(BrAPIClient genoBrAPIClient, Program program, List<String> sampleNames) throws ApiException {
-//        log.debug("fetching samples for OUs");
+        log.debug("fetching gigwa samples");
         if(sampleNames.isEmpty()) {
             log.debug("No samples were supplied, returning");
             return Collections.emptyList();
         }
-//
+
         SamplesApi samplesApi = brAPIEndpointProvider.get(genoBrAPIClient, SamplesApi.class);
 
         BrAPISampleSearchRequest sampleSearchRequest = new BrAPISampleSearchRequest();
@@ -477,7 +472,6 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
 
         BrAPICallSetsSearchRequest searchRequest = new BrAPICallSetsSearchRequest();
         searchRequest.setGermplasmDbIds(germplasmSamples.stream().map(BrAPISample::getGermplasmDbId).collect(Collectors.toList()));
-        List<BrAPICallSet> callSets =  brAPIDAOUtil.search(callSetsApi::searchCallsetsPost, callSetsApi::searchCallsetsSearchResultsDbIdGet, searchRequest);
         return brAPIDAOUtil.search(callSetsApi::searchCallsetsPost, callSetsApi::searchCallsetsSearchResultsDbIdGet, searchRequest);
     }
 

--- a/src/main/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImpl.java
+++ b/src/main/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImpl.java
@@ -37,6 +37,7 @@ import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
 import org.brapi.v2.model.pheno.request.BrAPIObservationUnitSearchRequest;
 import org.breedinginsight.brapi.v1.controller.BrapiVersion;
+import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapps.importer.daos.BrAPISampleDAO;
 import org.breedinginsight.brapps.importer.daos.ImportDAO;
 import org.breedinginsight.brapps.importer.daos.ImportMappingDAO;
@@ -57,6 +58,7 @@ import org.breedinginsight.services.geno.GenotypeService;
 import org.breedinginsight.services.parsers.MimeTypeParser;
 import org.breedinginsight.utilities.BrAPIDAOUtil;
 import org.breedinginsight.utilities.Utilities;
+import org.jetbrains.annotations.NotNull;
 import org.jooq.DSLContext;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
@@ -112,6 +114,8 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
 
     private final BrAPIEndpointProvider brAPIEndpointProvider;
 
+    private final BrAPIGermplasmDAO germplasmDAO;
+
     @Inject
     public GigwaGenotypeServiceImpl(@Property(name = "gigwa.host") String gigwaHost,
                                     @Property(name = "gigwa.username") String username,
@@ -128,7 +132,8 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
                                     DSLContext dsl,
                                     MimeTypeParser mimeTypeParser,
                                     BrAPIDAOUtil brAPIDAOUtil,
-                                    BrAPIEndpointProvider brAPIEndpointProvider) {
+                                    BrAPIEndpointProvider brAPIEndpointProvider,
+                                    BrAPIGermplasmDAO germplasmDAO) {
         this.gigwaHost = gigwaHost.endsWith("/") ? gigwaHost : gigwaHost + "/";
         this.username = username;
         this.password = password;
@@ -146,6 +151,7 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
         this.mimeTypeParser = mimeTypeParser;
         this.brAPIDAOUtil = brAPIDAOUtil;
         this.brAPIEndpointProvider = brAPIEndpointProvider;
+        this.germplasmDAO = germplasmDAO;
     }
 
     @Override
@@ -227,9 +233,44 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
         response.setProgress(progress);
         return response;
     }
+//    public GermplasmGenotype retrieveGenotypeData_OLD(UUID programId, BrAPIGermplasm germplasm) throws DoesNotExistException, AuthorizationException, ApiException {
+//        log.debug("fetching genotypes for " + germplasm.getGermplasmName());
+//        Program program = getProgram(programId);
+//        BrAPIClient brAPIClient = programDAO.getCoreClient(programId);
+//        brAPIClient.setBasePath(gigwaHost + GIGWA_BRAPI_BASE_PATH);
+//        Authentication authorizationToken = brAPIClient.getAuthentication("AuthorizationToken");
+//        if(authorizationToken instanceof OAuth) {
+//            ((OAuth)authorizationToken).setAccessToken(getAuthToken());
+//        }
+//
+//        BrAPIClient brapiPhenoClient = programDAO.getPhenoClient(programId);
+//
+//        if(verifyProgramExists(brAPIClient, program)) {
+//            List<BrAPIObservationUnit> germplasmOUs = fetchObservationUnits(brapiPhenoClient, germplasm);
+//
+//            List<BrAPISample> germplasmSamples = fetchSamples(brAPIClient, program, germplasmOUs);
+//
+//            List<BrAPICallSet> callSets = fetchCallsets(brAPIClient, germplasmSamples);
+//
+//            List<BrAPICall> calls = fetchCalls(brAPIClient, callSets);
+//
+//            List<BrAPIVariant> variants = fetchVariants(brAPIClient, calls);
+//
+//            return GermplasmGenotype.builder()
+//                    .germplasm(germplasm)
+//                    .calls(calls.stream().collect(Collectors.groupingBy(BrAPICall::getCallSetDbId)))
+//                    .callSets(callSets.stream().collect(Collectors.toMap(BrAPICallSet::getCallSetDbId, callset -> callset)))
+//                    .variants(variants.stream().collect(Collectors.toMap(BrAPIVariant::getVariantDbId, variant -> variant)))
+//                    .build();
+//        } else {
+//            return new GermplasmGenotype();
+//        }
+//    }
 
     @Override
-    public GermplasmGenotype retrieveGenotypeData(UUID programId, BrAPIGermplasm germplasm) throws DoesNotExistException, AuthorizationException, ApiException {
+    public GermplasmGenotype retrieveGenotypeData(UUID programId, UUID germplasmId) throws DoesNotExistException, AuthorizationException, ApiException {
+        BrAPIGermplasm germplasm = germplasmDAO.getGermplasmByUUID(germplasmId.toString(), programId);
+
         log.debug("fetching genotypes for " + germplasm.getGermplasmName());
         Program program = getProgram(programId);
         BrAPIClient brAPIClient = programDAO.getCoreClient(programId);
@@ -242,25 +283,31 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
         BrAPIClient brapiPhenoClient = programDAO.getPhenoClient(programId);
 
         if(verifyProgramExists(brAPIClient, program)) {
-            List<BrAPIObservationUnit> germplasmOUs = fetchObservationUnits(brapiPhenoClient, germplasm);
+            //loose this
+//            List<BrAPIObservationUnit> germplasmOUs = fetchObservationUnits(brapiPhenoClient, germplasm);
+            List<BrAPISample> samples = fetchSamples(program, germplasmId);
+            List<String> sampleNames = samples.stream().map(BrAPISample::getSampleName).collect(Collectors.toList());
+// TEMP REMOVE FOR Debug
 
-            List<BrAPISample> germplasmSamples = fetchSamples(brAPIClient, program, germplasmOUs);
-
-            List<BrAPICallSet> callSets = fetchCallsets(brAPIClient, germplasmSamples);
-
-            List<BrAPICall> calls = fetchCalls(brAPIClient, callSets);
-
-            List<BrAPIVariant> variants = fetchVariants(brAPIClient, calls);
-
-            return GermplasmGenotype.builder()
-                                    .germplasm(germplasm)
-                                    .calls(calls.stream().collect(Collectors.groupingBy(BrAPICall::getCallSetDbId)))
-                                    .callSets(callSets.stream().collect(Collectors.toMap(BrAPICallSet::getCallSetDbId, callset -> callset)))
-                                    .variants(variants.stream().collect(Collectors.toMap(BrAPIVariant::getVariantDbId, variant -> variant)))
-                                    .build();
-        } else {
+//            REMOVE THE BELOW Call
+            List<BrAPISample> germplasmSamples = fetchGigwaSamples(brAPIClient, program, sampleNames);
+            List<BrAPICallSet> callSets = fetchCallsets(brAPIClient, samples);
+//
+//            List<BrAPICall> calls = fetchCalls(brAPIClient, callSets);
+//
+//            List<BrAPIVariant> variants = fetchVariants(brAPIClient, calls);
+//
+//            return GermplasmGenotype.builder()
+//                                    .germplasm(germplasm)
+//                                    .calls(calls.stream().collect(Collectors.groupingBy(BrAPICall::getCallSetDbId)))
+//                                    .callSets(callSets.stream().collect(Collectors.toMap(BrAPICallSet::getCallSetDbId, callset -> callset)))
+//                                    .variants(variants.stream().collect(Collectors.toMap(BrAPIVariant::getVariantDbId, variant -> variant)))
+//                                    .build();
+//        } else {
             return new GermplasmGenotype();
         }
+        // remove the next line
+        return new GermplasmGenotype();
     }
 
     private boolean validateSamples(Program program, UUID submissionId, byte[] fileContents, ImportUpload upload) throws DoesNotExistException, ApiException {
@@ -332,7 +379,6 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
         log.debug("VCF samples are valid!");
         return true;
     }
-
     private boolean validateVcfHeader(String[] headerParts) {
         if(headerParts.length < 8) {
             return false;
@@ -380,23 +426,30 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
         return brAPIProgramListResponseApiResponse.getBody().getResult().getData().size() == 1;
     }
 
-    private List<BrAPISample> fetchSamples(BrAPIClient genoBrAPIClient, Program program, List<BrAPIObservationUnit> observationUnits) throws ApiException {
-        log.debug("fetching samples for OUs");
-        if(observationUnits.isEmpty()) {
-            log.debug("No OUs were supplied, returning");
+    private List<BrAPISample> fetchGigwaSamples(BrAPIClient genoBrAPIClient, Program program, List<String> sampleNames) throws ApiException {
+//        log.debug("fetching samples for OUs");
+        if(sampleNames.isEmpty()) {
+            log.debug("No samples were supplied, returning");
             return Collections.emptyList();
         }
-
+//
         SamplesApi samplesApi = brAPIEndpointProvider.get(genoBrAPIClient, SamplesApi.class);
 
         BrAPISampleSearchRequest sampleSearchRequest = new BrAPISampleSearchRequest();
-
-        sampleSearchRequest.setGermplasmDbIds(observationUnits.stream().map(ou -> program.getKey() + "§" + Utilities.removeProgramKeyAndUnknownAdditionalData(ou.getObservationUnitName(), program.getKey())).collect(Collectors.toList()));
+        sampleSearchRequest.setGermplasmDbIds(sampleNames.stream().map(sampleName -> program.getKey() + "§" +sampleName).collect(Collectors.toList()));
 
         return brAPIDAOUtil.search(samplesApi::searchSamplesPost, samplesApi::searchSamplesSearchResultsDbIdGet, sampleSearchRequest);
     }
 
-    private List<BrAPIObservationUnit> fetchObservationUnits(BrAPIClient phenoBrAPIClient, BrAPIGermplasm germplasm) throws ApiException {
+
+    private List<BrAPISample> fetchSamples(Program program, @NotNull UUID germplasmId) throws ApiException {
+        String germplasmIdString = germplasmId.toString();
+        java.util.List<String> germplasmIdList = List.of(germplasmIdString);
+        List<BrAPISample> sampleNames = sampleDAO.readSamplesByGermplasmIds(program, germplasmIdList);;
+        return sampleNames;
+    }
+
+    private List<BrAPISample> fetchObservationSamples(BrAPIClient phenoBrAPIClient, BrAPIGermplasm germplasm) throws ApiException {
         ObservationUnitsApi observationUnitsApi = brAPIEndpointProvider.get(phenoBrAPIClient, ObservationUnitsApi.class);
 
         BrAPIObservationUnitSearchRequest searchRequest = new BrAPIObservationUnitSearchRequest();
@@ -424,7 +477,7 @@ public class GigwaGenotypeServiceImpl implements GenotypeService {
 
         BrAPICallSetsSearchRequest searchRequest = new BrAPICallSetsSearchRequest();
         searchRequest.setGermplasmDbIds(germplasmSamples.stream().map(BrAPISample::getGermplasmDbId).collect(Collectors.toList()));
-
+        List<BrAPICallSet> callSets =  brAPIDAOUtil.search(callSetsApi::searchCallsetsPost, callSetsApi::searchCallsetsSearchResultsDbIdGet, searchRequest);
         return brAPIDAOUtil.search(callSetsApi::searchCallsetsPost, callSetsApi::searchCallsetsSearchResultsDbIdGet, searchRequest);
     }
 

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -63,8 +63,7 @@ public class BrAPIDAOUtil {
     private final ProgramService programService;
 
     @Inject
-    public
-    BrAPIDAOUtil(@Property(name = "brapi.search.wait-time") int searchWaitTime,
+    public BrAPIDAOUtil(@Property(name = "brapi.search.wait-time") int searchWaitTime,
                         @Property(name = "brapi.read-timeout") Duration searchTimeout,
                         @Property(name = "brapi.page-size") int pageSize,
                         @Property(name = "brapi.post-group-size") int postGroupSize,

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -64,7 +64,8 @@ public class BrAPIDAOUtil {
     private final ProgramService programService;
 
     @Inject
-    public BrAPIDAOUtil(@Property(name = "brapi.search.wait-time") int searchWaitTime,
+    public
+    BrAPIDAOUtil(@Property(name = "brapi.search.wait-time") int searchWaitTime,
                         @Property(name = "brapi.read-timeout") Duration searchTimeout,
                         @Property(name = "brapi.page-size") int pageSize,
                         @Property(name = "brapi.post-group-size") int postGroupSize,

--- a/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
@@ -5,6 +5,7 @@ import com.agorapulse.micronaut.amazon.awssdk.s3.SimpleStorageService;
 import com.agorapulse.micronaut.amazon.awssdk.s3.SimpleStorageServiceConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Replaces;
@@ -196,8 +197,7 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
         return mock(BrAPISampleDAO.class);
     }
 
-    @MockBean(SimpleStorageService.class)
-    @Named("genotype")
+    @MockBean(value = SimpleStorageService.class, named = "genotype")
     SimpleStorageService simpleStorageService() {
         return spy(new DefaultSimpleStorageService(bucketName, s3Client, presigner));
     }
@@ -219,13 +219,12 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
     @Requires(property = "micronaut.test.active.spec", value = "org.breedinginsight.services.geno.impl.GigwaGenotypeServiceImplIntegrationTest")
     static class GermplasmDaoTestFactory {
 
-        @Singleton
+        @Context
         @Replaces(BrAPIGermplasmDAO.class)
         BrAPIGermplasmDAO germplasmDAO() {
             return mock(BrAPIGermplasmDAO.class);
         }
     }
-
 
     private GenericContainer gigwa;
 
@@ -362,7 +361,6 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
 
     //TODO: Enable in BI-2841
     @Test
-    //@Disabled("BI-2841: retrieveGenotypeData should target BrAPI samples directly instead of resolving samples through observation units")
     public void testFetchGermplasmGenotype() throws AuthorizationException, ApiException, DoesNotExistException {
         UUID programId = UUID.fromString("8b667063-480b-4b0a-862c-7eaa651dda28");
         String programKey = "TESTFETCH";
@@ -370,11 +368,15 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
         UUID importId = UUID.randomUUID();
         assertTimeout(Duration.of(2, ChronoUnit.MINUTES), () -> uploadGenoData(programId, programKey, submissionId, importId), "Upload did not complete within the time period");
 
-        BrAPIGermplasm germplasm = new BrAPIGermplasm().germplasmDbId(UUID.randomUUID().toString()).germplasmName("Test Germ");
+        String germplasmName = "USDAMSP1";
+        String sampleName = germplasmName + "_A01";
+        BrAPIGermplasm germplasm = new BrAPIGermplasm().germplasmDbId(UUID.randomUUID().toString()).germplasmName(germplasmName);
 
         SamplesApi mockSamplesApi = spy(new SamplesApi());
-        BrAPISample sample = new BrAPISample().sampleName("USDAMSP1_A01")
-                                             .germplasmDbId(germplasm.getGermplasmDbId());
+        BrAPISample sample = new BrAPISample().sampleName(sampleName)
+                                             .germplasmDbId(programKey + "§" + sampleName);
+        doReturn(List.of(sample)).when(sampleDAO)
+                                 .readSamplesByGermplasmIds(any(Program.class), eq(List.of(germplasm.getGermplasmDbId())));
         doReturn(new ApiResponse<>(200,
                                    new HashMap<>(),
                                    Pair.of(Optional.of(new BrAPISampleListResponse().result(new BrAPISampleListResponseResult().data(List.of(sample)))),
@@ -386,16 +388,15 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
         doReturn(new BrAPIClient("", 300000)).when(programDAO).getCoreClient(any(UUID.class));
         doReturn(new BrAPIClient("", 300000)).when(programDAO).getPhenoClient(any(UUID.class));
 
-        assertTrue(mockingDetails(germplasmDAO).isMock(), germplasmDAO.getClass().getName());
-
         doReturn(germplasm).when(germplasmDAO)
                 .getGermplasmByUUID(any(String.class), any(UUID.class));
 
-        GermplasmGenotype germplasmGenotype = gigwaGenoStorageService.retrieveGenotypeData(programId, UUID.randomUUID());
+        GermplasmGenotype germplasmGenotype = gigwaGenoStorageService.retrieveGenotypeData(programId, UUID.fromString(germplasm.getGermplasmDbId()));
 
+        verify(sampleDAO).readSamplesByGermplasmIds(any(Program.class), eq(List.of(germplasm.getGermplasmDbId())));
         verify(brAPIEndpointProvider, never()).get(any(BrAPIClient.class), eq(ObservationUnitsApi.class));
         verify(mockSamplesApi).searchSamplesPost(argThat(searchRequest -> searchRequest.getGermplasmDbIds() != null &&
-                                                                          searchRequest.getGermplasmDbIds().contains(germplasm.getGermplasmDbId()) &&
+                                                                          searchRequest.getGermplasmDbIds().contains(programKey + "§" + sample.getSampleName()) &&
                                                                           (searchRequest.getObservationUnitDbIds() == null || searchRequest.getObservationUnitDbIds().isEmpty())));
         assertNotNull(germplasmGenotype);
         assertFalse(germplasmGenotype.getCalls().isEmpty());

--- a/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
@@ -38,6 +38,7 @@ import org.brapi.v2.model.geno.response.BrAPISampleListResponse;
 import org.brapi.v2.model.geno.response.BrAPISampleListResponseResult;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.breedinginsight.DatabaseTest;
+import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapps.importer.daos.BrAPISampleDAO;
 import org.breedinginsight.brapps.importer.daos.ImportDAO;
 import org.breedinginsight.brapps.importer.daos.ImportMappingDAO;
@@ -129,6 +130,9 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
     private BrAPISampleDAO sampleDAO;
 
     @Inject
+    private BrAPIGermplasmDAO germplasmDAO;
+
+    @Inject
     private ObjectMapper objectMapper;
 
     @Inject
@@ -210,6 +214,18 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
             return mock(SampleSubmissionDAO.class);
         }
     }
+
+    @Factory
+    @Requires(property = "micronaut.test.active.spec", value = "org.breedinginsight.services.geno.impl.GigwaGenotypeServiceImplIntegrationTest")
+    static class GermplasmDaoTestFactory {
+
+        @Singleton
+        @Replaces(BrAPIGermplasmDAO.class)
+        BrAPIGermplasmDAO germplasmDAO() {
+            return mock(BrAPIGermplasmDAO.class);
+        }
+    }
+
 
     private GenericContainer gigwa;
 
@@ -346,7 +362,7 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
 
     //TODO: Enable in BI-2841
     @Test
-    @Disabled("BI-2841: retrieveGenotypeData should target BrAPI samples directly instead of resolving samples through observation units")
+    //@Disabled("BI-2841: retrieveGenotypeData should target BrAPI samples directly instead of resolving samples through observation units")
     public void testFetchGermplasmGenotype() throws AuthorizationException, ApiException, DoesNotExistException {
         UUID programId = UUID.fromString("8b667063-480b-4b0a-862c-7eaa651dda28");
         String programKey = "TESTFETCH";
@@ -370,7 +386,12 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
         doReturn(new BrAPIClient("", 300000)).when(programDAO).getCoreClient(any(UUID.class));
         doReturn(new BrAPIClient("", 300000)).when(programDAO).getPhenoClient(any(UUID.class));
 
-        GermplasmGenotype germplasmGenotype = gigwaGenoStorageService.retrieveGenotypeData(programId, germplasm);
+        assertTrue(mockingDetails(germplasmDAO).isMock(), germplasmDAO.getClass().getName());
+
+        doReturn(germplasm).when(germplasmDAO)
+                .getGermplasmByUUID(any(String.class), any(UUID.class));
+
+        GermplasmGenotype germplasmGenotype = gigwaGenoStorageService.retrieveGenotypeData(programId, UUID.randomUUID());
 
         verify(brAPIEndpointProvider, never()).get(any(BrAPIClient.class), eq(ObservationUnitsApi.class));
         verify(mockSamplesApi).searchSamplesPost(argThat(searchRequest -> searchRequest.getGermplasmDbIds() != null &&

--- a/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
@@ -359,7 +359,6 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
         }
     }
 
-    //TODO: Enable in BI-2841
     @Test
     public void testFetchGermplasmGenotype() throws AuthorizationException, ApiException, DoesNotExistException {
         UUID programId = UUID.fromString("8b667063-480b-4b0a-862c-7eaa651dda28");

--- a/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImplIntegrationTest.java
@@ -38,6 +38,7 @@ import org.brapi.v2.model.geno.response.BrAPISampleListResponse;
 import org.brapi.v2.model.geno.response.BrAPISampleListResponseResult;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.breedinginsight.DatabaseTest;
+import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
 import org.breedinginsight.brapps.importer.daos.BrAPISampleDAO;
 import org.breedinginsight.brapps.importer.daos.ImportDAO;
 import org.breedinginsight.brapps.importer.daos.ImportMappingDAO;
@@ -129,6 +130,9 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
     private BrAPISampleDAO sampleDAO;
 
     @Inject
+    private BrAPIGermplasmDAO germplasmDAO;
+
+    @Inject
     private ObjectMapper objectMapper;
 
     @Inject
@@ -191,6 +195,9 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
     BrAPISampleDAO sampleDAO() {
         return mock(BrAPISampleDAO.class);
     }
+
+    @MockBean(BrAPIGermplasmDAO.class)
+    BrAPIGermplasmDAO germplasmDAO() { return mock(BrAPIGermplasmDAO.class); }
 
     @MockBean(SimpleStorageService.class)
     @Named("genotype")
@@ -346,7 +353,6 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
 
     //TODO: Enable in BI-2841
     @Test
-    @Disabled("BI-2841: retrieveGenotypeData should target BrAPI samples directly instead of resolving samples through observation units")
     public void testFetchGermplasmGenotype() throws AuthorizationException, ApiException, DoesNotExistException {
         UUID programId = UUID.fromString("8b667063-480b-4b0a-862c-7eaa651dda28");
         String programKey = "TESTFETCH";
@@ -357,6 +363,7 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
         BrAPIGermplasm germplasm = new BrAPIGermplasm().germplasmDbId(UUID.randomUUID().toString()).germplasmName("Test Germ");
 
         SamplesApi mockSamplesApi = spy(new SamplesApi());
+        BrAPIGermplasmDAO mockGermplasm = spy(new BrAPIGermplasmDAO(programDAO, importDAO, ));
         BrAPISample sample = new BrAPISample().sampleName("USDAMSP1_A01")
                                              .germplasmDbId(germplasm.getGermplasmDbId());
         doReturn(new ApiResponse<>(200,
@@ -370,7 +377,9 @@ public class GigwaGenotypeServiceImplIntegrationTest extends DatabaseTest {
         doReturn(new BrAPIClient("", 300000)).when(programDAO).getCoreClient(any(UUID.class));
         doReturn(new BrAPIClient("", 300000)).when(programDAO).getPhenoClient(any(UUID.class));
 
-        GermplasmGenotype germplasmGenotype = gigwaGenoStorageService.retrieveGenotypeData(programId, germplasm);
+        doReturn(mockGermplasm).when(germplasmDAO)
+                .getGermplasmByUUID(any(String.class), any(UUID.class));
+        GermplasmGenotype germplasmGenotype = gigwaGenoStorageService.retrieveGenotypeData(programId,  UUID.randomUUID());
 
         verify(brAPIEndpointProvider, never()).get(any(BrAPIClient.class), eq(ObservationUnitsApi.class));
         verify(mockSamplesApi).searchSamplesPost(argThat(searchRequest -> searchRequest.getGermplasmDbIds() != null &&


### PR DESCRIPTION
# Description
[BI-2841](https://breedinginsight.atlassian.net/browse/BI-2841) - Retrieve Germplasm Genotype Data Through DeltaBreed Samples

_Please include a summary of the change that was made._
Reflect the change of linking Genotypic Data to Germplasm via Genotype Samples instead of via Experiments

The main changes are in `main/java/org/breedinginsight/services/geno/impl/GigwaGenotypeServiceImpl.java`
- modified the `retrieveGenotypeData` function.
- Added the `fetchGigwaSamples` function.

In Support of those changes, modified `BrAPISampleDAO.java`
- Exchanged the method `readSamplesByIds` with `readSamplesByGermplasmIds`.

Modified GigwaGenotypeServiceImplIntegrationTest.java
- Re-enable `testFetchGermplasmGenotype()`



# Dependencies
**bi-web:*develop*

# Testing

1. Import germplasm: [germplasm ListHaps.xls](https://github.com/user-attachments/files/28517820/germplasm.ListHaps.xls)
2. Import Genotype Samples: [bi_2839_sample_submission.xls](https://github.com/user-attachments/files/28517861/bi_2839_sample_submission.xls)
3. Import Genotypic Data: _you will have to ask me for this file.  It will not allow this file type to be uploaded_
4. Go to a linked germpasm (such as GID=376).
5. Click the `Genotype` tab
THEN
the Genotype data should appear on the screen below the `Genotype` tab.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2841]: https://breedinginsight.atlassian.net/browse/BI-2841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ