### PR TITLE
Fix issues where bi-generated exref id used instead of trialDbId in brapi endpoints

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/BrAPIObservationsController.java
@@ -148,6 +148,7 @@ public class BrAPIObservationsController {
             }
 
             // Get a filtered list of observations.
+            // TODO: Handle filtering and pagination of this request entirely on BrAPI side once study and ou cache is removed: [BI-2964]
             List<BrAPIObservation> observations = observationDAO.getObservationsByFilters(program.get(), studyDbId);
 
             // If page is not provided, set it to the default value 0.

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -24,9 +24,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.model.exceptions.ApiException;
+import org.brapi.client.v2.model.queryParams.core.TrialQueryParams;
+import org.brapi.client.v2.model.queryParams.phenotype.ObservationQueryParams;
+import org.brapi.client.v2.modules.core.TrialsApi;
 import org.brapi.client.v2.modules.phenotype.ObservationsApi;
 import org.brapi.v2.model.BrAPIAcceptedSearchResponse;
 import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.core.BrAPIProgram;
+import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
 import org.brapi.v2.model.pheno.request.BrAPIObservationSearchRequest;
@@ -67,6 +72,8 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
     private boolean runScheduledTasks;
     private final TraitService traitService;
 
+    private final int brapiMaxPageSize;
+
     @Inject
     public BrAPIObservationDAO(ProgramDAO programDAO,
                                ImportDAO importDAO,
@@ -75,6 +82,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
                                BrAPIEndpointProvider brAPIEndpointProvider,
                                @Property(name = "brapi.server.reference-source") String referenceSource,
                                @Property(name = "micronaut.bi.api.run-scheduled-tasks") boolean runScheduledTasks,
+                               @Property(name = "brapi.cache.fetch-page-size")  int brapiFetchPageSize,
                                ProgramCacheProvider programCacheProvider, TraitService traitService) {
         this.programDAO = programDAO;
         this.importDAO = importDAO;
@@ -85,6 +93,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
         this.runScheduledTasks = runScheduledTasks;
         this.traitService = traitService;
         this.programCache = programCacheProvider.getProgramCache(this::fetchProgramObservations, BrAPIObservation.class);
+        this.brapiMaxPageSize = brapiFetchPageSize;
     }
 
     @Scheduled(initialDelay = "${startup.delay.observation}")
@@ -165,8 +174,14 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
     /**
      * Get all observations for a program from the cache.
      */
-    private Map<String, BrAPIObservation> getProgramObservations(UUID programId) throws ApiException {
-        return programCache.get(programId);
+    private List<BrAPIObservation> getProgramObservations(UUID programId) throws ApiException {
+
+        Program program = programDAO.get(programId)
+                .stream()
+                .findFirst()
+                .orElseThrow();
+
+        return getBrAPIObservationsUsingBrAPIProgramId(program);
     }
 
     // Note: not using cache, because unique studyName (with "[ProgramKey-ExtraInfo]") is not stored directly on Observation.
@@ -202,7 +217,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
 
         // Filter the observations based on the provided program ID and the provided list of dbIds
         // Collect the filtered observations into a List and return the result
-        return getProgramObservations(program.getId()).values().stream()
+        return getProgramObservations(program.getId()).stream()
                 .filter(o -> dbIds.contains(o.getObservationDbId()))
                 .collect(Collectors.toList());
     }
@@ -217,7 +232,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
                 .stream().map(BrAPIObservationUnit::getObservationUnitDbId).collect(Collectors.toList());
         // Finally, return all Observations for those ObservationUnits (Observations are linked to Trial through ObservationUnits).
         // TODO: This gets all observations for the program and filters, which is extremely inefficient.  If above TODO suggestion doesn't work, another improvement would be to search on OU ids directly in BrAPI instead. [BI-2963]
-        return getProgramObservations(program.getId()).values().stream()
+        return getProgramObservations(program.getId()).stream()
                 .filter(o -> observationUnitDbIds.contains(o.getObservationUnitDbId()))
                 .collect(Collectors.toList());
     }
@@ -226,26 +241,19 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
         if(ouDbIds.isEmpty() || variableDbIds.isEmpty()) {
             return Collections.emptyList();
         }
-        return getProgramObservations(program.getId()).values().stream()
+        // TODO: Once OUDAO removes cache, change to BrAPI Observation search request on program, observation var ids, and ouDbId [BI-2963]
+        return getProgramObservations(program.getId()).stream()
                 .filter(o -> ouDbIds.contains(o.getObservationUnitDbId()) && variableDbIds.contains(o.getObservationVariableDbId()))
                 .collect(Collectors.toList());
     }
 
     public List<BrAPIObservation> getObservationsByObservationUnits(Collection<String> ouDbIds, Program program) throws ApiException {
+        // TODO: Once OUDAO removes cache, change to BrAPI Observation search request on program and ouDbIds [BI-2963]
         if(ouDbIds.isEmpty()) {
             return Collections.emptyList();
         }
-        return getProgramObservations(program.getId()).values().stream()
+        return getProgramObservations(program.getId()).stream()
                 .filter(o -> ouDbIds.contains(o.getObservationUnitDbId()))
-                .collect(Collectors.toList());
-    }
-
-    public List<BrAPIObservation> getObservationsByObservationUnitsAndStudies(Collection<String> ouDbIds, Collection<String> studyDbIds, Program program) throws ApiException {
-        if(ouDbIds.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return getProgramObservations(program.getId()).values().stream()
-                .filter(o -> ouDbIds.contains(o.getObservationUnitDbId()) && studyDbIds.contains(o.getStudyDbId()))
                 .collect(Collectors.toList());
     }
 
@@ -257,7 +265,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
         String observationSource = Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.OBSERVATIONS);
 
         // Get all observations for the program.
-        Collection<BrAPIObservation> observations = getProgramObservations(program.getId()).values();
+        Collection<BrAPIObservation> observations = getProgramObservations(program.getId());
         // Build a hashmap of traits for fast lookup. The key is ObservationVariableDbId, the value is the Trait Id.
         HashMap<String, String> traitIdsByObservationVariableDbId = traitService.getIdsByObservationVariableDbIds(program.getId(), observations.stream().map(BrAPIObservation::getObservationVariableDbId).collect(Collectors.toList()));
 
@@ -269,6 +277,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
                     Optional<BrAPIExternalReference> xref = Utilities.getExternalReference(o.getExternalReferences(), studySource);
                     return xref.filter(brAPIExternalReference -> studyDbId.equals(brAPIExternalReference.getReferenceId())).isPresent();
                 })
+                // Try to figure out why/how this translation is used.
                 .peek(o -> {
                     // Translate ObservationVariableDbId.
                     o.setObservationVariableDbId(traitIdsByObservationVariableDbId.get(o.getObservationVariableDbId()));
@@ -308,33 +317,35 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
         }
     }
 
-    public BrAPIObservation updateBrAPIObservation(String dbId, BrAPIObservation observation, UUID programId) throws ApiException {
-        ObservationsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(programId), ObservationsApi.class);
-        var program = programDAO.fetchOneById(programId);
-        try {
-            Callable<Map<String, BrAPIObservation>> postFunction = () -> {
-                ApiResponse<BrAPIObservationSingleResponse> response = api.observationsObservationDbIdPut(dbId, observation);
-                    if (response == null)
-                    {
-                        throw new ApiException("Response is null", 0, null, null);
-                    }
-                    BrAPIObservationSingleResponse body = response.getBody();
-                    if (body == null) {
-                        throw new ApiException("Response is missing body", 0, response.getHeaders(), null);
-                    }
-                    BrAPIObservation updatedObservation = body.getResult();
-                    if (updatedObservation == null) {
-                        throw new ApiException("Response body is missing result", 0, response.getHeaders(), response.getBody().toString());
-                    }
-                    return processObservationsForCache(List.of(updatedObservation), program.getKey());
-            };
-            return programCache.post(programId, postFunction).get(0);
-        } catch (ApiException e) {
-            log.error(Utilities.generateApiExceptionLogMessage(e));
-            throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
-        } catch (Exception e) {
-            throw new InternalServerException("Unknown error has occurred: " + e.getMessage(), e);
+    private List<BrAPIObservation> getBrAPIObservationsUsingBrAPIProgramId(Program program) throws ApiException {
+
+        if (program == null || program.getId() == null) {
+            throw new InternalServerException("BI-API Program or Program ID is null");
         }
+
+        String brapiProgramDbId = Optional.of(program)
+                .map(Program::getBrapiProgram)
+                .map(BrAPIProgram::getProgramDbId)
+                .orElse(null);
+
+        if (brapiProgramDbId == null) {
+            brapiProgramDbId = programDAO.getProgramBrAPI(program).getProgramDbId();
+        }
+
+        ObservationQueryParams observationQueryParams =
+                ObservationQueryParams.builder()
+                        .programDbId(brapiProgramDbId)
+                        .pageSize(brapiMaxPageSize)
+                        .page(0)
+                        .build();
+
+        ObservationsApi api = brAPIEndpointProvider.get(programDAO.getCoreClient(program.getId()), ObservationsApi.class);
+
+        List<BrAPIObservation> result = brAPIDAOUtil.get(api::observationsGet, observationQueryParams);
+
+        processObservations(program.getKey(), result);
+
+        return result;
     }
 
     // This method overloads updateBrAPIObservation(String dbId, BrAPIObservation observation, UUID programId)

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -212,9 +212,11 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
             return Collections.emptyList();
         }
         // First, get all ObservationUnits for the given trialDbIds.
+        // TODO: Once OUDAO removes cache, investigate utilizing observationUnit GET param to includeObservations instead of making an extra call for the observations. This should offer performance gains. [BI-2963]
         List<String> observationUnitDbIds = observationUnitDAO.getObservationUnitsForTrialDbIds(program.getId(), trialDbIds)
                 .stream().map(BrAPIObservationUnit::getObservationUnitDbId).collect(Collectors.toList());
         // Finally, return all Observations for those ObservationUnits (Observations are linked to Trial through ObservationUnits).
+        // TODO: This gets all observations for the program and filters, which is extremely inefficient.  If above TODO suggestion doesn't work, another improvement would be to search on OU ids directly in BrAPI instead. [BI-2963]
         return getProgramObservations(program.getId()).values().stream()
                 .filter(o -> observationUnitDbIds.contains(o.getObservationUnitDbId()))
                 .collect(Collectors.toList());

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationDAO.java
@@ -24,14 +24,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.model.exceptions.ApiException;
-import org.brapi.client.v2.model.queryParams.core.TrialQueryParams;
 import org.brapi.client.v2.model.queryParams.phenotype.ObservationQueryParams;
-import org.brapi.client.v2.modules.core.TrialsApi;
 import org.brapi.client.v2.modules.phenotype.ObservationsApi;
 import org.brapi.v2.model.BrAPIAcceptedSearchResponse;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPIProgram;
-import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.pheno.BrAPIObservation;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
 import org.brapi.v2.model.pheno.request.BrAPIObservationSearchRequest;
@@ -43,7 +40,6 @@ import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.daos.ProgramDAO;
 import org.breedinginsight.daos.cache.ProgramCacheProvider;
 import org.breedinginsight.model.Program;
-import org.breedinginsight.model.Trait;
 import org.breedinginsight.services.TraitService;
 import org.breedinginsight.services.brapi.BrAPIEndpointProvider;
 import org.breedinginsight.services.exceptions.DoesNotExistException;
@@ -171,11 +167,7 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
         }
     }
 
-    /**
-     * Get all observations for a program from the cache.
-     */
     private List<BrAPIObservation> getProgramObservations(UUID programId) throws ApiException {
-
         Program program = programDAO.get(programId)
                 .stream()
                 .findFirst()
@@ -184,7 +176,6 @@ public class BrAPIObservationDAO extends BrAPICachedDAO<BrAPIObservation> {
         return getBrAPIObservationsUsingBrAPIProgramId(program);
     }
 
-    // Note: not using cache, because unique studyName (with "[ProgramKey-ExtraInfo]") is not stored directly on Observation.
     public List<BrAPIObservation> getObservationsByStudyName(List<String> studyNames, Program program) throws ApiException {
         if(studyNames.isEmpty()) {
             return Collections.emptyList();

--- a/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/dao/BrAPIObservationUnitDAO.java
@@ -288,7 +288,7 @@ public class BrAPIObservationUnitDAO extends BrAPICachedDAO<BrAPIObservationUnit
         BrAPIObservationUnitSearchRequest observationUnitSearchRequest = new BrAPIObservationUnitSearchRequest();
         observationUnitSearchRequest.programDbIds(List.of(program.getBrapiProgram()
                                                                  .getProgramDbId()));
-        //TODO add pagination support
+        //TODO add pagination support: This should be easy to implement with BrAPIDAOUtil.simpleSearch()
 //                                    .page(page)
 //                                    .pageSize(pageSize);
 
@@ -303,16 +303,15 @@ public class BrAPIObservationUnitDAO extends BrAPICachedDAO<BrAPIObservationUnit
         observationUnitName.ifPresent(name -> observationUnitSearchRequest.setObservationUnitNames(List.of(Utilities.appendProgramKey(name, program.getKey()))));
         locationDbId.ifPresent(dbid -> observationUnitSearchRequest.setLocationDbIds(List.of(dbid)));
         seasonDbId.ifPresent(dbid -> observationUnitSearchRequest.setSeasonDbIds(List.of(dbid)));
+        experimentId.ifPresent(dbId -> observationUnitSearchRequest.setTrialDbIds(List.of(dbId)));
         includeObservations.ifPresent(observationUnitSearchRequest::includeObservations);
         addLevelFilter(observationUnitLevelName, observationUnitLevelOrder, observationUnitLevelCode, level, levelFilter);
         addLevelFilter(observationUnitLevelRelationshipName, observationUnitLevelRelationshipOrder, observationUnitLevelRelationshipCode, relationship, relationshipFilter);
-        experimentId.ifPresent(expId -> addXRefFilter(expId, ExternalReferenceSource.TRIALS, xrefIds, xrefSources));
         environmentId.ifPresent(envId -> addXRefFilter(envId, ExternalReferenceSource.STUDIES, xrefIds, xrefSources));
 //        germplasmId.ifPresent(germId -> {
 //            xrefIds.add(germId);
 //            xrefSources.add(Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.));
 //        });
-
         if(!xrefIds.isEmpty()) {
             observationUnitSearchRequest.externalReferenceIDs(xrefIds);
         }
@@ -326,10 +325,6 @@ public class BrAPIObservationUnitDAO extends BrAPICachedDAO<BrAPIObservationUnit
                                                                                  .get()
                                                                                  .getReferenceId()))
                                                    .orElse(true);
-            matches = matches && experimentId.map(id -> id.equals(Utilities.getExternalReference(ou.getExternalReferences(), Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.TRIALS))
-                                                                                   .get()
-                                                                                   .getReferenceId()))
-                                                     .orElse(true);
             matches = matches && environmentId.map(id -> id.equals(Utilities.getExternalReference(ou.getExternalReferences(), Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.STUDIES))
                                                                              .get()
                                                                              .getReferenceId()))

--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIObservationVariableService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIObservationVariableService.java
@@ -74,10 +74,9 @@ public class BrAPIObservationVariableService {
             expId = UUID.fromString(experimentId.get());
         } else {
             UUID envId = UUID.fromString(environmentId.orElseThrow(() -> new IllegalStateException("no environment id found")));
+            // TODO: Double check this (and other studyDbId bi-brapi) lookup still works with cache removal on studies [BI-2962]
             BrAPIStudy environment = trialService.getEnvironment(program.get(), envId);
-            expId = UUID.fromString(Utilities.getExternalReference(environment.getExternalReferences(),
-                    Utilities.generateReferenceSource(referenceSource, ExternalReferenceSource.TRIALS))
-                    .orElseThrow(() -> new IllegalStateException("no external reference found")).getReferenceId());
+            expId = UUID.fromString(environment.getTrialDbId());
         }
 
         BrAPITrial experiment = trialService.getExperiment(program.get(), expId);

--- a/src/test/java/org/breedinginsight/brapi/v2/BrAPIObservationUnitControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/brapi/v2/BrAPIObservationUnitControllerIntegrationTest.java
@@ -31,6 +31,7 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import lombok.SneakyThrows;
 import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.core.BrAPITrial;
 import org.brapi.v2.model.germ.BrAPIGermplasm;
 import org.brapi.v2.model.pheno.BrAPIObservationUnit;
 import org.brapi.v2.model.pheno.response.BrAPIObservationUnitSingleResponse;
@@ -41,8 +42,10 @@ import org.breedinginsight.api.model.v1.request.ProgramRequest;
 import org.breedinginsight.api.model.v1.request.SpeciesRequest;
 import org.breedinginsight.api.v1.controller.TestTokenValidator;
 import org.breedinginsight.brapi.v2.dao.BrAPIGermplasmDAO;
+import org.breedinginsight.brapi.v2.dao.BrAPITrialDAO;
 import org.breedinginsight.brapps.importer.ImportTestUtils;
 import org.breedinginsight.brapps.importer.model.imports.experimentObservation.ExperimentObservation;
+import org.breedinginsight.brapps.importer.services.processors.experiment.service.TrialService;
 import org.breedinginsight.dao.db.enums.DataType;
 import org.breedinginsight.dao.db.tables.pojos.SpeciesEntity;
 import org.breedinginsight.daos.SpeciesDAO;
@@ -91,6 +94,8 @@ public class BrAPIObservationUnitControllerIntegrationTest extends BrAPITest {
     private OntologyService ontologyService;
     @Inject
     private BrAPIGermplasmDAO germplasmDAO;
+    @Inject
+    private BrAPITrialDAO brapiTrialDAO;
 
     @Inject
     @Client("/${micronaut.bi.api.version}")
@@ -195,12 +200,8 @@ public class BrAPIObservationUnitControllerIntegrationTest extends BrAPITest {
                 program,
                 mappingId,
                 newExperimentWorkflowId);
-        experimentId = importResult
-                .get("preview").getAsJsonObject()
-                .get("rows").getAsJsonArray()
-                .get(0).getAsJsonObject()
-                .get("trial").getAsJsonObject()
-                .get("id").getAsString();
+        List<BrAPITrial> trials = brapiTrialDAO.getTrials(program.getId());
+        experimentId = trials.get(0).getTrialDbId();
         // Add environmentIds.
         envIds.add(getEnvId(importResult, 0));
         envIds.add(getEnvId(importResult, 1));


### PR DESCRIPTION
# Description
**Story:** [BI-2944](https://breedinginsight.atlassian.net/browse/BI-2944?search_id=dd38657e-d4c5-4067-bb85-eb25d659384e)

Matches to the submitted `trialDbId` to the trial ex ref were removed in favor of using the actual BrAPI `trailDbId` explicitly to resolve functionality mismatches.

This change further cements the notion that for all intents and purposes, expId=trialDbId.

# Dependencies
* Use `feature/BI-2861` branch of the prod server
* Use `epic/BI-2862` branch of bi-web
* You may need to build the `feature/BI-2861` branch of the `brapi` repo for bi-api to pick up the required changes.

# Testing
Test the endpoints that were changed:
* http://localhost:8081/v1/programs/[insert program id]/brapi/v2/variables?trialDbId.  For this endpoint, all test with param ?studyDbId, where this id is the environment database id, and should be the BI generated id, and should remain this way until the study cache is removed.
* http://localhost:8081/v1/programs/[insert program id]/brapi/v2/observationunits?trialDbId.  For this endpoint ensure test uses the BrAPI trialDbId to get the observation units available, not the bi-generated exref id.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2944]: https://breedinginsight.atlassian.net/browse/BI-2944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ