### PR TITLE
[BI-2878] Germplasm External UID missing from UI

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/model/request/query/GermplasmQuery.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/model/request/query/GermplasmQuery.java
@@ -22,6 +22,7 @@ public class GermplasmQuery extends BrapiQuery {
     private String femaleParentGID;
     private String maleParentGID;
     private String createdDate;
+    private String externalUID;
     private String createdByUserName;
     private String synonym;
     // This is a meta-parameter, it describes the display format of any date fields.
@@ -56,9 +57,15 @@ public class GermplasmQuery extends BrapiQuery {
         if (!StringUtils.isBlank(getMaleParentGID())) {
             filters.add(constructFilterRequest("maleParentGID", getMaleParentGID()));
         }
+
         if (!StringUtils.isBlank(getCreatedDate())) {
             filters.add(constructFilterRequest("createdDate", getCreatedDate()));
         }
+
+        if (!StringUtils.isBlank(getExternalUID())) {
+            filters.add(constructFilterRequest("externalUID", getExternalUID()));
+        }
+
         if (!StringUtils.isBlank(getCreatedByUserName())) {
             filters.add(constructFilterRequest("createdByUserName", getCreatedByUserName()));
         }

--- a/src/main/java/org/breedinginsight/utilities/response/mappers/GermplasmQueryMapper.java
+++ b/src/main/java/org/breedinginsight/utilities/response/mappers/GermplasmQueryMapper.java
@@ -2,6 +2,7 @@ package org.breedinginsight.utilities.response.mappers;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.breedinginsight.api.v1.controller.metadata.SortOrder;
 import org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields;
@@ -11,6 +12,7 @@ import org.breedinginsight.brapi.v2.constants.GermplasmQueryDefaults;
 import javax.inject.Singleton;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -60,6 +62,21 @@ public class GermplasmQueryMapper extends AbstractQueryMapper {
                         germplasm.getAdditionalInfo() != null && germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID) ?
                                 germplasm.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_MALE_PARENT_GID).getAsString() :
                                 null),
+                Map.entry("externalUID", (germplasm) ->{
+                    String externalUID = null;
+                    if (germplasm.getExternalReferences() != null) {
+                        String source = germplasm.getSeedSource();
+                        List<BrAPIExternalReference> externalReferences = germplasm.getExternalReferences();
+                        for (BrAPIExternalReference reference : externalReferences) {
+                            if (reference.getReferenceSource().equals(source)) {
+                                externalUID = reference.getReferenceID();
+                                break;
+                            }
+                        }
+                    }
+
+                    return externalUID;
+                }),
                 Map.entry("createdDate", (germplasm) ->{
                     String createdDate = null;
                     if (germplasm.getAdditionalInfo() != null && germplasm.getAdditionalInfo().has(BrAPIAdditionalInfoFields.CREATED_DATE)) {


### PR DESCRIPTION
# Description
[BI-2878](https://breedinginsight.atlassian.net/browse/BI-2878) Germplasm External UID missing from UI


# Dependencies
bi-web: feature/BI-2878

# Testing

1. Import Germplasm with both a Seed Source and a External UID
2. Go to `Germplasm` page (list of all Germplasm).
**Expected Result:**
- The External UID should be displayed for the newly imported Germplasm.
3. Press the `Lists` tab.
4. Press the `Details` link for the newly imported Germplasm List.
**Expected Result:**
- The External UID should be displayed for the newly imported Germplasm.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2878]: https://breedinginsight.atlassian.net/browse/BI-2878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ