### PR TITLE
Update settings to fetch mvn central snapshots

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -50,6 +50,12 @@
                     <snapshots><enabled>true</enabled></snapshots>
                 </repository>
                 <repository>
+                    <id>central-snapshots</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+                    <releases><enabled>false</enabled></releases>
+                    <snapshots><enabled>true</enabled></snapshots>
+                </repository>
+                <repository>
                     <id>github-fannypack</id>
                     <name>FannyPack github repository</name>
                     <url>https://maven.pkg.github.com/BrandonKowalski/fannypack</url>


### PR DESCRIPTION
# Description
**Story:** [BI-2782](https://breedinginsight.atlassian.net/browse/BI-2782)

Update `settings.xml` to allow snapshot fetches from maven central.

This is required to grab the brapi-client snapshots for develop branches, as all releases are now being pushed to maven central instead of our github package repos.

If this change doesn't go through, the branches fail on build.


# Dependencies


# Testing
The project building is verification enough the change works.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2782]: https://breedinginsight.atlassian.net/browse/BI-2782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ