### PR TITLE
[BI-2949] - Update docker-compose to ensure localstack bucket persists

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,6 +176,9 @@ services:
           - localstack
     environment:
       - LOCALSTACK_HOST=localstack
+      - PERSISTENCE=1
+    volumes:
+      - localstack_data:/var/lib/localstack
 
 networks:
   backend:
@@ -187,3 +190,5 @@ volumes:
     name: ${GIGWA_CONTAINER_NAME:-gigwa}_data
   gigwa_mongo_data:
     name: ${GIGWA_CONTAINER_NAME:-gigwa}_mongo_data
+  localstack_data:
+    name: localstack_data


### PR DESCRIPTION
# Description
**Story:** [BI-2949- Update docker-compose to ensure localstack bucket persists](https://breedinginsight.atlassian.net/browse/BI-2949)

Previously when docker containers were restarted the localstack container lost data and any downloads of VCF data uploaded to DeltaBreed before the restart failed. This change updates the docker-compose to make the localstack container persistent so genotypic data can remain downloadable.

# Dependencies
bi-api: develop
bi-web: develop

# Testing
Upload genotypic data
Restart docker containers
Click download on row of previously uploaded genotypic data, VCF should now download without error

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
