### PR TITLE
Generalize BrAPI Entity GET code, and pagination/sorting/filtering code

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v1/model/request/query/BrapiQuery.java
+++ b/src/main/java/org/breedinginsight/brapi/v1/model/request/query/BrapiQuery.java
@@ -26,6 +26,7 @@ import org.breedinginsight.api.v1.controller.metadata.SortOrder;
 
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
+import java.util.Map;
 
 @Getter
 @Setter
@@ -57,5 +58,27 @@ public class BrapiQuery implements PaginationParams {
                 .field(field)
                 .value(value)
                 .build();
+    }
+
+    /**
+     * For BrapiQuery objects that have implemented this method, this map is used by the BrAPIDAOUtil
+     * to iterate through all valid filter columns and their associated values that are submitted from the fe.
+     *
+     * See @ExperimentQuery for example implementation
+     */
+    public Map<String, String> getFilterValuesByBrAPIColumnName() {
+            throw new UnsupportedOperationException(
+                    String.format("Server side BrAPI filtering not implemented for class [%s]", this.getClass().getSimpleName())
+            );
+    }
+
+    /**
+     * For BrapiQuery objects that have implemented this method, this map is used by the BrAPIDAOUtil
+     * to match submitted sortField column names to the associated brapi column name for sorting.
+     *
+     * See @ExperimentQuery for example implementation
+     */
+    public Map<String, String> getBrAPIColumnNamesByBiColumnName() {
+        throw new UnsupportedOperationException(String.format("Server side BrAPI sorting not implemented for class [%s]", this.getClass().getSimpleName()));
     }
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPITrialsController.java
@@ -93,7 +93,6 @@ public class BrAPITrialsController {
             Optional<Program> program = programService.getById(programId);
             if (program.isEmpty()) { return HttpResponse.notFound(); }
 
-            SearchRequest searchRequest = queryParams.constructSearchRequest();
             log.debug("fetching trials for program: " + programId);
 
             // If the program user is an experimental collaborator, filter results for only authorized experiments.

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -82,7 +82,6 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
      * This method requires a BI-API program.  If the BrAPIProgram inside this data model is not set,
      * this method will retrieve it.
      */
-    // TODO: Generalize Code for General Get By Program for BrAPI Entities [BI-2932]
     private List<BrAPITrial> getBrAPITrialsUsingBrAPIProgramId(Program program) throws ApiException {
 
         if (program == null || program.getId() == null) {
@@ -97,8 +96,6 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         if (brapiProgramDbId == null) {
             brapiProgramDbId = programDAO.getProgramBrAPI(program).getProgramDbId();
         }
-
-        // TODO: Configurable max amount of trials per program, or paginate [BI-2932]
 
         TrialQueryParams trialQueryParams =
                 TrialQueryParams.builder()

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -103,32 +103,13 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
         TrialQueryParams trialQueryParams =
                 TrialQueryParams.builder()
                         .programDbId(brapiProgramDbId)
-                        .pageSize(1000)
-                        .page(0)
                         .build();
 
-        return getTrialsFromBrAPI(program, trialQueryParams);
-    }
-
-    private List<BrAPITrial> getTrialsFromBrAPI(Program program, TrialQueryParams trialQueryParams) throws ApiException {
         TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), TrialsApi.class);
 
-        ApiResponse<BrAPITrialListResponse> response;
+        List<BrAPITrial> result = brAPIDAOUtil.get(api::trialsGet, trialQueryParams);
 
-        try {
-            response = api.trialsGet(trialQueryParams);
-        } catch (ApiException e) {
-            log.warn(Utilities.generateApiExceptionLogMessage(e));
-            throw new InternalServerException("Error making BrAPI call", e);
-        }
-
-        if (response.getBody().getMetadata().getPagination().getTotalCount() > trialQueryParams.pageSize()) {
-            throw new InternalServerException(String.format("More trials exist than requested [%s]", trialQueryParams));
-        }
-
-        List<BrAPITrial> trialsFromResponse = response.getBody().getResult().getData();
-
-        return processExperimentsForDisplay(trialsFromResponse, program.getKey());
+        return processExperimentsForDisplay(result, program.getKey());
     }
 
     @Override
@@ -192,12 +173,21 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
 
         TrialQueryParams params = TrialQueryParams.builder()
                 .trialDbId(trialId.toString())
-                .pageSize(1)
-                .page(0)
                 .build();
 
+        TrialsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), TrialsApi.class);
 
-        return getTrialsFromBrAPI(program, params).stream().findFirst();
+        List<BrAPITrial> result = brAPIDAOUtil.get(api::trialsGet, params);
+
+        if (result.isEmpty()) {
+            throw new DoesNotExistException(String.format("Trial with ID [%s] does not exist", trialId));
+        } else if (result.size() > 1) {
+            throw new InternalServerException(String.format("Trial with ID [%s] found multiple times in database. This should not be possible.", trialId));
+        }
+
+        processExperimentsForDisplay(result, program.getKey());
+
+        return result.stream().findFirst();
     }
 
     @Override

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/impl/BrAPITrialDAOImpl.java
@@ -27,7 +27,6 @@ import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.model.queryParams.core.TrialQueryParams;
 import org.brapi.client.v2.modules.core.TrialsApi;
 import org.brapi.v2.model.BrAPIFilterBy;
-import org.brapi.v2.model.BrAPIResponse;
 import org.brapi.v2.model.BrAPISortBy;
 import org.brapi.v2.model.core.BrAPIProgram;
 import org.brapi.v2.model.core.BrAPITrial;
@@ -284,40 +283,8 @@ public class BrAPITrialDAOImpl implements BrAPITrialDAO {
             searchRequest.setTrialDbIds(brapiTrialIds.stream().map(UUID::toString).collect(Collectors.toList()));
         }
 
-        // Set FilterBy
-        List<BrAPIFilterBy> brAPIFilterBy = new ArrayList<>();
-
-        if (StringUtils.isNotBlank(experimentQuery.getName())) {
-            brAPIFilterBy.add(brAPIDAOUtil.constructFilterBy(brAPITrialsMapper.getBrAPIName(BI_FILTER_COLUMN_NAME), experimentQuery.getName()));
-        }
-        if (StringUtils.isNotBlank(experimentQuery.getActive())) {
-            brAPIFilterBy.add(brAPIDAOUtil.constructFilterBy(brAPITrialsMapper.getBrAPIName(BI_FILTER_COLUMN_ACTIVE), experimentQuery.getActive()));
-        }
-        if (StringUtils.isNotBlank(experimentQuery.getCreatedBy())) {
-            brAPIFilterBy.add(brAPIDAOUtil.constructFilterBy(brAPITrialsMapper.getBrAPIName(BI_FILTER_COLUMN_CREATED_BY), experimentQuery.getCreatedBy()));
-        }
-        if (StringUtils.isNotBlank(experimentQuery.getCreatedDate())) {
-            brAPIFilterBy.add(brAPIDAOUtil.constructFilterBy(brAPITrialsMapper.getBrAPIName(BI_FILTER_COLUMN_CREATED_DATE), experimentQuery.getCreatedDate()));
-        }
-
-        if (!brAPIFilterBy.isEmpty()) {
-            searchRequest.setFilterBy(brAPIFilterBy);
-        }
-
-        // Set SortBy
-        List<BrAPISortBy> brAPISortBy = new ArrayList<>();
-
-        if (StringUtils.isNotBlank(experimentQuery.getSortField()) && brAPITrialsMapper.exists(experimentQuery.getSortField())) {
-            brAPISortBy.add(brAPIDAOUtil.constructSortBy(brAPITrialsMapper.getBrAPIName(experimentQuery.getSortField()), experimentQuery.getSortOrder().toString()));
-        }
-
-        if (!brAPISortBy.isEmpty()) {
-            searchRequest.setSortBy(brAPISortBy);
-        }
-
-        brAPIDAOUtil.setPagination(searchRequest, experimentQuery);
+        brAPIDAOUtil.setGenericSearchParameters(searchRequest, experimentQuery);
 
         return searchRequest;
-
     }
 }

--- a/src/main/java/org/breedinginsight/brapi/v2/model/request/query/ExperimentQuery.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/model/request/query/ExperimentQuery.java
@@ -2,13 +2,10 @@ package org.breedinginsight.brapi.v2.model.request.query;
 
 import io.micronaut.core.annotation.Introspected;
 import lombok.Getter;
-import org.breedinginsight.api.model.v1.request.query.FilterRequest;
-import org.breedinginsight.api.model.v1.request.query.SearchRequest;
 import org.breedinginsight.brapi.v1.model.request.query.BrapiQuery;
-import org.jooq.tools.StringUtils;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 @Getter
 @Introspected
@@ -18,20 +15,27 @@ public class ExperimentQuery extends BrapiQuery {
     private String createdBy;
     private String createdDate;
 
-    public SearchRequest constructSearchRequest() {
-        List<FilterRequest> filters = new ArrayList<>();
-        if (!StringUtils.isBlank(getName())) {
-            filters.add(constructFilterRequest("name", getName()));
-        }
-        if (!StringUtils.isBlank(getActive())) {
-            filters.add(constructFilterRequest("active", getActive()));
-        }
-        if (!StringUtils.isBlank(getCreatedBy())) {
-            filters.add(constructFilterRequest("createdBy", getCreatedBy()));
-        }
-        if (!StringUtils.isBlank(getCreatedDate())) {
-            filters.add(constructFilterRequest("createdDate", getCreatedDate()));
-        }
-        return new SearchRequest(filters);
+    @Override
+    public Map<String, String> getFilterValuesByBrAPIColumnName() {
+        Map<String, String> filterValuesByBrAPIColumnName = new HashMap<>();
+
+        filterValuesByBrAPIColumnName.put("trialName", getName());
+        filterValuesByBrAPIColumnName.put("active", getActive());
+        filterValuesByBrAPIColumnName.put("createdBy", getCreatedBy());
+        filterValuesByBrAPIColumnName.put("createdDate", getCreatedDate());
+
+        return filterValuesByBrAPIColumnName;
+    }
+
+    @Override
+    public Map<String, String> getBrAPIColumnNamesByBiColumnName() {
+        Map<String, String> brAPIColumnNamesByBiColumnName = new HashMap<>();
+
+        brAPIColumnNamesByBiColumnName.put("name", "trialName");
+        brAPIColumnNamesByBiColumnName.put("active", "active");
+        brAPIColumnNamesByBiColumnName.put("createdBy", "createdBy");
+        brAPIColumnNamesByBiColumnName.put("createdDate", "createdDate");
+
+        return brAPIColumnNamesByBiColumnName;
     }
 }

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -401,14 +401,6 @@ public class BrAPIDAOUtil {
                 .orElseThrow();
     }
 
-    // TODO: write generic put code
-    public <T> List<T> put(List<T> brapiObjects,
-                           ImportUpload upload,
-                           Function<List<T>, ApiResponse> putMethod,
-                           Consumer<ImportUpload> progressUpdateMethod) throws ApiException {
-        throw new UnsupportedOperationException();
-    }
-
     public <T, R> List<R> post(List<T> brapiObjects,
                             ImportUpload upload,
                             Function<List<T>, ApiResponse> postMethod,

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -33,7 +33,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.v2.model.*;
-import org.breedinginsight.api.model.v1.response.DataResponse;
 import org.breedinginsight.brapi.v1.controller.BrapiVersion;
 import org.breedinginsight.brapi.v1.model.request.query.BrapiQuery;
 import org.breedinginsight.brapps.importer.model.ImportUpload;
@@ -506,7 +505,7 @@ public class BrAPIDAOUtil {
         return programBrAPIBaseUrl.endsWith(BrapiVersion.BRAPI_V2) ? programBrAPIBaseUrl : programBrAPIBaseUrl + BrapiVersion.BRAPI_V2;
     }
 
-    public BrAPIFilterBy constructFilterBy(String filterOn, String value) {
+    private BrAPIFilterBy constructFilterBy(String filterOn, String value) {
         var filterBy = new BrAPIFilterBy();
 
         filterBy.setFilterOn(filterOn);
@@ -514,7 +513,7 @@ public class BrAPIDAOUtil {
         return filterBy;
     }
 
-    public BrAPISortBy constructSortBy(String sortOn, String sortOrder) {
+    private BrAPISortBy constructSortBy(String sortOn, String sortOrder) {
         var sortBy = new BrAPISortBy();
         sortBy.setSortedOn(sortOn);
 
@@ -529,7 +528,42 @@ public class BrAPIDAOUtil {
         return sortBy;
     }
 
-    public <T extends BrAPISearchRequestParametersPaging, U extends BrapiQuery> void setPagination(T brapiSearchRequest, U biSearchQuery) {
+    /**
+     * Sets three generic search parameters for an outgoing BrAPI Search Query:
+     * - Sorting
+     * - Filtering
+     * - Pagination
+     */
+    public <T extends BrAPISearchRequestParametersPaging, U extends BrapiQuery> void setGenericSearchParameters(T brapiSearchRequest, U biSearchQuery) {
+        // Set SortBy
+        List<BrAPISortBy> brAPISortBy = new ArrayList<>();
+
+        Map<String, String> brapiColNameByBiColName = biSearchQuery.getBrAPIColumnNamesByBiColumnName();
+
+        if (StringUtils.isNotBlank(biSearchQuery.getSortField()) && brapiColNameByBiColName.containsKey(biSearchQuery.getSortField())) {
+            brAPISortBy.add(constructSortBy(brapiColNameByBiColName.get(biSearchQuery.getSortField()), biSearchQuery.getSortOrder().toString()));
+        }
+
+        if (!brAPISortBy.isEmpty()) {
+            brapiSearchRequest.setSortBy(brAPISortBy);
+        }
+
+        // Set FilterBy
+        List<BrAPIFilterBy> brAPIFilterBy = new ArrayList<>();
+
+        Map<String, String> filterValuesByBrAPIColName = biSearchQuery.getFilterValuesByBrAPIColumnName();
+
+        filterValuesByBrAPIColName.forEach((brapiColumnName, value) -> {
+            if (StringUtils.isNotBlank(value)) {
+                brAPIFilterBy.add(constructFilterBy(brapiColumnName, value));
+            }
+        });
+
+        if (!brAPIFilterBy.isEmpty()) {
+            brapiSearchRequest.setFilterBy(brAPIFilterBy);
+        }
+
+        // Set Pagination
         if (biSearchQuery.getPage() == null) {
             brapiSearchRequest.setPage(biSearchQuery.getDefaultPage());
         } else {

--- a/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
+++ b/src/main/java/org/breedinginsight/utilities/BrAPIDAOUtil.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.client.v2.model.queryParams.core.BrAPIQueryParams;
 import org.brapi.v2.model.*;
 import org.breedinginsight.brapi.v1.controller.BrapiVersion;
 import org.breedinginsight.brapi.v1.model.request.query.BrapiQuery;
@@ -73,6 +74,55 @@ public class BrAPIDAOUtil {
         this.postGroupSize = postGroupSize;
         this.brapiFetchPageSize = brapiFetchPageSize;
         this.programService = programService;
+    }
+
+    public <T extends BrAPIResponse, U extends BrAPIQueryParams, V> List<V> get(Function<U, ApiResponse<T>> getMethod,
+                                                                       U queryParams) throws ApiException {
+        T brapiResponseResult;
+
+        boolean paginationSet = queryParams.page() != null && queryParams.pageSize() != null;
+
+        if (!paginationSet) {
+            queryParams.setPage(0);
+            queryParams.setPageSize(pageSize);
+        }
+
+        try {
+            brapiResponseResult = Optional.ofNullable(getMethod.apply(queryParams))
+                    .map(ApiResponse::getBody)
+                    .orElseThrow();
+        } catch (ApiException e) {
+            log.warn(Utilities.generateApiExceptionLogMessage(e));
+            throw e;
+        } catch (NoSuchElementException e) {
+            log.debug("Unable to retrieve BrAPIResponse from POST search request", e);
+            throw new InternalServerException(e.toString(), e);
+        } catch (Exception e) {
+            log.debug("error", e);
+            throw new InternalServerException(e.toString(), e);
+        }
+
+        BrAPIPagination responsePagination = Optional.of(brapiResponseResult)
+                .map(BrAPIResponse::getMetadata)
+                .map(BrAPIMetadata::getPagination)
+                .orElse(null);
+
+        if (responsePagination == null) {
+            throw new InternalServerException("Expected pagination metadata in BrAPI get response not present");
+        }
+
+        if (!paginationSet && responsePagination.getTotalPages() > 1) {
+            // Size of BrAPI entity GET data can not exceed configured pageSize.
+            // If it does, it is recommended the GET method not be used for this purpose.
+            // If you are trying to utilize this method to get a large amount of data for an entity, you can use
+            // searchInternal for now.  In the future, we need a more robust way of transmitting this data using
+            // compression client techniques to reduce strain on the server and avoid keeping all the database data
+            // in java memory.
+            throw new InternalServerException(String.format("More than one page found, meaning there is more data to be returned " +
+                    "with pageSize = [%s]", queryParams.pageSize()));
+        }
+
+        return getListResult(brapiResponseResult);
     }
 
     // Performs a POST brapi search on an entity without looping paging logic, utilizing filters and pagination provided in the searchBody.


### PR DESCRIPTION
# Description
**Story:** [BI-2932](https://breedinginsight.atlassian.net/browse/BI-2932)
Added generalized code for usage by other developers in brapi entity cache removal processes for the following usages:
* Generalized code for pagination/sorting/filtering in `BrAPIDAOUtil`
* Generalized code for BrAPI entity GET in `BrAPIDAOUtil`.  This code will set default pagination parameters if they are not set in submitted `BrapiQueryParams`


# Dependencies
[brapi](https://github.com/Breeding-Insight/brapi/pull/236)
# Testing
Same regression as BI-2861/2806

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2932]: https://breedinginsight.atlassian.net/browse/BI-2932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ