### PR TITLE
[BI-2883] - Add pedigree column to germplasm download files

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIGermplasmDAO.java
@@ -204,8 +204,7 @@ public class BrAPIGermplasmDAO {
                     germplasm.setAdditionalInfo(additionalInfo);
                 }
 
-                // TODO: BI-1883 to cleanup this workaround for the pedigree string
-                String pedigree = processBreedbasePedigree(germplasm.getPedigree());
+                String pedigree = germplasm.getPedigree();
                 additionalInfo.addProperty(BrAPIAdditionalInfoFields.GERMPLASM_RAW_PEDIGREE, pedigree);
 
                 String gidPedigreeString = "";
@@ -279,34 +278,6 @@ public class BrAPIGermplasmDAO {
         }
 
         return programGermplasmMap;
-    }
-
-    // TODO: hack for now, probably should update breedbase
-    // Made a JIRA card BI-1883 for this
-    // Breedbase will return NA/NA for no pedigree or NA/father, mother/NA
-    // strip NAs before saving RAW_PEDIGREE, if there was a germplasm with name NA it would be in format NA [program key]
-    // so that case should be ok if we just strip NA/NA, NA/, or /NA<\0>
-    private String processBreedbasePedigree(String pedigree) {
-
-        if (pedigree != null) {
-            if (pedigree.equals("NA/NA")) {
-                return "";
-            }
-
-            // Technically processGermplasmForDisplay should handle ok without stripping these NAs but will strip anyways
-            // for consistency.
-            // We only allow the /NA case for single parent as we require a female parent in the pedigree
-            // keep the leading slash, will be handled by processGermplasmForDisplay
-            if (pedigree.endsWith("/NA")) {
-                return pedigree.substring(0, pedigree.length()-2);
-            }
-
-            // shouldn't have this case in our data but just in case
-            if (pedigree.startsWith("NA/")) {
-                return pedigree.substring(2);
-            }
-        }
-        return pedigree;
     }
 
     public List<BrAPIGermplasm> createBrAPIGermplasm(List<BrAPIGermplasm> postBrAPIGermplasmList, UUID programId, ImportUpload upload) {

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -178,8 +178,10 @@ public class BrAPIGermplasmService {
             }
 
             // Pedigrees
-            String pedigreeString = germplasmEntry.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_PEDIGREE_BY_NAME).getAsString();
-            row.put("Pedigree", pedigreeString);
+            if (germplasmEntry.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_PEDIGREE_BY_NAME) != null) {
+                String pedigreeString = germplasmEntry.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_PEDIGREE_BY_NAME).getAsString();
+                row.put("Pedigree", pedigreeString);
+            }
 
             processedData.add(row);
         }

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -171,6 +171,10 @@ public class BrAPIGermplasmService {
                 row.put("Synonyms", joinedSynonyms);
             }
 
+            // Pedigrees
+            String pedigreeString = germplasmEntry.getAdditionalInfo().get(BrAPIAdditionalInfoFields.GERMPLASM_PEDIGREE_BY_NAME).getAsString();
+            row.put("Pedigree", pedigreeString);
+
             processedData.add(row);
         }
         return processedData;

--- a/src/main/java/org/breedinginsight/services/parsers/germplasm/GermplasmFileColumns.java
+++ b/src/main/java/org/breedinginsight/services/parsers/germplasm/GermplasmFileColumns.java
@@ -28,6 +28,7 @@ public enum GermplasmFileColumns {
     NAME("Germplasm Name", Column.ColumnDataType.STRING),
     BREEDING_METHOD("Breeding Method", Column.ColumnDataType.STRING),
     SOURCE("Source", Column.ColumnDataType.STRING),
+    PEDIGREE("Pedigree", Column.ColumnDataType.STRING),
     FEMALE_PARENT_GID("Female Parent GID", Column.ColumnDataType.INTEGER),
     MALE_PARENT_GID("Male Parent GID", Column.ColumnDataType.INTEGER),
     ENTRY_NO("Entry No", Column.ColumnDataType.INTEGER),

--- a/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
@@ -173,6 +173,9 @@ public class BrAPIGermplasmServiceUnitTest extends DatabaseTest {
         // Check that "GID" column matches "Entry No" for both (https://breedinginsight.atlassian.net/browse/BI-2266).
         assertEquals(resultTable.get(0, 0), resultTable.get(0, 7), "Incorrect data exported");
         assertEquals(resultTable.get(1, 0), resultTable.get(1, 7), "Incorrect data exported");
+        //Assert "Pedigree" column contains properly formatted data
+        assertEquals(resultTable.get(0, 4), "", "Incorrect data exported");
+        assertEquals(resultTable.get(1, 4), "Germplasm A", "Incorrect data exported");
     }
 
     @Test

--- a/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
@@ -171,8 +171,8 @@ public class BrAPIGermplasmServiceUnitTest extends DatabaseTest {
         assertEquals(2, resultTable.rowCount(), "Wrong number of rows were exported");
         assertEquals("Germplasm A", resultTable.get(0, 1), "Incorrect data exported");
         // Check that "GID" column matches "Entry No" for both (https://breedinginsight.atlassian.net/browse/BI-2266).
-        assertEquals(resultTable.get(0, 0), resultTable.get(0, 6), "Incorrect data exported");
-        assertEquals(resultTable.get(1, 0), resultTable.get(1, 6), "Incorrect data exported");
+        assertEquals(resultTable.get(0, 0), resultTable.get(0, 7), "Incorrect data exported");
+        assertEquals(resultTable.get(1, 0), resultTable.get(1, 7), "Incorrect data exported");
     }
 
     @Test


### PR DESCRIPTION
# Description
**Story:** [BI-2883- Add pedigree column to germplasm download files](https://breedinginsight.atlassian.net/browse/BI-2883)

Added pedigree column to germplasm file columns

Updated BrAPIGermplasmService.java:processListData to include pedigree data in export file

Updated unit tests

Also removed comments and code for processing Breedbase NA pedigrees as this is no longer relevant now that we don't use Breedbase for data

# Dependencies
bi-web: develop

# Testing

Download germplasm (both all germplasm and a germplasm list)
- Check that pedigree column exists in file
- Check that values in pedigree column have display pedigree values shown in germplasm table
- Check that pedigree values are correct and blank values remain blank

Upload downloaded germplasm file with pedigree column, and new male/female parent info
- Ensure pedigree in germplasm preview reflects changes from parent gid/entry numbers
- Finish import and ensure pedigrees were saved correctly

Upload downloaded germplasm file with pedigree column values changed
- Ensure pedigree column in germplasm preview is not affected by the pedigree column in the import file
- Ensure upload completes successfully
- Ensure pedigree was not affected by pedigree import file column values

Upload new germplasm file without pedigree column
- Ensure germplasm successfully uploads
- Ensure both germplasm and germplasm lists display properly

Upload new germplasm file with pedigree column
- Ensure pedigree column in germplasm preview is not affected by the pedigree column in the import file
- Ensure upload completes successfully
- Ensure pedigree was not affected by pedigree import file column values

Upload germplasm file with pedigree column in a different location in the file
- Ensure upload behaves as expected

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
