### PR TITLE
BI-2941 - Genotype Data Import erroring out when the file size is too Large

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,10 +27,10 @@ micronaut:
     thread-selection: AUTO
     multipart:
       enabled: true
-      max-file-size: '100MB'
+      max-file-size: '800MB'
       mixed: true
       threshold: '10MB'
-    max-request-size: '100MB'
+    max-request-size: '800MB'
   bi:
     api:
       version: v1


### PR DESCRIPTION
# Description
**Story:** [BI-2941](https://breedinginsight.atlassian.net/browse/BI-2941)

This change updates the Genotype Data import multipart upload limits in `application.yml`.

The root cause of the issue was that `max-file-size` and `max-request-size` were both configured as `100MB`, which caused larger VCF uploads to fail before the import could proceed normally. This PR increases both limits to `800MB`, which is the supported file size agreed for this story.

With this change, Genotype Data imports below 800MB are accepted and continue through the existing import/job flow without requiring additional backend logic changes.

# Dependencies
bi-web: feature/BI-2941
bi-api: feature/BI-2941

This PR pairs with the corresponding `bi-web` change for BI-2941, which customizes the UI error message shown when the backend rejects an oversized upload.

# Testing
1. Start the API with this configuration change.
2. Upload a VCF file below 800MB through the Genotype Data import flow and confirm the request is accepted.
3. Confirm the import continues through the existing job flow and is visible on the Jobs page.
4. Upload a VCF file above 800MB and confirm the backend rejects the request.
5. Verify normal behavior is unchanged for supported file sizes.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth

[BI-2941]: https://breedinginsight.atlassian.net/browse/BI-2941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ