### PR TITLE
BI-2936 - Prevent deleting sample submissions that have genotype imports associated with them

### DIFF
--- a/src/main/java/org/breedinginsight/api/v1/controller/geno/SampleSubmissionController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/geno/SampleSubmissionController.java
@@ -303,20 +303,20 @@ public class SampleSubmissionController {
             return HttpResponse.notFound();
         }
 
-        // sample status validation
-        Optional<SampleSubmission> submissionOpt = sampleSubmissionService.getSampleSubmission(program.get(), submissionId, false);
-
-        if(submissionOpt.isEmpty()) {
-            return HttpResponse.notFound();
+        SampleSubmissionService.DeleteResult result = sampleSubmissionService.deleteSampleSubmission(program.get(), submissionId);
+        switch (result) {
+            case NOT_FOUND:
+                return HttpResponse.notFound();
+            case STATUS_NOT_ALLOWED:
+                return HttpResponse.notAllowed()
+                        .body("Sample submission cannot be deleted because of its submission status");
+            case GENOTYPE_DATA_NOT_ALLOWED:
+                return HttpResponse.notAllowed()
+                        .body("Sample submission cannot be deleted because associated genotype data exists");
+            case DELETED:
+            default:
+                return HttpResponse.ok();
         }
-        SampleSubmission submission = submissionOpt.get();
-        if (!submission.isDeletable()) {
-            return HttpResponse.notAllowed();
-        }
-
-        sampleSubmissionService.deleteSampleSubmission(program.get(), submissionId);
-
-        return HttpResponse.ok();
     }
 
 }

--- a/src/main/java/org/breedinginsight/api/v1/controller/geno/SampleSubmissionController.java
+++ b/src/main/java/org/breedinginsight/api/v1/controller/geno/SampleSubmissionController.java
@@ -54,6 +54,11 @@ import java.util.UUID;
 @Secured(SecurityRule.IS_AUTHENTICATED)
 public class SampleSubmissionController {
 
+    public static final String DELETE_STATUS_NOT_ALLOWED_ERROR_MESSAGE =
+            "Sample submission cannot be deleted because status is submitted or completed";
+    public static final String DELETE_GENOTYPE_DATA_NOT_ALLOWED_ERROR_MESSAGE =
+            "Sample submission cannot be deleted because associated genotype data exists";
+
     private final boolean brapiSubmissionEnabled;
     private final SampleSubmissionService sampleSubmissionService;
     private final ProgramService programService;
@@ -309,10 +314,10 @@ public class SampleSubmissionController {
                 return HttpResponse.notFound();
             case STATUS_NOT_ALLOWED:
                 return HttpResponse.notAllowed()
-                        .body("Sample submission cannot be deleted because of its submission status");
+                        .body(DELETE_STATUS_NOT_ALLOWED_ERROR_MESSAGE);
             case GENOTYPE_DATA_NOT_ALLOWED:
                 return HttpResponse.notAllowed()
-                        .body("Sample submission cannot be deleted because associated genotype data exists");
+                        .body(DELETE_GENOTYPE_DATA_NOT_ALLOWED_ERROR_MESSAGE);
             case DELETED:
             default:
                 return HttpResponse.ok();

--- a/src/main/java/org/breedinginsight/daos/GenotypeImportDAO.java
+++ b/src/main/java/org/breedinginsight/daos/GenotypeImportDAO.java
@@ -59,6 +59,14 @@ public class GenotypeImportDAO extends GenotypeImportDao {
                 .build());
     }
 
+    public boolean existsBySampleSubmissionId(UUID submissionId) {
+        return dsl.fetchExists(
+                dsl.selectOne()
+                        .from(GENOTYPE_IMPORT)
+                        .where(GENOTYPE_IMPORT.SAMPLE_SUBMISSION_ID.eq(submissionId))
+        );
+    }
+
     public List<GenotypeImportDetails> getGenotypeImportsByProgramId(UUID programId) {
         BiUserTable sampleSubmissionCreatedByUser = BI_USER.as("sampleSubmissionCreatedByUser");
         BiUserTable genotypingImportByUser = BI_USER.as("genotypingImportByUser");

--- a/src/main/java/org/breedinginsight/services/SampleSubmissionService.java
+++ b/src/main/java/org/breedinginsight/services/SampleSubmissionService.java
@@ -41,6 +41,7 @@ import org.breedinginsight.brapps.importer.model.ImportUpload;
 import org.breedinginsight.brapps.importer.model.exports.FileType;
 import org.breedinginsight.brapps.importer.model.imports.sample.SampleSubmissionImport;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
+import org.breedinginsight.daos.GenotypeImportDAO;
 import org.breedinginsight.daos.ProgramDAO;
 import org.breedinginsight.daos.SampleSubmissionDAO;
 import org.breedinginsight.model.*;
@@ -78,6 +79,7 @@ public class SampleSubmissionService {
     private final BrAPISampleDAO sampleDAO;
     private final BrAPIEndpointProvider brAPIEndpointProvider;
     private final ProgramDAO programDAO;
+    private final GenotypeImportDAO genotypeImportDAO;
     private final DSLContext dsl;
 
     @Inject
@@ -92,6 +94,7 @@ public class SampleSubmissionService {
                                    BrAPISampleDAO sampleDAO,
                                    BrAPIEndpointProvider brAPIEndpointProvider,
                                    ProgramDAO programDAO,
+                                   GenotypeImportDAO genotypeImportDAO,
                                    DSLContext dsl) {
         this.referenceSource = referenceSource;
         this.dartBrapiUrl = dartBrapiUrl;
@@ -104,6 +107,7 @@ public class SampleSubmissionService {
         this.sampleDAO = sampleDAO;
         this.brAPIEndpointProvider = brAPIEndpointProvider;
         this.programDAO = programDAO;
+        this.genotypeImportDAO = genotypeImportDAO;
         this.dsl = dsl;
     }
 
@@ -432,9 +436,21 @@ public class SampleSubmissionService {
      * Deletes BrAPI plates and submission objects as well as sample submission record in bidb
      * We do not currently cache plates or samples so don't need to worry about that
      * @param submissionId sample submission UUID to delete
+     * @return result describing whether the submission was deleted or why deletion was rejected
      * @exception ApiException if a BrAPI call fails
      */
-    public void deleteSampleSubmission(Program program, UUID submissionId) throws ApiException {
+    public DeleteResult deleteSampleSubmission(Program program, UUID submissionId) throws ApiException {
+        Optional<SampleSubmission> submission = getSampleSubmission(program, submissionId, false);
+        if (submission.isEmpty()) {
+            return DeleteResult.NOT_FOUND;
+        }
+        if (!submission.get().isDeletable()) {
+            return DeleteResult.STATUS_NOT_ALLOWED;
+        }
+        if (genotypeImportDAO.existsBySampleSubmissionId(submissionId)) {
+            return DeleteResult.GENOTYPE_DATA_NOT_ALLOWED;
+        }
+
         // create a batch of sampleIds and plateIds to delete
         // get samples with the sample submission xref
         List<BrAPISample> samples = sampleDAO.readSamplesBySubmissionIds(program, List.of(submissionId.toString()));
@@ -449,6 +465,15 @@ public class SampleSubmissionService {
 
         // delete sample submission record from bidb
         submissionDAO.deleteById(submissionId);
+
+        return DeleteResult.DELETED;
+    }
+
+    public enum DeleteResult {
+        DELETED,
+        NOT_FOUND,
+        STATUS_NOT_ALLOWED,
+        GENOTYPE_DATA_NOT_ALLOWED
     }
 
 }

--- a/src/test/java/org/breedinginsight/api/v1/controller/SampleSubmissionControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/SampleSubmissionControllerIntegrationTest.java
@@ -63,6 +63,8 @@ import java.io.*;
 import java.util.*;
 
 import static io.micronaut.http.HttpRequest.*;
+import static org.breedinginsight.api.v1.controller.geno.SampleSubmissionController.DELETE_GENOTYPE_DATA_NOT_ALLOWED_ERROR_MESSAGE;
+import static org.breedinginsight.api.v1.controller.geno.SampleSubmissionController.DELETE_STATUS_NOT_ALLOWED_ERROR_MESSAGE;
 import static org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields.SUBMISSION_NAME;
 import static org.breedinginsight.dao.db.Tables.GENOTYPE_IMPORT;
 import static org.breedinginsight.dao.db.Tables.IMPORTER_IMPORT;
@@ -363,7 +365,7 @@ public class SampleSubmissionControllerIntegrationTest extends BrAPITest {
         ).blockingFirst());
         assertEquals(HttpStatus.METHOD_NOT_ALLOWED, statusError.getStatus());
         assertEquals(
-                "Sample submission cannot be deleted because of its submission status",
+                DELETE_STATUS_NOT_ALLOWED_ERROR_MESSAGE,
                 statusError.getResponse().getBody(String.class).orElse(null)
         );
 
@@ -385,7 +387,7 @@ public class SampleSubmissionControllerIntegrationTest extends BrAPITest {
         ).blockingFirst());
         assertEquals(HttpStatus.METHOD_NOT_ALLOWED, genotypeError.getStatus());
         assertEquals(
-                "Sample submission cannot be deleted because genotype data exists",
+                DELETE_GENOTYPE_DATA_NOT_ALLOWED_ERROR_MESSAGE,
                 genotypeError.getResponse().getBody(String.class).orElse(null)
         );
 

--- a/src/test/java/org/breedinginsight/api/v1/controller/SampleSubmissionControllerIntegrationTest.java
+++ b/src/test/java/org/breedinginsight/api/v1/controller/SampleSubmissionControllerIntegrationTest.java
@@ -25,6 +25,7 @@ import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.RxHttpClient;
 import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.http.netty.cookies.NettyCookie;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
@@ -43,6 +44,7 @@ import org.breedinginsight.brapps.importer.model.imports.experimentObservation.E
 import org.breedinginsight.brapps.importer.model.imports.sample.SampleSubmissionImport.Columns;
 import org.breedinginsight.brapps.importer.services.ExternalReferenceSource;
 import org.breedinginsight.dao.db.tables.pojos.SpeciesEntity;
+import org.breedinginsight.daos.GenotypeImportDAO;
 import org.breedinginsight.daos.SpeciesDAO;
 import org.breedinginsight.daos.UserDAO;
 import org.breedinginsight.model.*;
@@ -62,6 +64,8 @@ import java.util.*;
 
 import static io.micronaut.http.HttpRequest.*;
 import static org.breedinginsight.brapi.v2.constants.BrAPIAdditionalInfoFields.SUBMISSION_NAME;
+import static org.breedinginsight.dao.db.Tables.GENOTYPE_IMPORT;
+import static org.breedinginsight.dao.db.Tables.IMPORTER_IMPORT;
 import static org.junit.jupiter.api.Assertions.*;
 
 @MicronautTest
@@ -70,6 +74,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SampleSubmissionControllerIntegrationTest extends BrAPITest {
 
     private Program program;
+    private User testUser;
     private ImportTestUtils importTestUtils;
 
     @Property(name = "brapi.server.reference-source")
@@ -84,6 +89,8 @@ public class SampleSubmissionControllerIntegrationTest extends BrAPITest {
     private OntologyService ontologyService;
     @Inject
     private BrAPIGermplasmDAO germplasmDAO;
+    @Inject
+    private GenotypeImportDAO genotypeImportDAO;
 
     @Inject
     @Client("/${micronaut.bi.api.version}")
@@ -101,7 +108,7 @@ public class SampleSubmissionControllerIntegrationTest extends BrAPITest {
         FannyPack brapiFp = FannyPack.fill("src/test/resources/sql/brapi/species.sql");
 
         // Test User
-        User testUser = userDAO.getUserByOAuthId(TestTokenValidator.TEST_USER_ORCID).orElseThrow(Exception::new);
+        testUser = userDAO.getUserByOAuthId(TestTokenValidator.TEST_USER_ORCID).orElseThrow(Exception::new);
         dsl.execute(securityFp.get("InsertSystemRoleAdmin"), testUser.getId().toString());
 
         // Species
@@ -338,6 +345,73 @@ public class SampleSubmissionControllerIntegrationTest extends BrAPITest {
         assertEquals("Genotype", lookupTable.column(0).name());
         assertEquals("Germplasm Name", lookupTable.column(1).name());
         assertEquals("GID", lookupTable.column(2).name());
+    }
+
+    @Test
+    public void testDeleteSubmissionEnforcesStatusAndGenotypeImportRules() throws IOException, InterruptedException {
+        SampleSubmission submission = createSubmission(program).getLeft();
+        String submissionUrl = String.format("/programs/%s/submissions/%s", program.getId(), submission.getId());
+        NettyCookie authCookie = new NettyCookie("phylo-token", "test-registered-user");
+
+        client.exchange(
+                PUT(submissionUrl + "/status", "{status:\"SUBMITTED\"}").cookie(authCookie),
+                String.class
+        ).blockingFirst();
+
+        HttpClientResponseException statusError = assertThrows(HttpClientResponseException.class, () -> client.exchange(
+                DELETE(submissionUrl).cookie(authCookie), String.class
+        ).blockingFirst());
+        assertEquals(HttpStatus.METHOD_NOT_ALLOWED, statusError.getStatus());
+        assertEquals(
+                "Sample submission cannot be deleted because of its submission status",
+                statusError.getResponse().getBody(String.class).orElse(null)
+        );
+
+        client.exchange(
+                PUT(submissionUrl + "/status", "{status:\"NOT SUBMITTED\"}").cookie(authCookie),
+                String.class
+        ).blockingFirst();
+
+        UUID importerImportId = dsl.select(IMPORTER_IMPORT.ID)
+                .from(IMPORTER_IMPORT)
+                .where(IMPORTER_IMPORT.PROGRAM_ID.eq(program.getId()))
+                .orderBy(IMPORTER_IMPORT.CREATED_AT.desc())
+                .limit(1)
+                .fetchOne(IMPORTER_IMPORT.ID);
+        genotypeImportDAO.createGenotypeImportLink(submission.getId(), importerImportId, testUser.getId());
+
+        HttpClientResponseException genotypeError = assertThrows(HttpClientResponseException.class, () -> client.exchange(
+                DELETE(submissionUrl).cookie(authCookie), String.class
+        ).blockingFirst());
+        assertEquals(HttpStatus.METHOD_NOT_ALLOWED, genotypeError.getStatus());
+        assertEquals(
+                "Sample submission cannot be deleted because genotype data exists",
+                genotypeError.getResponse().getBody(String.class).orElse(null)
+        );
+
+        HttpResponse<String> preservedSubmission = client.exchange(
+                GET(submissionUrl + "?details=true").cookie(authCookie), String.class
+        ).blockingFirst();
+        SampleSubmission preserved = gson.fromJson(
+                JsonParser.parseString(preservedSubmission.body()).getAsJsonObject().getAsJsonObject("result"),
+                SampleSubmission.class
+        );
+        assertEquals(96, preserved.getSamples().size());
+        assertEquals(1, preserved.getPlates().size());
+
+        dsl.deleteFrom(GENOTYPE_IMPORT)
+                .where(GENOTYPE_IMPORT.SAMPLE_SUBMISSION_ID.eq(submission.getId()))
+                .execute();
+
+        HttpResponse<String> deleteResponse = client.exchange(
+                DELETE(submissionUrl).cookie(authCookie), String.class
+        ).blockingFirst();
+        assertEquals(HttpStatus.OK, deleteResponse.getStatus());
+
+        HttpClientResponseException notFound = assertThrows(HttpClientResponseException.class, () -> client.exchange(
+                GET(submissionUrl + "?details=true").cookie(authCookie), String.class
+        ).blockingFirst());
+        assertEquals(HttpStatus.NOT_FOUND, notFound.getStatus());
     }
 
 


### PR DESCRIPTION
# Description
**Story:** [BI-2936](https://breedinginsight.atlassian.net/browse/BI-2936?atlOrigin=eyJpIjoiMjQ1NDZjOTdhZDQ5NGZjMzgwNWFjMTg3NTJlZjAyODAiLCJwIjoiaiJ9)

- Give error notification and do not allow deletion when attempt to delete sample submission with associated genotype data

# Dependencies
- bi-web feature/BI-2936

# Testing
- See card acceptance criteria

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2936]: https://breedinginsight.atlassian.net/browse/BI-2936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ