### PR TITLE
BI-2959: Use External UID Source for Germplasm External UID References

### DIFF
--- a/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
+++ b/src/main/java/org/breedinginsight/brapi/v2/services/BrAPIGermplasmService.java
@@ -135,11 +135,12 @@ public class BrAPIGermplasmService {
 
             String source = germplasmEntry.getSeedSource();
             if (source != null) {
-                row.put("Source", source);
-                //If germplasm was imported with an external UID, it will be stored in external reference with same source as seed source
-                List<BrAPIExternalReference> externalReferences = germplasmEntry.getExternalReferences();
+                row.put("Source", source);}
+
+            List<BrAPIExternalReference> externalReferences = germplasmEntry.getExternalReferences();
+            if (externalReferences != null) {
                 for (BrAPIExternalReference reference : externalReferences) {
-                    if (reference.getReferenceSource().equals(source)) {
+                    if ("External UID".equals(reference.getReferenceSource())) {
                         row.put("External UID", reference.getReferenceID());
                         break;
                     }

--- a/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
+++ b/src/main/java/org/breedinginsight/brapps/importer/model/base/Germplasm.java
@@ -289,13 +289,13 @@ public class Germplasm implements BrAPIObject {
         // Seed Source
         //If there is an external uid, source is associated with it as an additional external reference
         BrAPIExternalReference uidExternalReference = null;
-        if (germplasmSource != null) {
+        if (StringUtils.isNotBlank(getGermplasmSource())) {
             germplasm.setSeedSource(getGermplasmSource());
-            if (externalUID != null) {
-                uidExternalReference = new BrAPIExternalReference();
-                uidExternalReference.setReferenceID(getExternalUID());
-                uidExternalReference.setReferenceSource(getGermplasmSource());
-            }
+        }
+        if (StringUtils.isNotBlank(getExternalUID())) {
+            uidExternalReference = new BrAPIExternalReference();
+            uidExternalReference.setReferenceSource("External UID");
+            uidExternalReference.setReferenceID(getExternalUID());
         }
 
         // External references

--- a/src/main/java/org/breedinginsight/utilities/response/mappers/GermplasmQueryMapper.java
+++ b/src/main/java/org/breedinginsight/utilities/response/mappers/GermplasmQueryMapper.java
@@ -65,10 +65,9 @@ public class GermplasmQueryMapper extends AbstractQueryMapper {
                 Map.entry("externalUID", (germplasm) ->{
                     String externalUID = null;
                     if (germplasm.getExternalReferences() != null) {
-                        String source = germplasm.getSeedSource();
                         List<BrAPIExternalReference> externalReferences = germplasm.getExternalReferences();
                         for (BrAPIExternalReference reference : externalReferences) {
-                            if (reference.getReferenceSource().equals(source)) {
+                            if ("External UID".equals(reference.getReferenceSource())) {
                                 externalUID = reference.getReferenceID();
                                 break;
                             }

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-version=v1.4.0+1172
-versionInfo=https://github.com/Breeding-Insight/bi-api/commit/3ed6bfe7c5ec31ca6fcd52e7c616603ffeedc853
+version=v1.4.0+1174
+versionInfo=https://github.com/Breeding-Insight/bi-api/commit/31e04a82ead663458313b5f48192f5f201b1ceab

--- a/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
+++ b/src/test/java/org/breedinginsight/brapps/importer/GermplasmFileImportTest.java
@@ -780,6 +780,25 @@ public class GermplasmFileImportTest extends BrAPITest {
         assertEquals(breedingMethod.getId().toString(), additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD_ID).getAsString());
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    @SneakyThrows
+    public void externalUidCanonicalReferenceSource(boolean commit) {
+        String pathname = "src/test/resources/files/germplasm_import/external_uid_reference_source.csv";
+        Table fileData = Table.read().file(pathname);
+        String listName = "ExternalUidCanonicalReferenceSource";
+        String listDescription = "External UID should use canonical reference source";
+
+        JsonObject result = importGermplasm(pathname, listName, listDescription, commit);
+        assertEquals(200, result.getAsJsonObject("progress").get("statuscode").getAsInt());
+
+        JsonArray previewRows = result.get("preview").getAsJsonObject().get("rows").getAsJsonArray();
+        for (int i = 0; i < previewRows.size(); i++) {
+            JsonObject germplasm = previewRows.get(i).getAsJsonObject().getAsJsonObject("germplasm").getAsJsonObject("brAPIObject");
+            checkBasicResponse(germplasm, fileData, i);
+        }
+    }
+
     @Test
     @SneakyThrows
     public void headerCaseInsensitive() {
@@ -1123,23 +1142,42 @@ public class GermplasmFileImportTest extends BrAPITest {
         assertEquals(breedingMethod.getId().toString(), additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD_ID).getAsString(), "Wrong Breeding Method ID");
         assertEquals(breedingMethod.getName(), additionalInfo.get(BrAPIAdditionalInfoFields.GERMPLASM_BREEDING_METHOD).getAsString(), "Wrong Breeding Method name");
         // Seed source
-        assertEquals(fileData.getString(i, "Source"), germplasm.get("seedSource").getAsString(), "Wrong seed source");
-        // External Reference (user specified)
-        // External Reference program
+        String source = fileData.getString(i, "Source");
+        if (isNotBlank(source)) {
+            assertEquals(source, germplasm.get("seedSource").getAsString(), "Wrong seed source");
+        } else {
+            assertTrue(!germplasm.has("seedSource")
+                    || germplasm.get("seedSource").isJsonNull()
+                    || germplasm.get("seedSource").getAsString().isBlank(), "Wrong seed source");
+        }
+
+        // External Reference program (user specified)
         JsonArray externalReferences = germplasm.getAsJsonArray("externalReferences");
         Map<String, String> expectedReferences = new HashMap<>();
         expectedReferences.put(Utilities.generateReferenceSource(BRAPI_REFERENCE_SOURCE, ExternalReferenceSource.PROGRAMS), validProgram.getId().toString());
-        expectedReferences.put(fileData.getString(i, "Source"), fileData.getString(i, "External UID"));
+
+        String externalUid = fileData.getString(i, "External UID");
+        if (isNotBlank(externalUid)) {
+            expectedReferences.put("External UID", externalUid);
+        }
+
         Integer referencesFound = 0;
-        for (JsonElement reference: externalReferences) {
+        boolean foundExternalUidReference = false;
+        for (JsonElement reference : externalReferences) {
             String referenceSource = reference.getAsJsonObject().get("referenceSource").getAsString();
             String referenceID = reference.getAsJsonObject().get("referenceID").getAsString();
+            if ("External UID".equals(referenceSource)) {
+                foundExternalUidReference = true;
+            }
             if (expectedReferences.containsKey(referenceSource)) {
                 assertEquals(expectedReferences.get(referenceSource), referenceID);
                 referencesFound += 1;
             }
         }
         assertEquals(expectedReferences.size(), referencesFound, "Not all expected references were returned");
+        if (!isNotBlank(externalUid)) {
+            assertFalse(foundExternalUidReference, "External UID reference should not be created");
+        }
     }
 
     public void checkGermplasmList(String listName, String listDescription, List<String> germplasmNames) {

--- a/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
+++ b/src/test/java/org/breedinginsight/services/BrAPIGermplasmServiceUnitTest.java
@@ -110,6 +110,10 @@ public class BrAPIGermplasmServiceUnitTest extends DatabaseTest {
         testReference.setReferenceSource(referenceSource);
         testReference.setReferenceID(parentUuid);
         externalRef.add(testReference);
+        BrAPIExternalReference externalUidReference = new BrAPIExternalReference();
+        externalUidReference.setReferenceSource("External UID");
+        externalUidReference.setReferenceID("UID-1");
+        externalRef.add(externalUidReference);
         testGermplasm.setExternalReferences(externalRef);
         germplasm.add(testGermplasm);
 
@@ -129,6 +133,10 @@ public class BrAPIGermplasmServiceUnitTest extends DatabaseTest {
         testReference.setReferenceID(UUID.randomUUID().toString());
         externalRef = new ArrayList<>();
         externalRef.add(testReference);
+        BrAPIExternalReference externalUidReference2 = new BrAPIExternalReference();
+        externalUidReference2.setReferenceSource("External UID");
+        externalUidReference2.setReferenceID("UID-2");
+        externalRef.add(externalUidReference2);
         testGermplasm.setExternalReferences(externalRef);
         germplasm.add(testGermplasm);
 
@@ -176,6 +184,9 @@ public class BrAPIGermplasmServiceUnitTest extends DatabaseTest {
         //Assert "Pedigree" column contains properly formatted data
         assertEquals(resultTable.get(0, 4), "", "Incorrect data exported");
         assertEquals(resultTable.get(1, 4), "Germplasm A", "Incorrect data exported");
+        //Asserting new External UID data
+        assertEquals("UID-1", resultTable.get(0, 10), "Incorrect data exported");
+        assertEquals("UID-2", resultTable.get(1, 10), "Incorrect data exported");
     }
 
     @Test

--- a/src/test/java/org/breedinginsight/utilities/response/mappers/GermplasmQueryMapperUnitTest.java
+++ b/src/test/java/org/breedinginsight/utilities/response/mappers/GermplasmQueryMapperUnitTest.java
@@ -1,0 +1,62 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.breedinginsight.utilities.response.mappers;
+
+import lombok.SneakyThrows;
+import org.brapi.v2.model.BrAPIExternalReference;
+import org.brapi.v2.model.germ.BrAPIGermplasm;
+import org.junit.jupiter.api.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class GermplasmQueryMapperUnitTest {
+
+    GermplasmQueryMapper germplasmQueryMapper;
+
+    @BeforeAll
+    @SneakyThrows
+    public void setup() {
+        germplasmQueryMapper = new GermplasmQueryMapper();
+    }
+
+    @Test
+    public void testExternalUidMappingUsesCanonicalReferenceSource() {
+        BrAPIGermplasm germplasm = new BrAPIGermplasm();
+        germplasm.setSeedSource("USDA");
+
+        List<BrAPIExternalReference> externalReferences = new ArrayList<>();
+
+        BrAPIExternalReference sourceReference = new BrAPIExternalReference();
+        sourceReference.setReferenceSource("USDA");
+        sourceReference.setReferenceID("OLD-UID");
+        externalReferences.add(sourceReference);
+
+        BrAPIExternalReference externalUidReference = new BrAPIExternalReference();
+        externalUidReference.setReferenceSource("External UID");
+        externalUidReference.setReferenceID("ABC-123");
+        externalReferences.add(externalUidReference);
+
+        germplasm.setExternalReferences(externalReferences);
+
+        assertEquals("ABC-123", germplasmQueryMapper.getField("externalUID").apply(germplasm), "Wrong getter");
+    }
+}

--- a/src/test/resources/files/germplasm_import/external_uid_reference_source.csv
+++ b/src/test/resources/files/germplasm_import/external_uid_reference_source.csv
@@ -1,0 +1,5 @@
+GID,Germplasm Name,Breeding Method,Source,Female Parent GID,Male Parent GID,Entry No,Female Parent Entry No,Male Parent Entry No,External UID,Synonyms
+,With Source And UID,BCR,USDA,,,1,,,ABC-123,
+,With UID Only,BCR,,,,2,,,ABC-456,
+,With Source Only,BCR,USDA,,,3,,,,
+,With Neither,BCR,,,,4,,,,


### PR DESCRIPTION
# Description
**Story:** [BI-2959](https://breedinginsight.atlassian.net/browse/BI-2959)

This PR updates germplasm import behavior so `Source` and `External UID` are handled independently.

Previously, when a germplasm row contained an `External UID`, the importer created the external reference using the row’s `Source` value as the `referenceSource`. This change updates the importer to always create the External UID reference with:
- `referenceSource = "External UID"`
- `referenceID = value from the External UID column`

This PR also updates backend read/export behavior so External UID values continue to appear correctly in API results and downloads after this change. The backend no longer infers External UID by matching external references to `seedSource`.

# Dependencies
bi-web: feature/BI-2959
bi-api: feature/BI-2959

# Testing
Tested the germplasm import flow for the following scenarios:
- row with both `Source` and `External UID`
- row with `External UID` and blank `Source`
- row with `Source` and blank `External UID`
- row with neither `Source` nor `External UID`

Tests updated:
- importer regression coverage for canonical `External UID` reference source
- import coverage for blank `Source` with `External UID` present
- export/read path coverage for canonical External UID lookup

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth

[BI-2959]: https://breedinginsight.atlassian.net/browse/BI-2959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ